### PR TITLE
Add `aarch64` wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,4 +155,4 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_NON_INTERACTIVE: 1
         run: |
-          python3 -m twine upload downloads/wheel-*/*aarch64.whl
+          python3 -m twine upload downloads/wheel-*/*.whl

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,6 @@ VERSION = "0.5.0"
 
 
 def get_version():
-    return VERSION
     if "RELEASE_VERSION" in os.environ:
         version = os.environ["RELEASE_VERSION"]
         if not version.startswith(VERSION):


### PR DESCRIPTION
In particular, `aarch64` wheels for v0.5.0 have been published. See [here](https://pypi.org/project/fiftyone-brain/#files)