### PR TITLE
Initialize similarity index before computing embeddings

### DIFF
--- a/fiftyone/brain/similarity.py
+++ b/fiftyone/brain/similarity.py
@@ -96,6 +96,8 @@ def compute_similarity(
         # automatically cleaning up the backend's index
         brain_method.register_run(samples, brain_key, overwrite=False)
 
+    results = brain_method.initialize(samples, brain_key)
+
     if embeddings is not False:
         embeddings, sample_ids, label_ids = fbu.get_embeddings(
             samples,
@@ -112,8 +114,6 @@ def compute_similarity(
     else:
         # Special syntax to allow embeddings to be added later
         embeddings = None
-
-    results = brain_method.initialize(samples, brain_key)
 
     if embeddings is not None:
         results.add_to_index(embeddings, sample_ids, label_ids=label_ids)


### PR DESCRIPTION
It's better to `initialize()` the similarity index first, to make sure that we're able to communicate with the vector backend, to save users the pain of computing a bunch of embeddings only to lose them if a configuration error is surfaced when trying to upload them:

<img width="801" alt="Screen Shot 2023-04-19 at 1 01 53 AM" src="https://user-images.githubusercontent.com/25985824/232971497-e612df10-b133-4572-9a50-0a6d6c4aacff.png">
