### PR TITLE
Handling missing data in visualize()

### DIFF
--- a/fiftyone/brain/internal/core/visualization.py
+++ b/fiftyone/brain/internal/core/visualization.py
@@ -163,12 +163,12 @@ def visualize(
         ids = results.current_sample_ids
 
     if good_inds is not None:
-        if labels is not None and not _is_expr(labels):
+        if etau.is_container(labels) and not _is_expr(labels):
             labels = fbu.filter_values(
                 labels, good_inds, patches_field=patches_field
             )
 
-        if sizes is not None and not _is_expr(sizes):
+        if etau.is_container(sizes) and not _is_expr(sizes):
             sizes = fbu.filter_values(
                 sizes, good_inds, patches_field=patches_field
             )


### PR DESCRIPTION
Fixes a bug in `VisualizationResults.visualize(labels=labels)` when `labels` is a string and there is missing data.

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz

dataset = fo.Dataset()

samples = [
    fo.Sample(filepath="non-existent1.jpg"),
]
samples.extend(list(foz.load_zoo_dataset("quickstart", max_samples=10)))
samples.extend(
    [
        fo.Sample(filepath="non-existent4.jpg"),
        fo.Sample(filepath="non-existent5.jpg"),
    ]
)

dataset.add_samples(samples)

model = foz.load_zoo_model("mobilenet-v2-imagenet-torch")
results = fob.compute_visualization(dataset, model=model, batch_size=1)

# previously would fail, now succeeds
plot = results.visualize(labels="uniqueness")
plot.show()
```
