### PR TITLE
MongoDB vector backend fix when embeddings already exist on dataset

### DIFF
--- a/fiftyone/brain/internal/core/mongodb.py
+++ b/fiftyone/brain/internal/core/mongodb.py
@@ -170,7 +170,7 @@ class MongoDBSimilarityIndex(SimilarityIndex):
 
     @property
     def total_index_size(self):
-        return len(self._sample_ids)
+        return len(self._sample_ids) if self._index is not None else 0
 
     def _initialize(self):
         coll = self._samples._dataset._sample_collection
@@ -197,6 +197,11 @@ class MongoDBSimilarityIndex(SimilarityIndex):
             self._index = True
 
             return
+
+        # self.config.index_name appears to be available largely for Mongo Atlas 6.0 support.
+        # The case where a user provides an index_name that already exists in indexes is quite
+        # dangerous otherwise as the existing index must precisely match (or be a superset perhaps)
+        # of self._sample_ids
 
         if self.config.index_name is None:
             root = self.config.embeddings_field


### PR DESCRIPTION
## Test Cases

```py
dsn = "quickstart-test-similarity-image-10"

if fo.dataset_exists(dsn):
    fo.delete_dataset(dsn)
     test cases
dataset = foz.load_zoo_dataset(
    "quickstart", 
    max_samples=10,
    dataset_name=dsn
)
dataset.persistent=True

d = 64
embs = np.random.rand(len(dataset),d)
dataset.set_values('embs',embs.tolist())

# existing embs, no model
idx0 = fob.compute_similarity(
    dataset,
    embeddings='embs',
    backend='mongodb',
    brain_key='bk_mongo0')

# existing embs, model
idx1 = fob.compute_similarity(
    dataset,
    model='clip-vit-base32-torch',
    embeddings='embs',
    backend='mongodb',
    brain_key='bk_mongo1')

# embs=False
idx2 = fob.compute_similarity(
    dataset,
    embeddings_field='embs',
    embeddings=False,
    backend='mongodb',
    brain_key='bk_mongo2')

# existing embs, deere case
model = foz.load_zoo_model("clip-vit-base32-torch")
embeddings = dataset.compute_embeddings(model, embeddings_field="embeddings", skip_failures=False)
idx3 = fob.compute_similarity(
    dataset,
    model="clip-vit-base32-torch",
    embeddings="embeddings",
    brain_key="pre_computed_embeddings_test",
    backend="mongodb",
)
```

## "Before" Results
```
_id = dataset.first().id
v0 = idx0.sort_by_similarity(_id,k=3)
v1 = idx1.sort_by_similarity(_id,k=3)
v2 = idx2.sort_by_similarity(_id,k=3)
v3 = idx3.sort_by_similarity(_id,k=3)
vv0 = dataset.sort_by_similarity(_id,k=3,brain_key='bk_mongo0')
vv1 = dataset.sort_by_similarity(_id,k=3,brain_key='bk_mongo1')
vv2 = dataset.sort_by_similarity(_id,k=3,brain_key='bk_mongo2')
vv3 = dataset.sort_by_similarity(_id,k=3,brain_key="pre_computed_embeddings_test")

print(len(v0),len(v1),len(v2),len(v3)) # returns 0 0 0 0
print(len(vv0),len(vv1),len(vv2),len(vv3)) # returns 0 0 0 0
```

## "After" test cases