### PR TITLE
Store IDs when generating brain results

### DIFF
--- a/fiftyone/brain/internal/core/utils.py
+++ b/fiftyone/brain/internal/core/utils.py
@@ -20,88 +20,15 @@ from fiftyone import ViewField as F
 logger = logging.getLogger(__name__)
 
 
-def parse_data(
-    samples,
-    data,
-    sample_ids=None,
-    label_ids=None,
-    patches_field=None,
-    data_type="embeddings",
-    allow_missing=False,
-    warn_missing=True,
-):
-    if sample_ids is None:
-        sample_ids, label_ids = get_ids(
-            samples,
-            patches_field=patches_field,
-            data=data,
-            data_type=data_type,
-        )
-
-        return samples, data, sample_ids, label_ids
-
-    samples, sample_ids, label_ids, keep_inds, good_inds = filter_ids(
-        samples,
-        sample_ids,
-        label_ids,
-        patches_field=patches_field,
-        allow_missing=True,
-        warn_missing=False,
-    )
-
-    if good_inds is not None:
-        num_missing = good_inds.size - np.count_nonzero(good_inds)
-        ftype = "samples" if patches_field is None else "labels"
-
-        if not allow_missing:
-            raise ValueError(
-                "The provided collection contains %d %s whose %s are not "
-                "present in the index" % (num_missing, ftype, data_type)
-            )
-
-        if warn_missing:
-            logger.warning(
-                "Ignoring %d %s from the provided collection whose %s are not "
-                "present in the index",
-                num_missing,
-                ftype,
-                data_type,
-            )
-
-    if keep_inds is not None:
-        num_missing = len(data) - len(keep_inds)
-        if num_missing > 0:
-            ftype = "samples" if patches_field is None else "labels"
-
-            if not allow_missing:
-                raise ValueError(
-                    "The index contains %d %s whose %s are no longer present "
-                    "in the provided collection"
-                    % (num_missing, data_type, ftype)
-                )
-
-            if warn_missing:
-                logger.warning(
-                    "Ignoring %d %s from the index whose %s are not present "
-                    "in the provided collection",
-                    num_missing,
-                    data_type,
-                    ftype,
-                )
-
-        data = data[keep_inds, :]
-
-    return samples, data, sample_ids, label_ids
-
-
 def get_ids(samples, patches_field=None, data=None, data_type="embeddings"):
     if patches_field is None:
         sample_ids = samples.values("id")
 
         if data is not None and len(sample_ids) != len(data):
             raise ValueError(
-                "The number of %s (%d) does not match the number of samples "
-                "(%d) in the collection "
+                "The number of %s (%d) in these results no longer matches the "
+                "number of samples (%d) in the collection. You must "
+                "regenerate the results"
                 % (data_type, len(data), len(sample_ids))
             )
 
@@ -115,8 +42,9 @@ def get_ids(samples, patches_field=None, data=None, data_type="embeddings"):
 
     if data is not None and len(sample_ids) != len(data):
         raise ValueError(
-            "The number of %s (%d) does not match the number of labels (%d) "
-            "in the '%s' field of the collection"
+            "The number of %s (%d) in these results no longer matches the "
+            "number of labels (%d) in the '%s' field of the collection. You "
+            "must regenerate the results"
             % (data_type, len(data), len(sample_ids), patches_field)
         )
 
@@ -129,14 +57,10 @@ def filter_ids(
     index_label_ids,
     index_samples=None,
     patches_field=None,
-    allow_missing=False,
-    warn_missing=True,
+    allow_missing=True,
+    warn_missing=False,
 ):
-    # No filtering required
-    if index_samples is not None and (
-        view == index_samples or view.view() == index_samples.view()
-    ):
-        return view, index_sample_ids, index_label_ids, None, None
+    _validate_args(view, None, patches_field)
 
     if patches_field is None:
         if view._is_patches:
