### PR TITLE
Unpin pandas

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,7 @@
 flickrapi==2.4.0
 imageio==2.8.0
 ipython>=7.16.1
-pandas==1.1.5
+pandas
 pre-commit==2.0.1
 pylint==2.3.1
 pytest==7.3.1


### PR DESCRIPTION
Unpin `pandas` in `requirements/dev.txt` to avoid local wheel build installation issues