### PR TITLE
Adding support for computing uniqueness on ROIs in images

### DIFF
--- a/fiftyone/brain/uniqueness.py
+++ b/fiftyone/brain/uniqueness.py
@@ -127,8 +127,9 @@ def _compute_patch_embeddings(samples, model, roi_field):
                 patches = torch.squeeze(patches, dim=0)
                 vectors = model.embed_all(patches)
 
-                # Average over image patches
-                embedding = vectors.mean(axis=0)
+                # Aggregate over patches
+                # @todo experiment with mean(), max(), abs().max(), etc
+                embedding = vectors.max(axis=0)
 
                 if embeddings is None:
                     embeddings = embedding


### PR DESCRIPTION
Adds support for passing an optional `roi_field` parameter to `compute_uniqueness()` that specifies a `Detection/Detections/Polyline/Polylines` field to use to extract image patches from each image; in this case, the embedding for each image is computed as the elementwise max of the embeddings for each image patch.

Requires https://github.com/voxel51/fiftyone/pull/623 in order to function.

Here's an example usage where we compute the uniqueness of stop signs in COCO:

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    dataset_name="coco-2017-roi-uniqueness",
)

roi_view = dataset.filter_detections("ground_truth", F("label") == "stop_sign", only_matches=True)

fob.compute_uniqueness(roi_view, roi_field="ground_truth")

session = fo.launch_app(view=roi_view)
```

The images below show the most unique (top) and least unique (bottom) stop signs, which seems plausible:

<img width="1358" alt="Screen Shot 2020-10-21 at 4 22 58 PM" src="https://user-images.githubusercontent.com/25985824/96778715-0b569300-13ba-11eb-849a-27f546d31d82.png">

<img width="1358" alt="Screen Shot 2020-10-21 at 4 23 07 PM" src="https://user-images.githubusercontent.com/25985824/96778735-11e50a80-13ba-11eb-89b6-2e69b0b1c49a.png">
