### PR TITLE
Update uniqueness to use similarity backend

### DIFF
--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -184,7 +184,8 @@ def compute_uniqueness(
     num_workers=None,
     skip_failures=True,
     progress=None,
-    backend=None,
+    similarity_backend=None,
+    similarity_index=None,
 ):
     """Adds a uniqueness field to each sample scoring how unique it is with
     respect to the rest of the samples.
@@ -269,7 +270,8 @@ def compute_uniqueness(
         num_workers,
         skip_failures,
         progress,
-        backend,
+        similarity_backend,
+        similarity_index,
     )
 
 

--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -250,10 +250,11 @@ def compute_uniqueness(
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
-        backend (None): the similarity backend to use. The supported values are
+        similarity_backend (None): the similarity backend to use. The supported values are
             ``fiftyone.brain.brain_config.similarity_backends.keys()`` and the
-            default is
-            ``fiftyone.brain.brain_config.default_similarity_backend``
+            default is ``fiftyone.brain.brain_config.default_similarity_backend``
+        similarity_index (None): the similarity index to use. This can be computed using
+            fob.compute_similarity
     """
     import fiftyone.brain.internal.core.uniqueness as fbu
 

--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -184,6 +184,7 @@ def compute_uniqueness(
     num_workers=None,
     skip_failures=True,
     progress=None,
+    backend=None,
 ):
     """Adds a uniqueness field to each sample scoring how unique it is with
     respect to the rest of the samples.
@@ -248,6 +249,10 @@ def compute_uniqueness(
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
+        backend (None): the similarity backend to use. The supported values are
+            ``fiftyone.brain.brain_config.similarity_backends.keys()`` and the
+            default is
+            ``fiftyone.brain.brain_config.default_similarity_backend``
     """
     import fiftyone.brain.internal.core.uniqueness as fbu
 
@@ -264,6 +269,7 @@ def compute_uniqueness(
         num_workers,
         skip_failures,
         progress,
+        backend,
     )
 
 

