### PR TITLE
Don't cleanup when overwriting uniqueness/mistakenness/hardness runs

### DIFF
--- a/fiftyone/brain/internal/core/hardness.py
+++ b/fiftyone/brain/internal/core/hardness.py
@@ -43,7 +43,7 @@ def compute_hardness(samples, label_field, hardness_field):
     brain_key = hardness_field
     brain_method = config.build()
     brain_method.ensure_requirements()
-    brain_method.register_run(samples, brain_key)
+    brain_method.register_run(samples, brain_key, cleanup=False)
     brain_method.register_samples(samples)
 
     view = samples.select_fields(label_field)

--- a/fiftyone/brain/internal/core/mistakenness.py
+++ b/fiftyone/brain/internal/core/mistakenness.py
@@ -101,7 +101,7 @@ def compute_mistakenness(
     brain_key = mistakenness_field
     brain_method = config.build()
     brain_method.ensure_requirements()
-    brain_method.register_run(samples, brain_key)
+    brain_method.register_run(samples, brain_key, cleanup=False)
     brain_method.register_samples(samples)
 
     if is_objects:

--- a/fiftyone/brain/internal/core/uniqueness.py
+++ b/fiftyone/brain/internal/core/uniqueness.py
@@ -96,7 +96,7 @@ def compute_uniqueness(
     brain_key = uniqueness_field
     brain_method = config.build()
     brain_method.ensure_requirements()
-    brain_method.register_run(samples, brain_key)
+    brain_method.register_run(samples, brain_key, cleanup=False)
 
     if roi_field is not None:
         # @todo experiment with mean(), max(), abs().max(), etc


### PR DESCRIPTION
Requires https://github.com/voxel51/fiftyone/pull/3978 to function.

Multiple users have wanted/expected that they can run the code below to compute uniqueness on disjoint subset views of a dataset and store the uniqueness values under the same field.

Previously, this code would silently delete the existing uniqueness values because, technically, the user is overwriting a brain run with same key (`brain_key == uniquenesss_field`), which triggers a call to the existing run's `cleanup()` method, which deletes the entire `uniqueness_field`.

Now, `cleanup()` is **not** called when running `compute_uniqueness()` multiple times with the same `uniqueness_field`, which allows the user to build up uniqueness values over multiple runs. The reason this was not previously allowed is that, technically, methods like `load_brain_view()` will now only load the *last* view on which uniqueness was computed; the dataset is no longer "aware" that multiple brain runs were executed on the dataset.

The way to have the best of both worlds would be to add a separate `brain_key` argument independent of `uniqueness_field` and also update the `cleanup()` method to only *clear* the `uniqueness_field` values if the input collection is a view rather than a dataset. However, I think the less invasive change in this PR is sufficient for now.

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("cifar10", split="test")

model = foz.load_zoo_model("mobilenet-v2-imagenet-torch")
dataset.compute_embeddings(model, embeddings_field="embeddings")

#
# Run uniqueness on each class individually
#

classes = dataset.distinct("ground_truth.label")
for label in classes:
    view = dataset.match(F("ground_truth.label") == label)
    fob.compute_uniqueness(view, embeddings="embeddings")

assert len(dataset) == len(dataset.exists("uniqueness"))

#
# Cleanup
#

dataset.delete_brain_run("uniqueness")
assert dataset.has_sample_field("uniqueness") is False
```
