### PR TITLE
use db cmd instead of create_search_index

### DIFF
--- a/fiftyone/brain/internal/core/mongodb.py
+++ b/fiftyone/brain/internal/core/mongodb.py
@@ -235,7 +235,7 @@ class MongoDBSimilarityIndex(SimilarityIndex):
         # for compatibility with async motor driver, we must use the
         # db.command interface instead of the Collection.create_search_index
         cmd = {
-            "createSearchIndexes": self.config.index_name,
+            "createSearchIndexes": self._curr_view._root_dataset._sample_collection_name,
             "indexes": [
                 {
                     "name": self.config.index_name,


### PR DESCRIPTION
async motor driver doesn't have create_search_index, so for compatibility, we need to use the db cmd

tested locally in proxy mode
```
ds=fo.load_dataset('qskacey')
mongodb_index = fob.compute_similarity(ds,model="clip-vit-base32-torch",embeddings="embeddings_kacey_new2",brain_key="bk0_kacey",backend="mongodb", )
```

hub debug logs show createSearchIndex executed:
```
2024-01-03T13:29:35.783 DEBUG default.py:227 Database(name="fiftyone-teams").command({'createSearchIndexes': 'samples.6595d079da696d4ca30d4cdf', 'indexes': [{'name': 'embeddings_kacey_new2', 'definition': {'mappings': {'dynamic': True, 'fields': {'embeddings_kacey_new2': {'type': 'knnVector', 'dimensions': 512, 'similarity': 'cosine'}}}}}]})
```

Atlas search dashboard shows index: 
<img width="1963" alt="image" src="https://github.com/voxel51/fiftyone-brain/assets/30936736/5568cbdb-7c0d-499d-b36f-99dd430fd0f6">


Also running sort by similarity via the sdk works:
```
 ds.sort_by_similarity(ds.first().id, brain_key="clip_sim__kacey1704317353")

[{'$match': {'_id': {'$in': [ObjectId('6595d08bff3ad7625889604c'), ObjectId('6595d08cff3ad76258896052'), ObjectId('6595d08eff3ad7625889606c'), ObjectId('6595d08eff3ad76258896090'), 
...
ObjectId('6595d094ff3ad762588960c3'), ObjectId('6595d08cff3ad76258896050')]}}}, {'$addFields': {'_select_order': {'$indexOfArray': [[ObjectId('6595d08bff3ad7625889604c'), 
...
], '$_id']}}}, {'$sort': {'_select_order': 1}}, {'$project': {'_select_order': False}}, {'$count': 'count'}]

Dataset:     qskacey
Media type:  image
Num samples: 200
Sample fields:
    id:                    fiftyone.core.fields.ObjectIdField
    filepath:              fiftyone.core.fields.StringField
    tags:                  fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
    metadata:              fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
    ground_truth:          fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
    uniqueness:            fiftyone.core.fields.FloatField
    predictions:           fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
    embeddings_kacey_new2: fiftyone.core.fields.ListField(fiftyone.core.fields.FloatField)
View stages:
    1. SortBySimilarity(query='6595d08bff3ad7625889604c', k=None, reverse=False, dist_field=None, brain_key='clip_sim__kacey1704317353')



