### PR TITLE
Adding Representativeness Method

### DIFF
--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -301,11 +301,12 @@ def compute_representativeness(
         representativeness_field ("representativeness"): the field name to use
             to store the representativeness value for each sample
         method ("cluster-center"): the name of the method to use to compute the
-            representativeness. One of ['cluster-center',
-            'cluster-center-downweight']. `cluster-center` will make a samples
-            representativeness proportional to it's proximity to cluster centers
-            while `cluster-center-downweight` will ensure more diversity in
-            representative samples.
+            representativeness. The supported values are
+            ``["cluster-center", 'cluster-center-downweight']``.
+            ``"cluster-center"` will make a sample's representativeness
+            proportional to it's proximity to cluster centers, while
+            ``"cluster-center-downweight"`` will ensure more diversity in
+            representative samples
         roi_field (None): an optional :class:`fiftyone.core.labels.Detection`,
             :class:`fiftyone.core.labels.Detections`,
             :class:`fiftyone.core.labels.Polyline`, or

--- a/fiftyone/brain/internal/core/representativeness.py
+++ b/fiftyone/brain/internal/core/representativeness.py
@@ -87,8 +87,8 @@ def compute_representativeness(
 
     config = RepresentativenessConfig(
         representativeness_field,
-        roi_field=roi_field,
         method=method,
+        roi_field=roi_field,
         embeddings_field=embeddings_field,
         model=model,
         model_kwargs=model_kwargs,
@@ -161,9 +161,11 @@ def _compute_representativeness(embeddings, method="cluster-center"):
         )
     else:
         raise ValueError(
-            "Method {} not supported. Please use one of ['cluster-center', 'cluster-center-downweight']".format(
-                method
+            (
+                "Method '%s' not supported. Please use one of "
+                "['cluster-center', 'cluster-center-downweight']"
             )
+            % method
         )
 
     return final_ranking
@@ -184,9 +186,11 @@ def _cluster_ranker(
         clusterer = skc.KMeans(n_clusters=N, random_state=1234).fit(embeddings)
     else:
         raise ValueError(
-            "Clustering algorithm {} no supported. Please use one of ['meanshift', 'kmeans']".format(
-                cluster_algorithm
+            (
+                "Clustering algorithm '%s' not supported. Please use one of "
+                "['meanshift', 'kmeans']"
             )
+            % cluster_algorithm
         )
 
     cluster_centers = clusterer.cluster_centers_
@@ -246,7 +250,7 @@ class RepresentativenessConfig(fob.BrainMethodConfig):
     def __init__(
         self,
         representativeness_field,
-        method="cluster-center",
+        method=None,
         roi_field=None,
         embeddings_field=None,
         model=None,
@@ -257,10 +261,10 @@ class RepresentativenessConfig(fob.BrainMethodConfig):
             model = etau.get_class_name(model)
 
         self.representativeness_field = representativeness_field
+        self._method = method
         self.roi_field = roi_field
         self.embeddings_field = embeddings_field
         self.model = model
-        self._method = method
         self.model_kwargs = model_kwargs
         super().__init__(**kwargs)
 


### PR DESCRIPTION
This PR add's a method to compute "representativeness" for each sample in the dataset. 

There are two basic implementations available (though there could be more). They both rely on first computing clusters of the data using MeanShift and then computes representativeness based on how close each point is to it's cluster center. 

As a simple example:
```python
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.brain as fob

dataset = foz.load_zoo_dataset('cifar10', split='train')

# "cluster-center"
fob.compute_representativeness(dataset, representativeness_field="rep_cluster", method="cluster-center")

```