--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -176,6 +176,7 @@ def compute_uniqueness(
     uniqueness_field="uniqueness",
     roi_field=None,
     embeddings=None,
+    similarity_index=None,
     model=None,
     model_kwargs=None,
     force_square=False,
@@ -184,8 +185,6 @@ def compute_uniqueness(
     num_workers=None,
     skip_failures=True,
     progress=None,
-    similarity_backend=None,
-    similarity_index=None,
 ):
     """Adds a uniqueness field to each sample scoring how unique it is with
     respect to the rest of the samples.
@@ -193,8 +192,8 @@ def compute_uniqueness(
     This function only uses the pixel data and can therefore process labeled or
     unlabeled samples.
 
-    If no ``embeddings`` or ``model`` is provided, a default model is used to
-    generate embeddings.
+    If no ``embeddings``, ``similarity_index``, or ``model`` is provided, a
+    default model is used to generate embeddings.
 
     .. note::
 
@@ -223,6 +222,9 @@ def compute_uniqueness(
             when working with patch embeddings, you can provide either the
             fully-qualified path to the patch embeddings or just the name of
             the label attribute in ``roi_field``
+        similarity_index (None): a
+            :class:`fiftyone.brain.similarity.SimilarityIndex` or the brain key
+            of a similarity index to use to load pre-computed embeddings
         model (None): a :class:`fiftyone.core.models.Model` or the name of a
             model from the
             `FiftyOne Model Zoo <https://docs.voxel51.com/user_guide/model_zoo/models.html>`_
@@ -250,11 +252,6 @@ def compute_uniqueness(
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
-        similarity_backend (None): the similarity backend to use. The supported values are
-            ``fiftyone.brain.brain_config.similarity_backends.keys()`` and the
-            default is ``fiftyone.brain.brain_config.default_similarity_backend``
-        similarity_index (None): the similarity index to use. This can be set to
-            ``fiftyone.brain.similarity.SimilarityIndex`` instance or a brain_key string to load the similarity index via samples.load_brain_results
     """
     import fiftyone.brain.internal.core.uniqueness as fbu
 
@@ -263,6 +260,7 @@ def compute_uniqueness(
         uniqueness_field,
         roi_field,
         embeddings,
+        similarity_index,
         model,
         model_kwargs,
         force_square,
@@ -271,8 +269,6 @@ def compute_uniqueness(
         num_workers,
         skip_failures,
         progress,
-        similarity_backend,
-        similarity_index,
     )
 
 
@@ -282,6 +278,7 @@ def compute_representativeness(
     method="cluster-center",
     roi_field=None,
     embeddings=None,
+    similarity_index=None,
     model=None,
     model_kwargs=None,
     force_square=False,
@@ -297,8 +294,8 @@ def compute_representativeness(
     This function only uses the pixel data and can therefore process labeled or
     unlabeled samples.
 
-    If no ``embeddings`` or ``model`` is provided, a default model is used to
-    generate embeddings.
+    If no ``embeddings``, ``similarity_index``, or ``model`` is provided, a
+    default model is used to generate embeddings.
 
     .. note::
 
@@ -334,6 +331,9 @@ def compute_representativeness(
             when working with patch embeddings, you can provide either the
             fully-qualified path to the patch embeddings or just the name of
             the label attribute in ``roi_field``
+        similarity_index (None): a
+            :class:`fiftyone.brain.similarity.SimilarityIndex` or the brain key
+            of a similarity index to use to load pre-computed embeddings
         model (None): a :class:`fiftyone.core.models.Model` or the name of a
             model from the
             `FiftyOne Model Zoo <https://docs.voxel51.com/user_guide/model_zoo/models.html>`_
@@ -370,6 +370,7 @@ def compute_representativeness(
         method,
         roi_field,
         embeddings,
+        similarity_index,
         model,
         model_kwargs,
         force_square,
@@ -389,6 +390,7 @@ def compute_visualization(
     brain_key=None,
     num_dims=2,
     method=None,
+    similarity_index=None,
     model=None,
     model_kwargs=None,
     force_square=False,
@@ -407,12 +409,8 @@ def compute_visualization(
     method of the returned
     :class:`fiftyone.brain.visualization.VisualizationResults` object.
 
-    If no ``embeddings`` or ``model`` is provided, the following default model
-    is used to generate embeddings::
-
-        import fiftyone.zoo as foz
-
-        model = foz.load_zoo_model("mobilenet-v2-imagenet-torch")
+    If no ``embeddings``, ``similarity_index``, or ``model`` is provided, a
+    default model is used to generate embeddings.
 
     You can use the ``method`` parameter to select the dimensionality reduction
     method to use, and you can optionally customize the method by passing
@@ -447,8 +445,6 @@ def compute_visualization(
                 to ``num_patches x num_embedding_dims`` arrays of patch
                 embeddings
             -   the name of a dataset field containing the embeddings to use
-            -   a :class:`fiftyone.brain.similarity.SimilarityIndex` from which
-                to retrieve embeddings for all samples/patches in ``samples``
 
             If a ``model`` is provided, this argument specifies the name of a
             field in which to store the computed embeddings. In either case,
@@ -480,6 +476,9 @@ def compute_visualization(
             ``fiftyone.brain.brain_config.visualization_methods.keys()`` and
             the default is
             ``fiftyone.brain.brain_config.default_visualization_method``
+        similarity_index (None): a
+            :class:`fiftyone.brain.similarity.SimilarityIndex` or the brain key
+            of a similarity index to use to load pre-computed embeddings
         model (None): a :class:`fiftyone.core.models.Model` or the name of a
             model from the
             `FiftyOne Model Zoo <https://docs.voxel51.com/user_guide/model_zoo/index.html>`_
@@ -524,6 +523,7 @@ def compute_visualization(
         brain_key,
         num_dims,
         method,
+        similarity_index,
         model,
         model_kwargs,
         force_square,
@@ -581,12 +581,8 @@ def compute_similarity(
         Query the index to select a subset of examples of a specified size that
         are maximally unique with respect to each other
 
-    If no ``embeddings`` or ``model`` is provided, the following default model
-    is used to generate embeddings::
-
-        import fiftyone.zoo as foz
-
-        model = foz.load_zoo_model("mobilenet-v2-imagenet-torch")
+    If no ``embeddings`` or ``model`` is provided, a default model is used to
+    generate embeddings.
 
     Args:
         samples: a :class:`fiftyone.core.collections.SampleCollection`

--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -253,8 +253,8 @@ def compute_uniqueness(
         similarity_backend (None): the similarity backend to use. The supported values are
             ``fiftyone.brain.brain_config.similarity_backends.keys()`` and the
             default is ``fiftyone.brain.brain_config.default_similarity_backend``
-        similarity_index (None): the similarity index to use. This can be computed using
-            fob.compute_similarity
+        similarity_index (None): the similarity index to use. This can be set to
+            ``fiftyone.brain.similarity.SimilarityIndex`` instance or a brain_key string to load the similarity index via samples.load_brain_results
     """
     import fiftyone.brain.internal.core.uniqueness as fbu
 

--- a/fiftyone/brain/internal/core/representativeness.py
+++ b/fiftyone/brain/internal/core/representativeness.py
@@ -42,6 +42,7 @@ def compute_representativeness(
     method,
     roi_field,
     embeddings,
+    similarity_index,
     model,
     model_kwargs,
     force_square,
@@ -80,7 +81,15 @@ def compute_representativeness(
         embeddings_field = None
         embeddings_exist = None
 
-    if model is None and embeddings is None and not embeddings_exist:
+    if etau.is_str(similarity_index):
+        similarity_index = samples.load_brain_results(similarity_index)
+
+    if (
+        model is None
+        and embeddings is None
+        and similarity_index is None
+        and not embeddings_exist
+    ):
         model = fbm.load_model(_DEFAULT_MODEL)
         if batch_size is None:
             batch_size = _DEFAULT_BATCH_SIZE
@@ -90,6 +99,7 @@ def compute_representativeness(
         method=method,
         roi_field=roi_field,
         embeddings_field=embeddings_field,
+        similarity_index=similarity_index,
         model=model,
         model_kwargs=model_kwargs,
     )
@@ -111,6 +121,7 @@ def compute_representativeness(
         patches_field=roi_field,
         embeddings_field=embeddings_field,
         embeddings=embeddings,
+        similarity_index=similarity_index,
         force_square=force_square,
         alpha=alpha,
         handle_missing="image",
@@ -253,10 +264,14 @@ class RepresentativenessConfig(fob.BrainMethodConfig):
         method=None,
         roi_field=None,
         embeddings_field=None,
+        similarity_index=None,
         model=None,
         model_kwargs=None,
         **kwargs,
     ):
+        if similarity_index is not None and not etau.is_str(similarity_index):
+            similarity_index = similarity_index.key
+
         if model is not None and not etau.is_str(model):
             model = etau.get_class_name(model)
 
@@ -264,6 +279,7 @@ class RepresentativenessConfig(fob.BrainMethodConfig):
         self._method = method
         self.roi_field = roi_field
         self.embeddings_field = embeddings_field
+        self.similarity_index = similarity_index
         self.model = model
         self.model_kwargs = model_kwargs
         super().__init__(**kwargs)

--- a/fiftyone/brain/internal/core/sklearn.py
+++ b/fiftyone/brain/internal/core/sklearn.py
@@ -93,13 +93,12 @@ class SklearnSimilarity(Similarity):
         config: an :class:`SklearnSimilarityConfig`
     """
 
-    def initialize(self, samples, brain_key, embeddings=None):
+    def initialize(self, samples, brain_key):
         return SklearnSimilarityIndex(
             samples,
             self.config,
             brain_key,
             backend=self,
-            embeddings=embeddings,
         )
 
 

--- a/fiftyone/brain/internal/core/sklearn.py
+++ b/fiftyone/brain/internal/core/sklearn.py
@@ -95,10 +95,7 @@ class SklearnSimilarity(Similarity):
 
     def initialize(self, samples, brain_key):
         return SklearnSimilarityIndex(
-            samples,
-            self.config,
-            brain_key,
-            backend=self,
+            samples, self.config, brain_key, backend=self
         )
 
 
@@ -826,6 +823,7 @@ class NeighborsHelper(object):
         embeddings -= embeddings.mean(axis=0, keepdims=True)
 
         metric = self.metric
+
         if metric == "cosine":
             # Nearest neighbors does not directly support cosine distance, so
             # we approximate via euclidean distance on unit-norm embeddings

--- a/fiftyone/brain/internal/core/sklearn.py
+++ b/fiftyone/brain/internal/core/sklearn.py
@@ -93,9 +93,13 @@ class SklearnSimilarity(Similarity):
         config: an :class:`SklearnSimilarityConfig`
     """
 
-    def initialize(self, samples, brain_key):
+    def initialize(self, samples, brain_key, embeddings=None):
         return SklearnSimilarityIndex(
-            samples, self.config, brain_key, backend=self
+            samples,
+            self.config,
+            brain_key,
+            backend=self,
+            embeddings=embeddings,
         )
 
 
@@ -823,7 +827,6 @@ class NeighborsHelper(object):
         embeddings -= embeddings.mean(axis=0, keepdims=True)
 
         metric = self.metric
-
         if metric == "cosine":
             # Nearest neighbors does not directly support cosine distance, so
             # we approximate via euclidean distance on unit-norm embeddings

--- a/fiftyone/brain/internal/core/uniqueness.py
+++ b/fiftyone/brain/internal/core/uniqueness.py
@@ -166,13 +166,16 @@ def compute_uniqueness(
 
 
 def _compute_uniqueness(sample_ids, similarity_index, n_neighbors=3):
-    num_embeddings = len(sample_ids)
-    if num_embeddings <= n_neighbors:
-        return [1] * num_embeddings
+    num_samples = len(sample_ids)
+    if num_samples <= n_neighbors:
+        return [1] * num_samples
 
-    _, dists_list = similarity_index._kneighbors(
-        query=sample_ids, k=n_neighbors + 1, return_dists=True
-    )
+    dists_list = []
+    for sample_id in sample_ids:
+        _, dist = similarity_index._kneighbors(
+            query=sample_id, k=n_neighbors + 1, return_dists=True
+        )
+        dists_list.append(dist)
     dists = np.array(dists_list)
 
     # @todo experiment on which method for assessing uniqueness is best

--- a/fiftyone/brain/internal/core/uniqueness.py
+++ b/fiftyone/brain/internal/core/uniqueness.py
@@ -95,6 +95,19 @@ def compute_uniqueness(
         if batch_size is None:
             batch_size = _DEFAULT_BATCH_SIZE
 
+    config = UniquenessConfig(
+        uniqueness_field,
+        roi_field=roi_field,
+        embeddings_field=embeddings_field,
+        similarity_index=similarity_index,
+        model=model,
+        model_kwargs=model_kwargs,
+    )
+    brain_key = uniqueness_field
+    brain_method = config.build()
+    brain_method.ensure_requirements()
+    brain_method.register_run(samples, brain_key, cleanup=False)
+
     if roi_field is not None:
         # @todo experiment with mean(), max(), abs().max(), etc
         agg_fcn = lambda e: np.mean(e, axis=0)
@@ -124,19 +137,6 @@ def compute_uniqueness(
             samples, backend="sklearn", embeddings=False
         )
         similarity_index.add_to_index(embeddings, sample_ids)
-
-    config = UniquenessConfig(
-        uniqueness_field,
-        roi_field=roi_field,
-        embeddings_field=embeddings_field,
-        similarity_index=similarity_index,
-        model=model,
-        model_kwargs=model_kwargs,
-    )
-    brain_key = uniqueness_field
-    brain_method = config.build()
-    brain_method.ensure_requirements()
-    brain_method.register_run(samples, brain_key, cleanup=False)
 
     logger.info("Computing uniqueness...")
     uniqueness = _compute_uniqueness(

--- a/fiftyone/brain/internal/core/uniqueness.py
+++ b/fiftyone/brain/internal/core/uniqueness.py
@@ -6,7 +6,6 @@ Uniqueness methods.
 |
 """
 from copy import deepcopy
-from tqdm import tqdm
 
 import logging
 
@@ -175,7 +174,7 @@ def _compute_uniqueness(sample_ids, similarity_index, n_neighbors=3):
     dists_list = []
     if similarity_index.config.method != "sklearn":
         logger.info("This computation may take a while.")
-    for sample_id in tqdm(sample_ids):
+    for sample_id in sample_ids:
         _, dist = similarity_index._kneighbors(
             query=sample_id, k=n_neighbors + 1, return_dists=True
         )

--- a/fiftyone/brain/internal/core/uniqueness.py
+++ b/fiftyone/brain/internal/core/uniqueness.py
@@ -5,8 +5,6 @@ Uniqueness methods.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-from copy import deepcopy
-
 import logging
 
 import numpy as np
@@ -17,7 +15,7 @@ import fiftyone.brain as fb
 import fiftyone.core.brain as fob
 import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
-import fiftyone.core.media as fom
+import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
 
 import fiftyone.brain.internal.core.utils as fbu
@@ -42,6 +40,7 @@ def compute_uniqueness(
     uniqueness_field,
     roi_field,
     embeddings,
+    similarity_index,
     model,
     model_kwargs,
     force_square,
@@ -50,8 +49,6 @@ def compute_uniqueness(
     num_workers,
     skip_failures,
     progress,
-    similarity_backend=None,
-    similarity_index=None,
 ):
     """See ``fiftyone/brain/__init__.py``."""
 
@@ -66,83 +63,73 @@ def compute_uniqueness(
     # than, say, "representativeness" which would stress samples that are core
     # to dense clusters of related samples.
     #
-    if not (similarity_index and similarity_backend):
-        similarity_backend = fb.brain_config.default_similarity_backend
 
     fov.validate_image_collection(samples)
 
-    if isinstance(similarity_index, fb.SimilarityIndex):
-        logger.info("Using input similarity_index instance")
-        similarity_index_obj = similarity_index
-    elif isinstance(similarity_index, str):
-        try:
-            similarity_index_obj = samples.load_brain_results(similarity_index)
-        except:
-            similarity_index_obj = None
-    else:
-        similarity_index_obj = None
-
-    sample_ids = samples.values("id")
-    embeddings_field = None
-    if isinstance(similarity_backend, str) and not similarity_index_obj:
-        logger.info(
-            f"Initializing similarity index with {similarity_backend} backend and {similarity_index} brain_key."
-        )
-        similarity_index_obj = fb.compute_similarity(
-            samples,
-            backend=similarity_backend,
-            brain_key=similarity_index,
-            embeddings=False,
+    if roi_field is not None:
+        fov.validate_collection_label_fields(
+            samples, roi_field, _ALLOWED_ROI_FIELD_TYPES
         )
 
-        if roi_field is not None:
-            fov.validate_collection_label_fields(
-                samples, roi_field, _ALLOWED_ROI_FIELD_TYPES
-            )
-
-        if etau.is_str(embeddings):
-            embeddings_field, embeddings_exist = fbu.parse_embeddings_field(
-                samples,
-                embeddings,
-                patches_field=roi_field,
-            )
-            embeddings = None
-        else:
-            embeddings_exist = None
-
-        if model is None and embeddings is None and not embeddings_exist:
-            model = fbm.load_model(_DEFAULT_MODEL)
-            if batch_size is None:
-                batch_size = _DEFAULT_BATCH_SIZE
-
-        if roi_field is not None:
-            # @todo experiment with mean(), max(), abs().max(), etc
-            agg_fcn = lambda e: np.mean(e, axis=0)
-        else:
-            agg_fcn = None
-
-        embeddings, sample_ids, _ = fbu.get_embeddings(
+    if etau.is_str(embeddings):
+        embeddings_field, embeddings_exist = fbu.parse_embeddings_field(
             samples,
-            model=model,
-            model_kwargs=model_kwargs,
+            embeddings,
             patches_field=roi_field,
-            embeddings_field=embeddings_field,
-            embeddings=embeddings,
-            force_square=force_square,
-            alpha=alpha,
-            handle_missing="image",
-            agg_fcn=agg_fcn,
-            batch_size=batch_size,
-            num_workers=num_workers,
-            skip_failures=skip_failures,
-            progress=progress,
         )
-        similarity_index_obj.add_to_index(embeddings, sample_ids)
+        embeddings = None
+    else:
+        embeddings_field = None
+        embeddings_exist = None
+
+    if etau.is_str(similarity_index):
+        similarity_index = samples.load_brain_results(similarity_index)
+
+    if (
+        model is None
+        and embeddings is None
+        and similarity_index is None
+        and not embeddings_exist
+    ):
+        model = fbm.load_model(_DEFAULT_MODEL)
+        if batch_size is None:
+            batch_size = _DEFAULT_BATCH_SIZE
+
+    if roi_field is not None:
+        # @todo experiment with mean(), max(), abs().max(), etc
+        agg_fcn = lambda e: np.mean(e, axis=0)
+    else:
+        agg_fcn = None
+
+    embeddings, sample_ids, _ = fbu.get_embeddings(
+        samples,
+        model=model,
+        model_kwargs=model_kwargs,
+        patches_field=roi_field,
+        embeddings_field=embeddings_field,
+        embeddings=embeddings,
+        similarity_index=similarity_index,
+        force_square=force_square,
+        alpha=alpha,
+        handle_missing="image",
+        agg_fcn=agg_fcn,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        skip_failures=skip_failures,
+        progress=progress,
+    )
+
+    if similarity_index is None:
+        similarity_index = fb.compute_similarity(
+            samples, backend="sklearn", embeddings=False
+        )
+        similarity_index.add_to_index(embeddings, sample_ids)
 
     config = UniquenessConfig(
         uniqueness_field,
         roi_field=roi_field,
         embeddings_field=embeddings_field,
+        similarity_index=similarity_index,
         model=model,
         model_kwargs=model_kwargs,
     )
@@ -152,7 +139,9 @@ def compute_uniqueness(
     brain_method.register_run(samples, brain_key, cleanup=False)
 
     logger.info("Computing uniqueness...")
-    uniqueness = _compute_uniqueness(sample_ids, similarity_index_obj)
+    uniqueness = _compute_uniqueness(
+        embeddings, similarity_index, progress=progress
+    )
 
     # Ensure field exists, even if `uniqueness` is empty
     samples._dataset.add_sample_field(uniqueness_field, fof.FloatField)
@@ -166,20 +155,28 @@ def compute_uniqueness(
     logger.info("Uniqueness computation complete")
 
 
-def _compute_uniqueness(sample_ids, similarity_index, n_neighbors=3):
-    num_samples = len(sample_ids)
-    if num_samples <= n_neighbors:
-        return [1] * num_samples
+def _compute_uniqueness(
+    embeddings, similarity_index, batch_size=10, progress=None
+):
+    K = 3
 
-    dists_list = []
-    if similarity_index.config.method != "sklearn":
-        logger.info("This computation may take a while.")
-    for sample_id in sample_ids:
-        _, dist = similarity_index._kneighbors(
-            query=sample_id, k=n_neighbors + 1, return_dists=True
-        )
-        dists_list.append(dist)
-    dists = np.array(dists_list)
+    num_embeddings = len(embeddings)
+    if num_embeddings <= K:
+        return [1] * num_embeddings
+
+    if similarity_index.config.method == "sklearn":
+        _, dists = similarity_index._kneighbors(k=K + 1, return_dists=True)
+    else:
+        dists = []
+        with fou.ProgressBar(total=num_embeddings, progress=progress) as pb:
+            for _embeddings in fou.iter_slices(embeddings, batch_size):
+                _, _dists = similarity_index._kneighbors(
+                    query=_embeddings, k=K + 1, return_dists=True
+                )
+                dists.extend(_dists)
+                pb.update(len(_dists))
+
+    dists = np.array(dists)
 
     # @todo experiment on which method for assessing uniqueness is best
     #
@@ -203,16 +200,21 @@ class UniquenessConfig(fob.BrainMethodConfig):
         uniqueness_field,
         roi_field=None,
         embeddings_field=None,
+        similarity_index=None,
         model=None,
         model_kwargs=None,
         **kwargs,
     ):
+        if similarity_index is not None and not etau.is_str(similarity_index):
+            similarity_index = similarity_index.key
+
         if model is not None and not etau.is_str(model):
             model = etau.get_class_name(model)
 
         self.uniqueness_field = uniqueness_field
         self.roi_field = roi_field
         self.embeddings_field = embeddings_field
+        self.similarity_index = similarity_index
         self.model = model
         self.model_kwargs = model_kwargs
 

--- a/fiftyone/brain/internal/core/uniqueness.py
+++ b/fiftyone/brain/internal/core/uniqueness.py
@@ -6,6 +6,8 @@ Uniqueness methods.
 |
 """
 from copy import deepcopy
+from tqdm import tqdm
+
 import logging
 
 import numpy as np
@@ -171,7 +173,9 @@ def _compute_uniqueness(sample_ids, similarity_index, n_neighbors=3):
         return [1] * num_samples
 
     dists_list = []
-    for sample_id in sample_ids:
+    if similarity_index.config.method != "sklearn":
+        logger.info("This computation may take a while.")
+    for sample_id in tqdm(sample_ids):
         _, dist = similarity_index._kneighbors(
             query=sample_id, k=n_neighbors + 1, return_dists=True
         )

--- a/fiftyone/brain/internal/core/uniqueness.py
+++ b/fiftyone/brain/internal/core/uniqueness.py
@@ -132,8 +132,9 @@ def compute_uniqueness(
     if config.backend:
         similarity_method = config.backend.build()
         similarity_index = similarity_method.initialize(
-            samples=samples, brain_key="", embeddings=embeddings
+            samples=samples, brain_key=""
         )
+        similarity_index.add_to_index(embeddings, sample_ids)
 
     logger.info("Computing uniqueness...")
     uniqueness = _compute_uniqueness(embeddings, similarity_index)

--- a/fiftyone/brain/internal/core/uniqueness.py
+++ b/fiftyone/brain/internal/core/uniqueness.py
@@ -128,10 +128,12 @@ def compute_uniqueness(
         progress=progress,
     )
 
-    similarity_method = config.backend.build()
-    similarity_index = similarity_method.initialize(
-        samples=samples, brain_key="", embeddings=embeddings
-    )
+    similarity_index = None
+    if config.backend:
+        similarity_method = config.backend.build()
+        similarity_index = similarity_method.initialize(
+            samples=samples, brain_key="", embeddings=embeddings
+        )
 
     logger.info("Computing uniqueness...")
     uniqueness = _compute_uniqueness(embeddings, similarity_index)

--- a/fiftyone/brain/internal/core/uniqueness.py
+++ b/fiftyone/brain/internal/core/uniqueness.py
@@ -165,6 +165,10 @@ def compute_uniqueness(
 def _compute_uniqueness(
     embeddings, similarity_index, metric="euclidean", n_neighbors=3
 ):
+    num_embeddings = len(embeddings)
+    if num_embeddings <= n_neighbors:
+        return [1] * num_embeddings
+
     _, dists_list = similarity_index._kneighbors(
         query=embeddings, k=n_neighbors + 1, return_dists=True
     )

--- a/fiftyone/brain/internal/core/uniqueness.py
+++ b/fiftyone/brain/internal/core/uniqueness.py
@@ -9,8 +9,6 @@ from copy import deepcopy
 import logging
 
 import numpy as np
-import sklearn.metrics as skm
-import sklearn.neighbors as skn
 
 import eta.core.utils as etau
 
@@ -67,62 +65,61 @@ def compute_uniqueness(
     # than, say, "representativeness" which would stress samples that are core
     # to dense clusters of related samples.
     #
-    if similarity_backend and similarity_index:
-        raise IOError(
-            "At least one of (similarity_backend, similarity_index) values need to be None."
-        )
-
-    if not (similarity_index or similarity_backend):
+    if not (similarity_index and similarity_backend):
         similarity_backend = fb.brain_config.default_similarity_backend
 
     fov.validate_image_collection(samples)
 
-    if roi_field is not None:
-        fov.validate_collection_label_fields(
-            samples, roi_field, _ALLOWED_ROI_FIELD_TYPES
-        )
+    if isinstance(similarity_index, fb.SimilarityIndex):
+        logger.info("Using input similarity_index instance")
+        similarity_index_obj = similarity_index
+    elif isinstance(similarity_index, str):
+        try:
+            similarity_index_obj = samples.load_brain_results(similarity_index)
+        except:
+            similarity_index_obj = None
+    else:
+        similarity_index_obj = None
 
-    if etau.is_str(embeddings):
-        embeddings_field, embeddings_exist = fbu.parse_embeddings_field(
+    sample_ids = samples.values("id")
+    embeddings_field = None
+    if isinstance(similarity_backend, str) and not similarity_index_obj:
+        logger.info(
+            f"Initializing similarity index with {similarity_backend} backend and {similarity_index} brain_key."
+        )
+        similarity_index_obj = fb.compute_similarity(
             samples,
-            embeddings,
-            patches_field=roi_field,
+            backend=similarity_backend,
+            brain_key=similarity_index,
+            embeddings=False,
         )
-        embeddings = None
-    else:
-        embeddings_field = None
-        embeddings_exist = None
 
-    if model is None and embeddings is None and not embeddings_exist:
-        model = fbm.load_model(_DEFAULT_MODEL)
-        if batch_size is None:
-            batch_size = _DEFAULT_BATCH_SIZE
+        if roi_field is not None:
+            fov.validate_collection_label_fields(
+                samples, roi_field, _ALLOWED_ROI_FIELD_TYPES
+            )
 
-    config = UniquenessConfig(
-        uniqueness_field,
-        similarity_backend=similarity_backend,
-        roi_field=roi_field,
-        embeddings_field=embeddings_field,
-        model=model,
-        model_kwargs=model_kwargs,
-    )
-    brain_key = uniqueness_field
-    brain_method = config.build()
-    brain_method.ensure_requirements()
-    brain_method.register_run(samples, brain_key, cleanup=False)
+        if etau.is_str(embeddings):
+            embeddings_field, embeddings_exist = fbu.parse_embeddings_field(
+                samples,
+                embeddings,
+                patches_field=roi_field,
+            )
+            embeddings = None
+        else:
+            embeddings_exist = None
 
-    if roi_field is not None:
-        # @todo experiment with mean(), max(), abs().max(), etc
-        agg_fcn = lambda e: np.mean(e, axis=0)
-    else:
-        agg_fcn = None
+        if model is None and embeddings is None and not embeddings_exist:
+            model = fbm.load_model(_DEFAULT_MODEL)
+            if batch_size is None:
+                batch_size = _DEFAULT_BATCH_SIZE
 
-    if similarity_index:
-        sample_ids = similarity_index.sample_ids
-        embeddings = np.array(
-            similarity_index.get_embeddings(sample_ids=sample_ids)[0]
-        )
-    elif config.similarity_method:
+        if roi_field is not None:
+            # @todo experiment with mean(), max(), abs().max(), etc
+            agg_fcn = lambda e: np.mean(e, axis=0)
+        else:
+            agg_fcn = None
+
         embeddings, sample_ids, _ = fbu.get_embeddings(
             samples,
             model=model,
@@ -139,16 +136,22 @@ def compute_uniqueness(
             skip_failures=skip_failures,
             progress=progress,
         )
-        brain_method = config.similarity_method.build()
-        similarity_index = brain_method.initialize(
-            samples=samples, brain_key=f"{similarity_backend}_index"
-        )
-        similarity_index.add_to_index(embeddings, sample_ids)
-    else:
-        raise AssertionError("Similarity index not available.")
+        similarity_index_obj.add_to_index(embeddings, sample_ids)
+
+    config = UniquenessConfig(
+        uniqueness_field,
+        roi_field=roi_field,
+        embeddings_field=embeddings_field,
+        model=model,
+        model_kwargs=model_kwargs,
+    )
+    brain_key = uniqueness_field
+    brain_method = config.build()
+    brain_method.ensure_requirements()
+    brain_method.register_run(samples, brain_key, cleanup=False)
 
     logger.info("Computing uniqueness...")
-    uniqueness = _compute_uniqueness(embeddings, similarity_index)
+    uniqueness = _compute_uniqueness(sample_ids, similarity_index_obj)
 
     # Ensure field exists, even if `uniqueness` is empty
     samples._dataset.add_sample_field(uniqueness_field, fof.FloatField)
@@ -162,15 +165,13 @@ def compute_uniqueness(
     logger.info("Uniqueness computation complete")
 
 
-def _compute_uniqueness(
-    embeddings, similarity_index, metric="euclidean", n_neighbors=3
-):
-    num_embeddings = len(embeddings)
+def _compute_uniqueness(sample_ids, similarity_index, n_neighbors=3):
+    num_embeddings = len(sample_ids)
     if num_embeddings <= n_neighbors:
         return [1] * num_embeddings
 
     _, dists_list = similarity_index._kneighbors(
-        query=embeddings, k=n_neighbors + 1, return_dists=True
+        query=sample_ids, k=n_neighbors + 1, return_dists=True
     )
     dists = np.array(dists_list)
 
@@ -198,7 +199,6 @@ class UniquenessConfig(fob.BrainMethodConfig):
         embeddings_field=None,
         model=None,
         model_kwargs=None,
-        similarity_backend=None,
         **kwargs,
     ):
         if model is not None and not etau.is_str(model):
@@ -209,27 +209,6 @@ class UniquenessConfig(fob.BrainMethodConfig):
         self.embeddings_field = embeddings_field
         self.model = model
         self.model_kwargs = model_kwargs
-
-        # Similarity backend.
-        self.similarity_method = None
-        if similarity_backend:
-            backends = fb.brain_config.similarity_backends
-            if similarity_backend not in backends:
-                raise ValueError(
-                    f"Unsupported backend {similarity_backend}. The available backends are {sorted(backends.keys())}"
-                )
-            backend_params = deepcopy(backends[similarity_backend])
-            config_cls = kwargs.pop("config_cls", None)
-            if config_cls is None:
-                config_cls = backend_params.pop("config_cls", None)
-            if config_cls is None:
-                raise ValueError(
-                    f"Similarity backend {similarity_backend} has no `config_cls`"
-                )
-            if etau.is_str(config_cls):
-                config_cls = etau.get_class(config_cls)
-            backend_params.update(**kwargs)
-            self.similarity_method = config_cls(**backend_params)
 
         super().__init__(**kwargs)
 

--- a/fiftyone/brain/internal/core/utils.py
+++ b/fiftyone/brain/internal/core/utils.py
@@ -169,6 +169,7 @@ def get_embeddings_from_index(
         sample_ids = None
         label_ids = samples.values(label_id_path, unwind=True)
 
+    logger.info("Retrieving embeddings from similarity index...")
     return similarity_index.get_embeddings(
         sample_ids=sample_ids,
         label_ids=label_ids,
@@ -720,6 +721,7 @@ def get_embeddings(
     patches_field=None,
     embeddings_field=None,
     embeddings=None,
+    similarity_index=None,
     force_square=False,
     alpha=None,
     handle_missing="skip",
@@ -731,16 +733,20 @@ def get_embeddings(
 ):
     _validate_args(samples, patches_field=patches_field)
 
-    if model is None and embeddings_field is None and embeddings is None:
+    if (
+        model is None
+        and embeddings_field is None
+        and embeddings is None
+        and similarity_index is None
+    ):
         return _empty_embeddings(patches_field)
 
-    if isinstance(embeddings, fob.SimilarityIndex):
-        allow_missing = handle_missing == "skip"
+    if similarity_index is not None:
         return get_embeddings_from_index(
             samples,
-            embeddings,
+            similarity_index,
             patches_field=patches_field,
-            allow_missing=allow_missing,
+            allow_missing=True,
             warn_missing=True,
         )
 

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -41,6 +41,7 @@ def compute_visualization(
     brain_key,
     num_dims,
     method,
+    similarity_index,
     model,
     model_kwargs,
     force_square,
@@ -78,10 +79,14 @@ def compute_visualization(
         embeddings_field = None
         embeddings_exist = None
 
+    if etau.is_str(similarity_index):
+        similarity_index = samples.load_brain_results(similarity_index)
+
     if (
         model is None
         and points is None
         and embeddings is None
+        and similarity_index is None
         and not embeddings_exist
     ):
         model = _DEFAULT_MODEL
@@ -91,6 +96,7 @@ def compute_visualization(
     config = _parse_config(
         method,
         embeddings_field=embeddings_field,
+        similarity_index=similarity_index,
         model=model,
         model_kwargs=model_kwargs,
         patches_field=patches_field,
@@ -112,6 +118,7 @@ def compute_visualization(
             patches_field=patches_field,
             embeddings_field=embeddings_field,
             embeddings=embeddings,
+            similarity_index=similarity_index,
             force_square=force_square,
             alpha=alpha,
             batch_size=batch_size,
@@ -586,6 +593,8 @@ class VisualizationConfig(fob.BrainMethodConfig):
     Args:
         embeddings_field (None): the sample field containing the embeddings,
             if one was provided
+        similarity_index (None): the similarity index containing the
+            embeddings, if one was provided
         model (None): the :class:`fiftyone.core.models.Model` or name of the
             zoo model that was used to compute embeddings, if known
         model_kwargs (None): a dictionary of optional keyword arguments to pass
@@ -598,16 +607,21 @@ class VisualizationConfig(fob.BrainMethodConfig):
     def __init__(
         self,
         embeddings_field=None,
+        similarity_index=None,
         model=None,
         model_kwargs=None,
         patches_field=None,
         num_dims=2,
         **kwargs,
     ):
+        if similarity_index is not None and not etau.is_str(similarity_index):
+            similarity_index = similarity_index.key
+
         if model is not None and not etau.is_str(model):
             model = None
 
         self.embeddings_field = embeddings_field
+        self.similarity_index = similarity_index
         self.model = model
         self.model_kwargs = model_kwargs
         self.patches_field = patches_field
@@ -641,6 +655,8 @@ class UMAPVisualizationConfig(VisualizationConfig):
     Args:
         embeddings_field (None): the sample field containing the embeddings,
             if one was provided
+        similarity_index (None): the similarity index containing the
+            embeddings, if one was provided
         model (None): the :class:`fiftyone.core.models.Model` or name of the
             zoo model that was used to compute embeddings, if known
         model_kwargs (None): a dictionary of optional keyword arguments to pass
@@ -667,6 +683,7 @@ class UMAPVisualizationConfig(VisualizationConfig):
     def __init__(
         self,
         embeddings_field=None,
+        similarity_index=None,
         model=None,
         model_kwargs=None,
         patches_field=None,
@@ -680,6 +697,7 @@ class UMAPVisualizationConfig(VisualizationConfig):
     ):
         super().__init__(
             embeddings_field=embeddings_field,
+            similarity_index=similarity_index,
             model=model,
             model_kwargs=model_kwargs,
             patches_field=patches_field,
@@ -731,6 +749,8 @@ class TSNEVisualizationConfig(VisualizationConfig):
     Args:
         embeddings_field (None): the sample field containing the embeddings,
             if one was provided
+        similarity_index (None): the similarity index containing the
+            embeddings, if one was provided
         model (None): the :class:`fiftyone.core.models.Model` or name of the
             zoo model that was used to compute embeddings, if known
         model_kwargs (None): a dictionary of optional keyword arguments to pass
@@ -768,6 +788,7 @@ class TSNEVisualizationConfig(VisualizationConfig):
     def __init__(
         self,
         embeddings_field=None,
+        similarity_index=None,
         model=None,
         model_kwargs=None,
         patches_field=None,
@@ -784,6 +805,7 @@ class TSNEVisualizationConfig(VisualizationConfig):
     ):
         super().__init__(
             embeddings_field=embeddings_field,
+            similarity_index=similarity_index,
             model=model,
             model_kwargs=model_kwargs,
             patches_field=patches_field,
@@ -841,6 +863,8 @@ class PCAVisualizationConfig(VisualizationConfig):
     Args:
         embeddings_field (None): the sample field containing the embeddings,
             if one was provided
+        similarity_index (None): the similarity index containing the
+            embeddings, if one was provided
         model (None): the :class:`fiftyone.core.models.Model` or name of the
             zoo model that was used to compute embeddings, if known
         model_kwargs (None): a dictionary of optional keyword arguments to pass
@@ -856,6 +880,7 @@ class PCAVisualizationConfig(VisualizationConfig):
     def __init__(
         self,
         embeddings_field=None,
+        similarity_index=None,
         model=None,
         model_kwargs=None,
         patches_field=None,
@@ -866,6 +891,7 @@ class PCAVisualizationConfig(VisualizationConfig):
     ):
         super().__init__(
             embeddings_field=embeddings_field,
+            similarity_index=similarity_index,
             model=model,
             model_kwargs=model_kwargs,
             patches_field=patches_field,

--- a/tests/intensive/test_uniqueness.py
+++ b/tests/intensive/test_uniqueness.py
@@ -105,6 +105,13 @@ def test_uniqueness_similarity_index():
     fob.compute_uniqueness(dataset, similarity_index=index)
     assert dataset.has_field("uniqueness")
 
+    del index
+    dataset.clear_cache()
+    dataset.delete_sample_field("uniqueness")
+
+    fob.compute_uniqueness(dataset, similarity_index="sklearn_index")
+    assert dataset.has_field("uniqueness")
+
     # Computing similarity index based on backend.
     dataset.delete_sample_field("uniqueness")
     assert not dataset.has_field("uniqueness")
@@ -112,16 +119,12 @@ def test_uniqueness_similarity_index():
     fob.compute_uniqueness(dataset, similarity_backend="sklearn")
     assert dataset.has_field("uniqueness")
 
-    # Error when similarity_index and similarity_backend are both set.
-    try:
-        fob.compute_uniqueness(
-            dataset, similarity_index=index, similarity_backend="sklearn"
-        )
-    except IOError as e:
-        assert (
-            str(e)
-            == "At least one of (similarity_backend, similarity_index) values need to be None."
-        )
+    fob.compute_uniqueness(
+        dataset,
+        similarity_backend="sklearn",
+        similarity_index="my_sklearn_index",
+    )
+    assert dataset.has_field("uniqueness")
 
 
 def _run_uniqueness(roi_field=None, model=None, batch_size=None):

--- a/tests/intensive/test_uniqueness.py
+++ b/tests/intensive/test_uniqueness.py
@@ -90,41 +90,37 @@ def test_uniqueness_similarity_index():
     )
     dataset.delete_sample_field("uniqueness")
 
-    # Using pre-computed similarity index.
-    sklearn_index = fob.compute_similarity(
+    # Full similarity index
+
+    similarity_index = fob.compute_similarity(
         dataset, brain_key="sklearn_index", backend="sklearn"
     )
-    fob.compute_uniqueness(dataset, similarity_index=sklearn_index)
+
+    fob.compute_uniqueness(dataset, similarity_index=similarity_index)
+
     assert dataset.has_field("uniqueness")
 
-    del sklearn_index
-    dataset.clear_cache()
-    dataset.delete_sample_field("uniqueness")
-
-    index = dataset.load_brain_results("sklearn_index")
-    fob.compute_uniqueness(dataset, similarity_index=index)
-    assert dataset.has_field("uniqueness")
-
-    del index
     dataset.clear_cache()
     dataset.delete_sample_field("uniqueness")
 
     fob.compute_uniqueness(dataset, similarity_index="sklearn_index")
+
     assert dataset.has_field("uniqueness")
 
-    # Computing similarity index based on backend.
-    dataset.delete_sample_field("uniqueness")
-    assert not dataset.has_field("uniqueness")
+    # Partial similarity index
 
-    fob.compute_uniqueness(dataset, similarity_backend="sklearn")
-    assert dataset.has_field("uniqueness")
+    view = dataset.take(100, seed=51)
+    similarity_index2 = fob.compute_similarity(
+        view, brain_key="sklearn_index2", backend="sklearn"
+    )
 
     fob.compute_uniqueness(
         dataset,
-        similarity_backend="sklearn",
-        similarity_index="my_sklearn_index",
+        uniqueness_field="uniqueness2",
+        similarity_index="sklearn_index2",
     )
-    assert dataset.has_field("uniqueness")
+
+    assert len(dataset.exists("uniqueness2")) == len(view)
 
 
 def _run_uniqueness(roi_field=None, model=None, batch_size=None):

--- a/tests/intensive/test_visualization.py
+++ b/tests/intensive/test_visualization.py
@@ -242,6 +242,41 @@ def test_points():
     dataset.delete()
 
 
+def test_similarity_index():
+    dataset = foz.load_zoo_dataset(
+        "quickstart", dataset_name=fo.get_default_dataset_name()
+    )
+
+    # Full similarity index
+
+    similarity_index = fob.compute_similarity(
+        dataset, brain_key="sklearn_index", backend="sklearn"
+    )
+
+    results = fob.compute_visualization(
+        dataset,
+        brain_key="img_viz",
+        similarity_index=similarity_index,
+    )
+
+    assert len(results.points) == len(dataset)
+
+    # Partial similarity index
+
+    view = dataset.take(100, seed=51)
+    similarity_index2 = fob.compute_similarity(
+        view, brain_key="sklearn_index2", backend="sklearn"
+    )
+
+    results2 = fob.compute_visualization(
+        dataset,
+        brain_key="img_viz2",
+        similarity_index="sklearn_index2",
+    )
+
+    assert len(results2.points) == len(view)
+
+
 def _load_images_dataset():
     name = "test-visualization-images"
 


### PR DESCRIPTION
This PR enables uniqueness computation to use `kneighbors` method from various `SimilarityIndex` classes to compute k-nearest  neighbors.