### PR TITLE
[WIP] Add support for labels when visualizing embeddings

### DIFF
--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -253,6 +253,7 @@ def compute_visualization(
     batch_size=None,
     num_workers=None,
     skip_failures=True,
+    labels=None,
     **kwargs,
 ):
     """Computes a low-dimensional representation of the samples' media or their
@@ -358,6 +359,7 @@ def compute_visualization(
         batch_size,
         num_workers,
         skip_failures,
+        labels,
         **kwargs,
     )
 


### PR DESCRIPTION
UMAP fitting supports labels for supervised dimensionality reduction allowing it to accept an (incomplete) set of labels. It allows you to guide how the dimensionality reduction is performed to structure the embedding space based on certain tagged attribute. 
Example workflow:
* Take the coco dataset 
* tag 5 images of people and 5 with no people
* compute embeddings to generate this plot which distributed all samples along the axis of "personness"
![image](https://user-images.githubusercontent.com/21222883/198617949-f75a368d-a283-44e7-9ae7-d962f8a524a3.png)

* select samples of the tails of this distribution and tag them as "person" and "not person"
* Recompute embeddings to get an even more structured embeddings visualization
![image](https://user-images.githubusercontent.com/21222883/198617678-9ed7c56d-4f69-4a85-bca6-3d8c60894b84.png)

* Iteratively add good examples of classes, recomputing the visualization each time to generate more accurate clusters

This was all done just using tags in the App:
```python
def visualize_from_tags(dataset, embeddings):
    labels = [t[0] if t else None for t in dataset.values("tags")]
    results = fob.compute_visualization(dataset, embeddings=embeddings, labels=labels)
    plot = results.visualize(labels=(F("tags").length() > 0).if_else(F("tags")[0], "None"))
    return plot
```