### PR TITLE
Graceful handling of missing embeddings in compute_uniqueness()

### DIFF
--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -162,9 +162,10 @@ def compute_uniqueness(
     roi_field=None,
     embeddings=None,
     model=None,
-    batch_size=None,
     force_square=False,
     alpha=None,
+    batch_size=None,
+    num_workers=None,
     skip_failures=True,
 ):
     """Adds a uniqueness field to each sample scoring how unique it is with
@@ -203,8 +204,6 @@ def compute_uniqueness(
             `FiftyOne Model Zoo <https://voxel51.com/docs/fiftyone/user_guide/model_zoo/models.html>`_
             to use to generate embeddings. The model must expose embeddings
             (``model.has_embeddings = True``)
-        batch_size (None): a batch size to use when computing embeddings. Only
-            applicable when a ``model`` is provided
         force_square (False): whether to minimally manipulate the patch
             bounding boxes into squares prior to extraction. Only applicable
             when a ``model`` and ``roi_field`` are specified
@@ -215,6 +214,11 @@ def compute_uniqueness(
             ``alpha = 1.1`` to expand the boxes by 10%, and set ``alpha = 0.9``
             to contract the boxes by 10%. Only applicable when a ``model`` and
             ``roi_field`` are specified
+        batch_size (None): a batch size to use when computing embeddings. Only
+            applicable when a ``model`` is provided
+        num_workers (None): the number of workers to use when loading images.
+            Only applicable when a Torch-based model is being used to compute
+            embeddings
         skip_failures (True): whether to gracefully continue without raising an
             error if embeddings cannot be generated for a sample
     """
@@ -226,9 +230,10 @@ def compute_uniqueness(
         roi_field,
         embeddings,
         model,
-        batch_size,
         force_square,
         alpha,
+        batch_size,
+        num_workers,
         skip_failures,
     )
 
@@ -242,9 +247,10 @@ def compute_visualization(
     num_dims=2,
     method="umap",
     model=None,
-    batch_size=None,
     force_square=False,
     alpha=None,
+    batch_size=None,
+    num_workers=None,
     skip_failures=True,
     **kwargs,
 ):
