### PR TITLE
Use voxel51-ci credentials for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,11 +82,13 @@ jobs:
           name: wheel-linux-${{ matrix.python-version }}
           path: downloads
       - name: Install fiftyone
+        env:
+          PIP_INDEX_URL: https://voxel51-ci:${{ secrets.FIFTYONE_GITHUB_TOKEN }}@pypi.voxel51.com
         run: |
           git clone https://${{ secrets.FIFTYONE_GITHUB_TOKEN }}@github.com/voxel51/fiftyone fiftyone-src --depth 1 --branch develop
           cd fiftyone-src
           python setup.py bdist_wheel
-          pip install --index https://pypi.voxel51.com ./dist/*.whl
+          pip install ./dist/*.whl
       - name: Reinstall fiftyone-brain
         run: |
           pip install --force-reinstall --no-deps downloads/*.whl


### PR DESCRIPTION
This is needed to make builds work.
Corresponding fiftyone change in https://github.com/voxel51/fiftyone/pull/240
Passing build: https://github.com/voxel51/fiftyone-brain/actions/runs/154608496