@@ -155,33 +79,7 @@ def filter_ids(
         if bad_ids is not None:
             _sample_ids = _sample_ids[good_inds]
 
-            if view._is_patches:
-                view = view.exclude_by("sample_id", bad_ids)
-            else:
-                view = view.exclude(bad_ids)
-
-        return view, _sample_ids, None, keep_inds, good_inds
-
-    # Filter labels in patches view
-
-    if (
-        isinstance(view, fop.PatchesView)
-        and patches_field != view.patches_field
-    ):
-        raise ValueError(
-            "This patches view contains labels from field '%s', not "
-            "'%s'" % (view.patches_field, patches_field)
-        )
-
-    if isinstance(view, fop.EvaluationPatchesView) and patches_field not in (
-        view.gt_field,
-        view.pred_field,
-    ):
-        raise ValueError(
-            "This evaluation patches view contains patches from "
-            "fields '%s' and '%s', not '%s'"
-            % (view.gt_field, view.pred_field, patches_field)
-        )
+        return _sample_ids, None, keep_inds, good_inds
 
     labels = view._get_selected_labels(fields=patches_field)
     _sample_ids = np.array([l["sample_id"] for l in labels])
@@ -198,9 +96,8 @@ def filter_ids(
     if bad_ids is not None:
         _sample_ids = _sample_ids[good_inds]
         _label_ids = _label_ids[good_inds]
-        view = view.exclude_labels(ids=bad_ids, fields=patches_field)
 
-    return view, _sample_ids, _label_ids, keep_inds, good_inds
+    return _sample_ids, _label_ids, keep_inds, good_inds
 
 
 def _parse_ids(ids, index_ids, ftype, allow_missing, warn_missing):
@@ -220,29 +117,47 @@ def _parse_ids(ids, index_ids, ftype, allow_missing, warn_missing):
             bad_inds.append(_idx)
             bad_ids.append(_id)
 
+    num_missing_index = len(index_ids) - len(keep_inds)
+    if num_missing_index > 0:
+        if not allow_missing:
+            raise ValueError(
+                "The index contains %d %s that are not present in the "
+                "provided collection" % (num_missing_index, ftype)
+            )
+
+        if warn_missing:
+            logger.warning(
+                "Ignoring %d %s from the index that are not present in the "
+                "provided collection",
+                num_missing_index,
+                ftype,
+            )
+
+    num_missing_collection = len(bad_ids)
+    if num_missing_collection > 0:
+        if not allow_missing:
+            raise ValueError(
+                "The provided collection contains %d %s not present in the "
+                "index" % (num_missing_collection, ftype)
+            )
+
+        if warn_missing:
+            logger.warning(
+                "Ignoring %d %s from the provided collection that are not "
+                "present in the index",
+                num_missing_collection,
+                ftype,
+            )
+
+        bad_inds = np.array(bad_inds, dtype=np.int64)
+
+        good_inds = np.full(ids.shape, True)
+        good_inds[bad_inds] = False
+    else:
+        good_inds = None
+        bad_ids = None
+
     keep_inds = np.array(keep_inds, dtype=np.int64)
-
-    if not bad_inds:
-        return keep_inds, None, None
-
-    if not allow_missing:
-        raise ValueError(
-            "The provided collection contains %d %s not present in the index"
-            % (len(bad_ids), ftype)
-        )
-
-    if warn_missing:
-        logger.warning(
-            "Ignoring %d %s from the provided collection that are not present "
-            "in the index",
-            len(bad_ids),
-            ftype,
-        )
-
-    bad_inds = np.array(bad_inds, dtype=np.int64)
-
-    good_inds = np.full(ids.shape, True)
-    good_inds[bad_inds] = False
 
     return keep_inds, good_inds, bad_ids
 
@@ -270,6 +185,13 @@ def filter_values(values, keep_inds, patches_field=None):
     # will gracefully handle either flat or nested list data
 
     return _values
+
+
+def get_values(samples, path_or_expr, ids, patches_field=None):
+    _validate_args(samples, path_or_expr, patches_field)
+    return samples._get_values_by_id(
+        path_or_expr, ids, link_field=patches_field
+    )
 
 
 def get_embeddings(
@@ -343,6 +265,57 @@ def get_embeddings(
         embeddings = np.stack(embeddings)
 
     return embeddings
+
+
+def _validate_args(samples, path_or_expr, patches_field):
+    if patches_field is not None:
+        _validate_patches_args(samples, path_or_expr, patches_field)
+    else:
+        _validate_samples_args(samples, path_or_expr)
+
+
+def _validate_samples_args(samples, path_or_expr):
+    if not etau.is_str(path_or_expr):
+        return
+
+    path, _, list_fields, _, _ = samples._parse_field_name(path_or_expr)
+
+    if list_fields:
+        raise ValueError(
+            "Values path '%s' contains invalid list field '%s'"
+            % (path, list_fields[0])
+        )
+
+
+def _validate_patches_args(samples, path_or_expr, patches_field):
+    if etau.is_str(path_or_expr) and not path_or_expr.startswith(
+        patches_field + "."
+    ):
+        raise ValueError(
+            "Values path '%s' must start with patches field '%s'"
+            % (path_or_expr, patches_field)
+        )
+
+    if (
+        isinstance(samples, fop.PatchesView)
+        and patches_field != samples.patches_field
+    ):
+        raise ValueError(
+            "This patches view contains labels from field '%s', not "
+            "'%s'" % (samples.patches_field, patches_field)
+        )
+
+    if isinstance(
+        samples, fop.EvaluationPatchesView
+    ) and patches_field not in (
+        samples.gt_field,
+        samples.pred_field,
+    ):
+        raise ValueError(
+            "This evaluation patches view contains patches from "
+            "fields '%s' and '%s', not '%s'"
+            % (samples.gt_field, samples.pred_field, patches_field)
+        )
 
 
 def _handle_missing_embeddings(embeddings):


### PR DESCRIPTION
This PR extends the gracefulness of https://github.com/voxel51/fiftyone-brain/pull/113 by storing sample/label IDs for similarity/visualization runs so that the index can be used even if the contents of the underlying view changes between when the results are generated and when they are used.

The example below demonstrates that the interface now correctly handles a complex case where the view on which the results were computed undergoes both additions and deletions.

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.brain.internal.models as fbm
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart")

# Tag samples with >= 10 ground truth objects
is_crowded = F("ground_truth.detections").length() > 10
crowded_view = dataset.match(is_crowded)
crowded_view.tag_samples("crowded")

# Convert to a tag-based view for illustrative purposes
crowded_view = dataset.match_tags("crowded")

# Generate visualization
model = fbm.load_model("simple-resnet-cifar10")
results = fob.compute_visualization(
    crowded_view, model=model, brain_key="crowded_sim"
)

print(results.total_index_size)  # 39
print(results.index_size)  # 39
print(results.missing_size)  # None

plot = results.visualize(labels=is_crowded)
plot.show()

# Add and delete some data
crowded_view.take(10).untag_samples("crowded")
dataset.match(~is_crowded).take(10).tag_samples("crowded")

results.use_view(crowded_view, warn_missing=True)
# Ignoring 10 samples from the index that are not present in the provided collection
# Ignoring 10 samples from the provided collection that are not present in the index

# These numbers were previously incorrect; now they are correct
print(results.total_index_size)  # 39
print(results.index_size)  # 29
print(results.missing_size)  # 10

# Since the original index was only computed on points where `is_crowded=True`, this 
# plot should only show points with `label=True`, which it does
plot = results.visualize(labels=is_crowded)
plot.show()
```