@@ -311,8 +317,6 @@ def compute_visualization(
             `FiftyOne Model Zoo <https://voxel51.com/docs/fiftyone/user_guide/model_zoo/index.html>`_
             to use to generate embeddings. The model must expose embeddings
             (``model.has_embeddings = True``)
-        batch_size (None): an optional batch size to use when computing
-            embeddings. Only applicable when a ``model`` is provided
         force_square (False): whether to minimally manipulate the patch
             bounding boxes into squares prior to extraction. Only applicable
             when a ``model`` and ``patches_field`` are specified
@@ -323,6 +327,11 @@ def compute_visualization(
             ``alpha = 1.1`` to expand the boxes by 10%, and set ``alpha = 0.9``
             to contract the boxes by 10%. Only applicable when a ``model`` and
             ``patches_field`` are specified
+        batch_size (None): an optional batch size to use when computing
+            embeddings. Only applicable when a ``model`` is provided
+        num_workers (None): the number of workers to use when loading images.
+            Only applicable when a Torch-based model is being used to compute
+            embeddings
         skip_failures (True): whether to gracefully continue without raising an
             error if embeddings cannot be generated for a sample
         **kwargs: optional keyword arguments for the constructor of the
@@ -343,9 +352,10 @@ def compute_visualization(
         num_dims,
         method,
         model,
-        batch_size,
         force_square,
         alpha,
+        batch_size,
+        num_workers,
         skip_failures,
         **kwargs,
     )
@@ -358,9 +368,10 @@ def compute_similarity(
     brain_key=None,
     metric="euclidean",
     model=None,
-    batch_size=None,
     force_square=False,
     alpha=None,
+    batch_size=None,
+    num_workers=None,
     skip_failures=True,
 ):
     """Uses embeddings to index the samples or their patches so that you can
@@ -411,8 +422,6 @@ def compute_similarity(
             `FiftyOne Model Zoo <https://voxel51.com/docs/fiftyone/user_guide/model_zoo/index.html>`_
             to use to generate embeddings. The model must expose embeddings
             (``model.has_embeddings = True``)
-        batch_size (None): an optional batch size to use when computing
-            embeddings. Only applicable when a ``model`` is provided
         force_square (False): whether to minimally manipulate the patch
             bounding boxes into squares prior to extraction. Only applicable
             when a ``model`` and ``patches_field`` are specified
@@ -423,6 +432,11 @@ def compute_similarity(
             ``alpha = 1.1`` to expand the boxes by 10%, and set ``alpha = 0.9``
             to contract the boxes by 10%. Only applicable when a ``model`` and
             ``patches_field`` are specified
+        batch_size (None): an optional batch size to use when computing
+            embeddings. Only applicable when a ``model`` is provided
+        num_workers (None): the number of workers to use when loading images.
+            Only applicable when a Torch-based model is being used to compute
+            embeddings
         skip_failures (True): whether to gracefully continue without raising an
             error if embeddings cannot be generated for a sample
 
@@ -438,9 +452,10 @@ def compute_similarity(
         brain_key,
         metric,
         model,
-        batch_size,
         force_square,
         alpha,
+        batch_size,
+        num_workers,
         skip_failures,
     )
 

--- a/fiftyone/brain/internal/core/similarity.py
+++ b/fiftyone/brain/internal/core/similarity.py
@@ -47,9 +47,10 @@ def compute_similarity(
     brain_key,
     metric,
     model,
-    batch_size,
     force_square,
     alpha,
+    batch_size,
+    num_workers,
     skip_failures,
 ):
     """See ``fiftyone/brain/__init__.py``."""
@@ -85,9 +86,10 @@ def compute_similarity(
         patches_field=patches_field,
         embeddings_field=embeddings_field,
         embeddings=embeddings,
-        batch_size=batch_size,
         force_square=force_square,
         alpha=alpha,
+        batch_size=batch_size,
+        num_workers=num_workers,
         skip_failures=skip_failures,
     )
 

--- a/fiftyone/brain/internal/core/uniqueness.py
+++ b/fiftyone/brain/internal/core/uniqueness.py
@@ -45,9 +45,10 @@ def compute_uniqueness(
     roi_field,
     embeddings,
     model,
-    batch_size,
     force_square,
     alpha,
+    batch_size,
+    num_workers,
     skip_failures,
 ):
     """See ``fiftyone/brain/__init__.py``."""
@@ -108,12 +109,13 @@ def compute_uniqueness(
         patches_field=roi_field,
         embeddings_field=embeddings_field,
         embeddings=embeddings,
-        batch_size=batch_size,
         force_square=force_square,
         alpha=alpha,
-        skip_failures=skip_failures,
         handle_missing="image",
         agg_fcn=agg_fcn,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        skip_failures=skip_failures,
     )
 
     logger.info("Computing uniqueness...")

--- a/fiftyone/brain/internal/core/utils.py
+++ b/fiftyone/brain/internal/core/utils.py
@@ -109,12 +109,13 @@ def get_embeddings(
     patches_field=None,
     embeddings_field=None,
     embeddings=None,
-    batch_size=None,
     force_square=False,
     alpha=None,
-    skip_failures=True,
     handle_missing="skip",
     agg_fcn=None,
+    batch_size=None,
+    num_workers=None,
+    skip_failures=True,
 ):
     if model is not None:
         if etau.is_str(model):
@@ -126,10 +127,11 @@ def get_embeddings(
                 model,
                 patches_field,
                 embeddings_field=embeddings_field,
-                handle_missing=handle_missing,
-                batch_size=batch_size,
                 force_square=force_square,
                 alpha=alpha,
+                handle_missing=handle_missing,
+                batch_size=batch_size,
+                num_workers=num_workers,
                 skip_failures=skip_failures,
             )
         else:
@@ -138,6 +140,7 @@ def get_embeddings(
                 model,
                 embeddings_field=embeddings_field,
                 batch_size=batch_size,
+                num_workers=num_workers,
                 skip_failures=skip_failures,
             )
     elif embeddings_field is not None:

--- a/fiftyone/brain/internal/core/visualization.py
+++ b/fiftyone/brain/internal/core/visualization.py
@@ -46,9 +46,10 @@ def compute_visualization(
     num_dims,
     method,
     model,
-    batch_size,
     force_square,
     alpha,
+    batch_size,
+    num_workers,
     skip_failures,
     **kwargs,
 ):
@@ -95,9 +96,10 @@ def compute_visualization(
             patches_field=patches_field,
             embeddings_field=embeddings_field,
             embeddings=embeddings,
-            batch_size=batch_size,
             force_square=force_square,
             alpha=alpha,
+            batch_size=batch_size,
+            num_workers=num_workers,
             skip_failures=skip_failures,
         )
 


### PR DESCRIPTION
#90 introduced graceful handling of missing embeddings to `compute_visualization()` and `compute_similarity()`.

This PR adds the same graceful handling of missing embeddings to `compute_uniqueness()`.

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.brain as fob

dataset = foz.load_zoo_dataset("quickstart").clone()

dataset.set_values("validity", ["good"] * len(dataset))

# Give 50 samples non-existent images so embedding computaion will fail
bad_view = dataset.limit(50)
bad_view.set_values("filepath", ["/non/exsistent.png"] * len(bad_view))
bad_view.set_values("validity", ["bad"] * len(bad_view))

# Warnings are printed but results are still returned
fob.compute_uniqueness(dataset, uniqueness_field="uniqueness")

# Warnings are printed but results are still returned
fob.compute_uniqueness(dataset, roi_field="ground_truth", uniqueness_field="uniqueness_gt")
```