### PR TITLE
Mistakenness added as an insight computer.

### DIFF
--- a/fiftyone/brain/hardness.py
+++ b/fiftyone/brain/hardness.py
@@ -31,8 +31,10 @@ def _validate(data, key):
     for sample in data.iter_samples():
         label = sample.get_label(key)
         if label.logits is None:
-            raise ValueError("sample " + sample.id +
-                " failed compute_hardness validation because it has no logits")
+            raise ValueError(
+                "sample " + sample.id +
+                " failed compute_hardness validation because it has no logits"
+            )
 
 
 def compute_hardness(data, key, key_insight=None, validate=False):

--- a/fiftyone/brain/mistakenness.py
+++ b/fiftyone/brain/mistakenness.py
@@ -33,13 +33,17 @@ def _validate(data, key_p, key_l):
     for sample in data.iter_samples():
         label = sample.get_label(key_p)
         if label.logits is None:
-            raise ValueError("sample " + sample.id + " failed " +
-                "compute_mistakenness validation because it has no logits")
+            raise ValueError(
+                "sample " + sample.id + " failed " +
+                "compute_mistakenness validation because it has no logits"
+            )
         label = sample.get_label(key_l)
         if label is None:
-            raise ValueError("sample " + sample.id + " failed " +
+            raise ValueError(
+                "sample " + sample.id + " failed " +
                 "compute_mistakenness validation because it has no entry in " +
-                key_l)
+                key_l
+            )
 
 
 def compute_mistakenness(data, key_prediction, key_label="ground_truth",


### PR DESCRIPTION
This adds mistakenness in addition to hardness as a plausible way of computing insights.  Mistakenness is computed based on the prediction output of a model (through logits) required on data in group "key_prediction" in conjunction with the label.  This makes the measure quantitative and can be used to detect things like annotation errors as well as unusually hard samples.

Algorithm: the chance of a mistake is related to how confident the model prediction was as well as whether or not the prediction is correct.  A prediction that is highly confident and incorrect is likely to be a mistake.  A prediction that is low confidence and incorrect is not likely to be a mistake.  Let us compute a confidence measure based on negative entropy of logits: $c = -entropy(logits)$. (High when low uncertainty, and low confidence when high uncertainty.) Let us define modulator, $m$, based on whether or not the answer is correct.  $m = 1$ when the label is correct and $0$ otherwise.  Then, mistakenness is computed using $exp(m*c)$.