### PR TITLE
Remove duplicate config parameter from compute_visualization()

### DIFF
--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -235,7 +235,6 @@ def compute_visualization(
     brain_key=None,
     num_dims=2,
     method="umap",
-    config=None,
     model=None,
     batch_size=None,
     force_square=False,
@@ -248,6 +247,18 @@ def compute_visualization(
 
     If no ``embeddings`` or ``model`` is provided, a default model is used to
     generate embeddings.
+
+    You can use the ``method`` parameter to select the dimensionality-reduction
+    method to use, and you can optionally customize the method by passing
+    additional parameters for the method's
+    :class:`fiftyone.brain.visualization.VisualizationConfig` class as
+    ``kwargs``.
+
+    The supported ``method`` values and their associated config classes are:
+
+    -   ``"umap"``: :class:`fiftyone.brain.visualization.UMAPVisualizationConfig`
+    -   ``"tsne"``: :class:`fiftyone.brain.visualization.TSNEVisualizationConfig`
+    -   ``"pca"``: :class:`fiftyone.brain.visualization.PCAVisualizationConfig`
 
     Args:
         samples: a :class:`fiftyone.core.collections.SampleCollection`
@@ -270,10 +281,6 @@ def compute_visualization(
         num_dims (2): the dimension of the visualization space
         method ("umap"): the dimensionality-reduction method to use. Supported
             values are ``("umap", "tsne", "pca")``
-        config (None): a
-            :class:`fiftyone.brain.visualization.VisualizationConfig`
-            specifying the parameters to use. If provided, takes precedence
-            over other parameters
         model (None): a :class:`fiftyone.core.models.Model` or the name of a
             model from the
             `FiftyOne Model Zoo <https://voxel51.com/docs/fiftyone/user_guide/model_zoo/index.html>`_
@@ -307,7 +314,6 @@ def compute_visualization(
         brain_key,
         num_dims,
         method,
-        config,
         model,
         batch_size,
         force_square,

--- a/fiftyone/brain/internal/core/visualization.py
+++ b/fiftyone/brain/internal/core/visualization.py
@@ -39,7 +39,6 @@ def compute_visualization(
     brain_key,
     num_dims,
     method,
-    config,
     model,
     batch_size,
     force_square,
@@ -62,7 +61,7 @@ def compute_visualization(
         embeddings_field = None
 
     config = _parse_config(
-        config, embeddings_field, patches_field, method, num_dims, **kwargs
+        embeddings_field, patches_field, method, num_dims, **kwargs
     )
     brain_method = config.build()
     if brain_key is not None:
@@ -214,12 +213,7 @@ class PCAVisualization(Visualization):
         return _pca.fit_transform(embeddings)
 
 
-def _parse_config(
-    config, embeddings_field, patches_field, method, num_dims, **kwargs
-):
-    if config is not None:
-        return config
-
+def _parse_config(embeddings_field, patches_field, method, num_dims, **kwargs):
     if method is None or method == "umap":
         config_cls = UMAPVisualizationConfig
     elif method == "tsne":


### PR DESCRIPTION
Removes the optional `config` parameter from `compute_visualization()`, which was intended to provide a way to preconfigure a visualization method rather than providing `**kwargs` to the method itself.

The motivation for this is the same as the reasoning from the description of https://github.com/voxel51/fiftyone/pull/1114. Namely, that `config` is a redundant way to accomplish something that's already possible via `**kwargs`, and that the `config` syntax creates some possible confusion as to whether certain parameters that are documented in `compute_visualization()` itself should be passed as arguments or included in the pre-made `config`.