### PR TITLE
Using LazyImporter to handle PyTorch imports

### DIFF
--- a/fiftyone/brain/uniqueness.py
+++ b/fiftyone/brain/uniqueness.py
@@ -29,11 +29,8 @@ import eta.core.utils as etau
 
 import fiftyone.core.utils as fou
 
-# Lazy equivalent of `import torchvision`
-torch = fou.LazyImporter("torch", "torch", globals(), fou.ensure_torch)
-
-# Lazy equivalent of `import fiftyone.utils.torch as fout`
-fout = fou.LazyImporter("fiftyone.utils.torch", "fout", globals())
+torch = fou.lazy_import("torch", fou.ensure_torch)
+fout = fou.lazy_import("fiftyone.utils.torch")
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Using `LazyImporter` introduced in https://github.com/voxel51/fiftyone/pull/114 as a more consistent practice for JIT importing of heavy modules. In this case PyTorch.

Recall the underlying goal here is for `import fiftyone.brain` to work and show all available methods, but only raise an error at runtime if a method is executed that requires, say, PyTorch installed when it is not.

Another advantage with this approach is that `torch` will not even be imported unless `compute_uniqueness` is actually invoked