### PR TITLE
Handling empty view in sort_by_similarity()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.6.0
+    rev: v1.12.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==19.10b0]
+        additional_dependencies: [black==21.12b0]
         args: ["-l 79"]
   - repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3
@@ -19,7 +19,16 @@ repos:
         files: \.py$
         entry: pylint
         args: ["--errors-only"]
+  - repo: local
+    hooks:
+      - id: ipynb-strip
+        name: ipynb-strip
+        language: system
+        files: \.ipynb$
+        entry: jupyter nbconvert --clear-output --ClearOutputPreprocessor.enabled=True
+        args: ["--log-level=ERROR"]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.6.2
     hooks:
       - id: prettier
+        language_version: system

--- a/fiftyone/brain/internal/core/utils.py
+++ b/fiftyone/brain/internal/core/utils.py
@@ -100,7 +100,7 @@ def _get_keep_inds(ids, ref_ids):
             "index" % (num_bad, bad_ids[0])
         )
 
-    return np.array(keep_inds)
+    return np.array(keep_inds, dtype=np.int64)
 
 
 def get_embeddings(


### PR DESCRIPTION
Handles a previously uncaught edge case where `view.sort_by_similarity()` would raise an error if `view` is empty.

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=5).clone()
results = fob.compute_similarity(dataset, brain_key="image_sim")

# Previously would raise an error; now succeeds
view = dataset.limit(0).sort_by_similarity(dataset.first().id)
```

Note that other methods like `find_duplicates()` and `find_unique()` will still raise an error on empty views, but I'm not going to do anything about that right now because:
- The methods won't output anything useful in such cases anyway
- The methods aren't currently used by the App, where fatal errors are less acceptable
- The error message is informative

```py
results.use_view(dataset.limit(0))

results.find_duplicates(thresh=0.1)
```

```
ValueError: Found array with 0 sample(s) (shape=(0, 0)) while a minimum of 1 is required by NearestNeighbors.
```
