### PR TITLE
Only log when there are missing patch embeddings

### DIFF
--- a/fiftyone/brain/internal/core/utils.py
+++ b/fiftyone/brain/internal/core/utils.py
@@ -207,4 +207,7 @@ def _handle_missing_patch_embeddings(embeddings, samples, patches_field):
         embeddings[idx] = np.tile(missing_embedding, (count, 1))
         num_missing += count
 
-    logger.warning("Using zeros for %d missing patch embeddings", num_missing)
+    if num_missing > 0:
+        logger.warning(
+            "Using zeros for %d missing patch embeddings", num_missing
+        )


### PR DESCRIPTION
Prior to this change, a warning would be printed when running `compute_patch_embeddings()` if a sample contained zero patches (which is allowed). However, the intention was only to print an error if there were actually patch embeddings that could not be computed due to bad data.