### PR TITLE
Fix mongodb vector db integration

### DIFF
--- a/fiftyone/brain/internal/core/mongodb.py
+++ b/fiftyone/brain/internal/core/mongodb.py
@@ -176,7 +176,10 @@ class MongoDBSimilarityIndex(SimilarityIndex):
         coll = self._samples._dataset._sample_collection
 
         try:
-            indexes = {i["name"]: i for i in coll.list_search_indexes()}
+            indexes = {
+                i["name"]: i
+                for i in coll.aggregate([{"$listSearchIndexes": {}}])
+            }
         except OperationFailure:
             # https://www.mongodb.com/docs/manual/release-notes/7.0/#atlas-search-index-management
             # https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-overview
@@ -259,7 +262,10 @@ class MongoDBSimilarityIndex(SimilarityIndex):
 
         try:
             coll = self._samples._dataset._sample_collection
-            indexes = {i["name"]: i for i in coll.list_search_indexes()}
+            indexes = {
+                i["name"]: i
+                for i in coll.aggregate([{"$listSearchIndexes": {}}])
+            }
         except OperationFailure:
             # requires MongoDB Atlas 7.0 or later
             return None


### PR DESCRIPTION
motor doesn't have a coll.list_search_indexes() function, so compute_similarity() will fail if run with the async client. However, we can still run the query via aggregation

TEAMS-2055
