### PR TITLE
Improving PyPI README

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -1,5 +1,68 @@
-# FiftyOne Brain
+<div align="center">
 
-The proprietary brains behind [FiftyOne](https://github.com/voxel51/fiftyone).
+<h1>
+    FiftyOne Brain
+</h1>
 
-<img src="https://user-images.githubusercontent.com/3719547/74191434-8fe4f500-4c21-11ea-8d73-555edfce0854.png" alt="voxel51-logo.png" width="40%"/>
+**The proprietary brains behind
+[FiftyOne](https://github.com/voxel51/fiftyone).**
+
+<p align="center">
+  <a href="https://voxel51.com/docs/fiftyone/user_guide/brain.html">Docs</a> •
+  <a href="https://colab.research.google.com/github/voxel51/fiftyone-examples/blob/master/examples/quickstart.ipynb">Try it Now</a> •
+  <a href="https://voxel51.com/docs/fiftyone/tutorials/index.html">Tutorials</a> •
+  <a href="https://github.com/voxel51/fiftyone-examples">Examples</a>
+</p>
+
+[![PyPI python](https://img.shields.io/pypi/pyversions/fiftyone-brain)](https://pypi.org/project/fiftyone-brain)
+[![PyPI version](https://badge.fury.io/py/fiftyone-brain.svg)](https://pypi.org/project/fiftyone-brain)
+[![Slack](https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=white)](https://join.slack.com/t/fiftyone-users/shared_invite/zt-gtpmm76o-9AjvzNPBOzevBySKzt02gg)
+[![Medium](https://img.shields.io/badge/Medium-12100E?logo=medium&logoColor=white)](https://medium.com/voxel51)
+[![Twitter](https://img.shields.io/badge/Twitter-1DA1F2?logo=twitter&logoColor=white)](https://twitter.com/voxel51)
+
+<img src="https://user-images.githubusercontent.com/25985824/104953482-7ea97a00-5994-11eb-8cc3-f648c15502b1.png" alt="fiftyone-brain.png">
+
+</div>
+
+---
+
+The [FiftyOne Brain](https://voxel51.com/docs/fiftyone/user_guide/brain.html)
+provides powerful machine learning techniques that are designed to transform
+how you curate your data from an art into a measurable science.
+
+The FiftyOne Brain is a separate Python package that is bundled with
+[FiftyOne](https://voxel51.com/docs/fiftyone). Although it is closed-source, it
+is licensed as freeware, and you have permission to use it for commercial or
+non-commercial purposes. See the license below for more details.
+
+The FiftyOne Brain methods are useful across the stages of the machine learning
+workflow:
+
+-   **[Uniqueness](https://voxel51.com/docs/fiftyone/user_guide/brain.html#image-uniqueness):**
+    During the training loop for a model, the best results will be seen when
+    training on unique data. The FiftyOne Brain provides a uniqueness measure
+    for images that compare the content of every image in a FiftyOne Dataset
+    with all other images. Uniqueness operates on raw images and does not
+    require any prior annotation on the data. It is hence very useful in the
+    early stages of the machine learning workflow when you are likely asking
+    "What data should I select to annotate?"
+
+-   **[Mistakenness](https://voxel51.com/docs/fiftyone/user_guide/brain.html#label-mistakes):**
+    Annotations mistakes create an artificial ceiling on the performance of
+    your models. However, finding these mistakes by hand is at least as arduous
+    as the original annotation was, especially in cases of larger datasets. The
+    FiftyOne Brain provides a quantitative mistakenness measure to identify
+    possible label mistakes. Mistakenness operates on labeled images and
+    requires the logit-output of your model predictions in order to provide
+    maximum efficacy. It also works on detection datasets to find missed
+    objects, incorrect annotations, and localization issues.
+
+-   **[Hardness](https://voxel51.com/docs/fiftyone/user_guide/brain.html#sample-hardness):**
+    While a model is training, it will learn to understand attributes of
+    certain samples faster than others. The FiftyOne Brain provides a hardness
+    measure that calculates how easy or difficult it is for your model to
+    understand any given sample. Mining hard samples is a tried and true
+    measure of mature machine learning processes. Use your current model
+    instance to compute predictions on unlabeled samples to determine which are
+    the most valuable to have annotated and fed back into the system as
+    training samples, for example.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 The proprietary brains behind [FiftyOne](https://github.com/voxel51/fiftyone).
 
-<img src="https://user-images.githubusercontent.com/3719547/74191434-8fe4f500-4c21-11ea-8d73-555edfce0854.png" alt="voxel51-logo.png" width="40%"/>
-
 ## Repository Layout
 
 -   `docs/` documentation about the repository and project
@@ -57,7 +55,3 @@ to get started.
 ```shell
 pip uninstall fiftyone-brain
 ```
-
-## Copyright
-
-Copyright 2017-2021, Voxel51, Inc.<br> voxel51.com

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,9 @@ class CustomBdistWheel(bdist_wheel):
 with open("PYPI_README.md", "r") as fh:
     long_description = fh.read()
 
+with open("LICENSE", "r") as fh:
+    long_description += "\n## License\n\n" + fh.read()
+
 
 VERSION = "0.2.0"
 
@@ -119,10 +122,23 @@ setup(
     include_package_data=True,
     install_requires=["numpy", "scipy>=1.2.0", "scikit-learn"],
     classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "License :: Freeware:",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Scientific/Engineering :: Image Processing",
+        "Topic :: Scientific/Engineering :: Image Recognition",
+        "Topic :: Scientific/Engineering :: Information Analysis",
+        "Topic :: Scientific/Engineering :: Visualization",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     scripts=[],
     python_requires=">=3.6",


### PR DESCRIPTION
Improves the description that appears at https://pypi.org/project/fiftyone-brain. The contents of the `LICENSE` are also appended to the description when the package is built so that users can see the explicit license terms.

I think it is better to include the license terms in this way rather than storing the license at https://github.com/voxel51/fiftyone/blob/develop/LICENSE-BRAIN, since that repo doesn't actually contain any of the brain code. **update** https://github.com/voxel51/fiftyone/pull/792 moves `LICENSE-BRAIN` to package/brain/LICENSE for consistency with other packages and to avoid confusing github.com on the license of the main project

<img width="849" alt="Screen Shot 2021-01-18 at 2 15 47 PM" src="https://user-images.githubusercontent.com/25985824/104955152-b960e180-5997-11eb-9faa-91d6d1731951.png">
