### PR TITLE
throw an error when compute_similarity gets empty brain key

### DIFF
--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -652,6 +652,9 @@ def compute_similarity(
     """
     import fiftyone.brain.similarity as fbs
 
+    if brain_key is None:
+        raise ValueError("brain_key cannot be None")
+
     return fbs.compute_similarity(
         samples,
         patches_field,


### PR DESCRIPTION
https://voxel51.slack.com/archives/C0128P8LGGK/p1723662456125099

can we throw an error when brain_key is empty?

I have had the same typo before