### PR TITLE
Optimize k-neighbors similarity queries

### DIFF
--- a/fiftyone/brain/internal/core/elasticsearch.py
+++ b/fiftyone/brain/internal/core/elasticsearch.py
@@ -710,7 +710,8 @@ class ElasticsearchSimilarityIndex(SimilarityIndex):
         else:
             _filter = None
 
-        ids = []
+        sample_ids = []
+        label_ids = [] if self.config.patches_field is not None else None
         dists = []
         for q in query:
             if self._get_metric() == _SUPPORTED_METRICS["dotproduct"]:
@@ -730,19 +731,29 @@ class ElasticsearchSimilarityIndex(SimilarityIndex):
                 knn=knn,
                 size=k,
             )
-            ids.append([r["_id"] for r in response["hits"]["hits"]])
+
+            if self.config.patches_field is not None:
+                sample_ids.append(
+                    [r["sample_id"] for r in response["hits"]["hits"]]
+                )
+                label_ids.append([r["_id"] for r in response["hits"]["hits"]])
+            else:
+                sample_ids.append([r["_id"] for r in response["hits"]["hits"]])
+
             if return_dists:
                 dists.append([r["_score"] for r in response["hits"]["hits"]])
 
         if single_query:
-            ids = ids[0]
+            sample_ids = sample_ids[0]
+            if label_ids is not None:
+                label_ids = label_ids[0]
             if return_dists:
                 dists = dists[0]
 
         if return_dists:
-            return ids, dists
+            return sample_ids, label_ids, dists
 
-        return ids
+        return sample_ids, label_ids
 
     def _parse_neighbors_query(self, query):
         if etau.is_str(query):

--- a/fiftyone/brain/internal/core/elasticsearch.py
+++ b/fiftyone/brain/internal/core/elasticsearch.py
@@ -726,15 +726,20 @@ class ElasticsearchSimilarityIndex(SimilarityIndex):
             if _filter:
                 knn["filter"] = _filter
 
+            source = self.config.patches_field is not None
             response = self._client.search(
                 index=self.config.index_name,
                 knn=knn,
                 size=k,
+                source=source,
             )
 
             if self.config.patches_field is not None:
                 sample_ids.append(
-                    [r["sample_id"] for r in response["hits"]["hits"]]
+                    [
+                        r["_source"]["sample_id"]
+                        for r in response["hits"]["hits"]
+                    ]
                 )
                 label_ids.append([r["_id"] for r in response["hits"]["hits"]])
             else:

--- a/fiftyone/brain/internal/core/lancedb.py
+++ b/fiftyone/brain/internal/core/lancedb.py
@@ -441,23 +441,32 @@ class LanceDBSimilarityIndex(SimilarityIndex):
 
         metric = _SUPPORTED_METRICS[self.config.metric]
 
-        ids = []
+        sample_ids = []
+        label_ids = [] if self.config.patches_field is not None else None
         dists = []
         for q in query:
             results = table.search(q).metric(metric).limit(k).to_df()
-            ids.append(results.id.tolist())
+
+            if self.config.patches_field is not None:
+                sample_ids.append(results.sample_id.tolist())
+                label_ids.append(results.id.tolist())
+            else:
+                sample_ids.append(results.id.tolist())
+
             if return_dists:
                 dists.append(results._distance.tolist())
 
         if single_query:
-            ids = ids[0]
+            sample_ids = sample_ids[0]
+            if label_ids is not None:
+                label_ids = label_ids[0]
             if return_dists:
                 dists = dists[0]
 
         if return_dists:
-            return ids, dists
+            return sample_ids, label_ids, dists
 
-        return ids
+        return sample_ids, label_ids
 
     def _parse_neighbors_query(self, query):
         if etau.is_str(query):

--- a/fiftyone/brain/internal/core/milvus.py
+++ b/fiftyone/brain/internal/core/milvus.py
@@ -701,16 +701,24 @@ class MilvusSimilarityIndex(SimilarityIndex):
         label_ids = [] if self.config.patches_field is not None else None
         dists = []
         for q in query:
+            if self.config.patches_field is not None:
+                output_fields = ["sample_id"]
+            else:
+                output_fields = None
+
             response = self._collection.search(
                 data=[q.tolist()],
                 anns_field="vector",
                 limit=k,
                 expr=expr,
                 param=self.config.search_params,
+                output_fields=output_fields,
             )
 
             if self.config.patches_field is not None:
-                sample_ids.append([r.sample_id for r in response[0]])
+                sample_ids.append(
+                    [r.entity.get("sample_id") for r in response[0]]
+                )
                 label_ids.append([r.id for r in response[0]])
             else:
                 sample_ids.append([r.id for r in response[0]])

--- a/fiftyone/brain/internal/core/milvus.py
+++ b/fiftyone/brain/internal/core/milvus.py
@@ -697,7 +697,8 @@ class MilvusSimilarityIndex(SimilarityIndex):
         else:
             expr = None
 
-        ids = []
+        sample_ids = []
+        label_ids = [] if self.config.patches_field is not None else None
         dists = []
         for q in query:
             response = self._collection.search(
@@ -707,19 +708,27 @@ class MilvusSimilarityIndex(SimilarityIndex):
                 expr=expr,
                 param=self.config.search_params,
             )
-            ids.append([r.id for r in response[0]])
+
+            if self.config.patches_field is not None:
+                sample_ids.append([r.sample_id for r in response[0]])
+                label_ids.append([r.id for r in response[0]])
+            else:
+                sample_ids.append([r.id for r in response[0]])
+
             if return_dists:
                 dists.append([r.score for r in response[0]])
 
         if single_query:
-            ids = ids[0]
+            sample_ids = sample_ids[0]
+            if label_ids is not None:
+                label_ids = label_ids[0]
             if return_dists:
                 dists = dists[0]
 
         if return_dists:
-            return ids, dists
+            return sample_ids, label_ids, dists
 
-        return ids
+        return sample_ids, label_ids
 
     def _parse_neighbors_query(self, query):
         if etau.is_str(query):

--- a/fiftyone/brain/internal/core/mongodb.py
+++ b/fiftyone/brain/internal/core/mongodb.py
@@ -435,12 +435,12 @@ class MongoDBSimilarityIndex(SimilarityIndex):
 
         return embeddings, sample_ids, label_ids
 
-    def reload(self):
+    def reload(self, lazy=False):
         sample_ids, label_ids = self._parse_data(self._dataset, self.config)
         self._sample_ids = sample_ids
         self._label_ids = label_ids
 
-        super().reload()
+        super().reload(lazy=lazy)
 
     def cleanup(self):
         if self._index is None:

--- a/fiftyone/brain/internal/core/mongodb.py
+++ b/fiftyone/brain/internal/core/mongodb.py
@@ -549,6 +549,7 @@ class MongoDBSimilarityIndex(SimilarityIndex):
             # if self.config.patches_field is not None:
             #     sample_ids.append([str(m["_sample_id"]) for m in matches])
             #     label_ids.append([str(m["_id"]) for m in matches])
+
             if return_dists:
                 dists.append([m["score"] for m in matches])
 

--- a/fiftyone/brain/internal/core/mongodb.py
+++ b/fiftyone/brain/internal/core/mongodb.py
@@ -491,9 +491,17 @@ class MongoDBSimilarityIndex(SimilarityIndex):
             query = [query]
 
         if self.has_view:
-            index_ids = self.current_sample_ids
+            # https://www.mongodb.com/community/forums/t/258494
+            logger.warning(
+                "The MongoDB backend does not yet support views; the full "
+                "index will instead be queried, which may result in fewer "
+                "matches in your current view"
+            )
+            index_ids = None
             # if self.config.patches_field is not None:
             #     index_ids = self.current_label_ids
+            # else:
+            #     index_ids = self.current_sample_ids
         else:
             index_ids = None
 

--- a/fiftyone/brain/internal/core/mongodb.py
+++ b/fiftyone/brain/internal/core/mongodb.py
@@ -128,15 +128,11 @@ class MongoDBSimilarityIndex(SimilarityIndex):
     """
 
     def __init__(self, samples, config, brain_key, backend=None):
-        dataset = samples._dataset
-        sample_ids, label_ids = self._parse_data(dataset, config)
-
-        self._dataset = dataset
-        self._sample_ids = sample_ids
-        self._label_ids = label_ids
-
         super().__init__(samples, config, brain_key, backend=backend)
 
+        self._dataset = samples._dataset
+        self._sample_ids = None
+        self._label_ids = None
         self._index = None
         self._initialize()
 
@@ -145,16 +141,31 @@ class MongoDBSimilarityIndex(SimilarityIndex):
         return False
 
     @property
-    def sample_ids(self):
-        return self._sample_ids
-
-    @property
-    def label_ids(self):
-        return self._label_ids
-
-    @property
     def total_index_size(self):
-        return len(self._sample_ids)
+        if self._sample_ids is not None:
+            return len(self._sample_ids)
+
+        if self._dataset.media_type == fom.GROUP:
+            samples = self._dataset.select_group_slices(_allow_mixed=True)
+        else:
+            samples = self._dataset
+
+        patches_field = self.config.patches_field
+        embeddings_field = self.config.embeddings_field
+
+        if patches_field is not None:
+            _, embeddings_path = self._dataset._get_label_field_path(
+                patches_field, embeddings_field
+            )
+            samples = samples.filter_labels(
+                patches_field, F(embeddings_field).exists()
+            )
+            return samples.count(embeddings_path)
+
+        if samples.has_field(embeddings_field):
+            return samples.exists(embeddings_field).count()
+
+        return 0
 
     def _initialize(self):
         coll = self._dataset._sample_collection
@@ -208,19 +219,31 @@ class MongoDBSimilarityIndex(SimilarityIndex):
             pass
 
     def _get_dimension(self):
-        if self.total_index_size == 0:
+        if self._dataset.media_type == fom.GROUP:
+            samples = self._dataset.select_group_slices(_allow_mixed=True)
+        else:
+            samples = self._dataset
+
+        patches_field = self.config.patches_field
+        embeddings_field = self.config.embeddings_field
+
+        if patches_field is not None:
+            _, embeddings_path = self._dataset._get_label_field_path(
+                patches_field, embeddings_field
+            )
+            view = samples.filter_labels(
+                patches_field, F(embeddings_field).exists()
+            ).limit(1)
+            embeddings = view.values(embeddings_path, unwind=True)
+        else:
+            view = samples.exists(embeddings_field).limit(1)
+            embeddings = view.values(embeddings_field)
+
+        embedding = next(iter(embeddings), None)
+        if embedding is None:
             return None
 
-        if self.config.patches_field is not None:
-            embeddings, _, _ = self.get_embeddings(
-                label_ids=self._label_ids[:1]
-            )
-        else:
-            embeddings, _, _ = self.get_embeddings(
-                sample_ids=self._sample_ids[:1]
-            )
-
-        return embeddings.shape[1]
+        return len(embedding)  # MongoDB requires list fields
 
     def _create_index(self, dimension):
         # https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-stage
@@ -245,6 +268,7 @@ class MongoDBSimilarityIndex(SimilarityIndex):
             }
         ]
 
+        """
         if self._dataset.media_type == fom.GROUP:
             fields.append(
                 {
@@ -252,6 +276,7 @@ class MongoDBSimilarityIndex(SimilarityIndex):
                     "path": self._dataset.group_field + ".name",
                 }
             )
+        """
 
         model = SearchIndexModel(
             name=self.config.index_name,
@@ -301,34 +326,52 @@ class MongoDBSimilarityIndex(SimilarityIndex):
         sample_ids = np.asarray(sample_ids)
         label_ids = np.asarray(label_ids) if label_ids is not None else None
 
-        _sample_ids, _label_ids, ii, _ = fbu.add_ids(
-            sample_ids,
-            label_ids,
-            self._sample_ids,
-            self._label_ids,
-            patches_field=self.config.patches_field,
-            overwrite=overwrite,
-            allow_existing=allow_existing,
-            warn_existing=warn_existing,
-        )
+        if not overwrite or not allow_existing or warn_existing:
+            if self._sample_ids is not None:
+                _sample_ids, _label_ids = self._sample_ids, self._label_ids
+            else:
+                _sample_ids, _label_ids = self._parse_data(
+                    self._dataset, self.config
+                )
 
-        if ii.size == 0:
-            return
+            index_sample_ids, index_label_ids, ii, _ = fbu.add_ids(
+                sample_ids,
+                label_ids,
+                _sample_ids,
+                _label_ids,
+                patches_field=self.config.patches_field,
+                overwrite=overwrite,
+                allow_existing=allow_existing,
+                warn_existing=warn_existing,
+            )
+
+            self._sample_ids = index_sample_ids
+            self._label_ids = index_label_ids
+
+            if ii.size == 0:
+                return
+
+            embeddings = embeddings[ii, :]
+            sample_ids = sample_ids[ii]
+            label_ids = label_ids[ii] if label_ids is not None else None
+        else:
+            index_sample_ids = None
+            index_label_ids = None
 
         fbu.add_embeddings(
             self._dataset,
-            embeddings[ii, :].tolist(),  # MongoDB requires list fields
-            sample_ids[ii],
-            label_ids[ii] if label_ids is not None else None,
+            embeddings.tolist(),  # MongoDB requires list fields
+            sample_ids,
+            label_ids,
             self.config.embeddings_field,
             patches_field=self.config.patches_field,
         )
 
-        self._sample_ids = _sample_ids
-        self._label_ids = _label_ids
-
         if reload:
             super().reload()
+
+        self._sample_ids = index_sample_ids
+        self._label_ids = index_label_ids
 
     def remove_from_index(
         self,
@@ -338,39 +381,53 @@ class MongoDBSimilarityIndex(SimilarityIndex):
         warn_missing=False,
         reload=True,
     ):
-        _sample_ids, _label_ids, rm_inds = fbu.remove_ids(
-            sample_ids,
-            label_ids,
-            self._sample_ids,
-            self._label_ids,
-            patches_field=self.config.patches_field,
-            allow_missing=allow_missing,
-            warn_missing=warn_missing,
-        )
+        if not allow_missing or warn_missing:
+            if self._sample_ids is not None:
+                _sample_ids, _label_ids = self._sample_ids, self._label_ids
+            else:
+                _sample_ids, _label_ids = self._parse_data(
+                    self._dataset, self.config
+                )
 
-        if rm_inds.size == 0:
-            return
+            index_sample_ids, index_label_ids, rm_inds = fbu.remove_ids(
+                sample_ids,
+                label_ids,
+                _sample_ids,
+                _label_ids,
+                patches_field=self.config.patches_field,
+                allow_missing=allow_missing,
+                warn_missing=warn_missing,
+            )
 
-        if self.config.patches_field is not None:
-            rm_sample_ids = None
-            rm_label_ids = self._label_ids[rm_inds]
+            self._sample_ids = index_sample_ids
+            self._label_ids = index_label_ids
+
+            if rm_inds.size == 0:
+                return
+
+            if self.config.patches_field is not None:
+                sample_ids = None
+                label_ids = _label_ids[rm_inds]
+            else:
+                sample_ids = _sample_ids[rm_inds]
+                label_ids = None
         else:
-            rm_sample_ids = self._sample_ids[rm_inds]
-            rm_label_ids = None
+            index_sample_ids = None
+            index_label_ids = None
 
         fbu.remove_embeddings(
             self._dataset,
             self.config.embeddings_field,
-            sample_ids=rm_sample_ids,
-            label_ids=rm_label_ids,
+            sample_ids=sample_ids,
+            label_ids=label_ids,
             patches_field=self.config.patches_field,
         )
 
-        self._sample_ids = _sample_ids
-        self._label_ids = _label_ids
-
         if reload:
             super().reload()
+
+        self._sample_ids = index_sample_ids
+        self._label_ids = index_label_ids
 
     def get_embeddings(
         self,
@@ -379,13 +436,14 @@ class MongoDBSimilarityIndex(SimilarityIndex):
         allow_missing=True,
         warn_missing=False,
     ):
-        _embeddings, _sample_ids, _label_ids = fbu.get_embeddings(
-            self._dataset,
-            patches_field=self.config.patches_field,
-            embeddings_field=self.config.embeddings_field,
-        )
+        if self._dataset.media_type == fom.GROUP:
+            samples = self._dataset.select_group_slices(_allow_mixed=True)
+        else:
+            samples = self._dataset
 
-        if label_ids is not None:
+        if sample_ids is not None:
+            samples = samples.select(sample_ids)
+        elif label_ids is not None:
             if self.config.patches_field is None:
                 raise ValueError("This index does not support label IDs")
 
@@ -394,6 +452,17 @@ class MongoDBSimilarityIndex(SimilarityIndex):
                     "Ignoring sample IDs when label IDs are provided"
                 )
 
+            samples = samples.select_labels(
+                ids=label_ids, fields=self.config.patches_field
+            )
+
+        _embeddings, _sample_ids, _label_ids = fbu.get_embeddings(
+            samples,
+            patches_field=self.config.patches_field,
+            embeddings_field=self.config.embeddings_field,
+        )
+
+        if label_ids is not None:
             inds = _get_inds(
                 label_ids,
                 _label_ids,
@@ -436,9 +505,8 @@ class MongoDBSimilarityIndex(SimilarityIndex):
         return embeddings, sample_ids, label_ids
 
     def reload(self):
-        sample_ids, label_ids = self._parse_data(self._dataset, self.config)
-        self._sample_ids = sample_ids
-        self._label_ids = label_ids
+        self._sample_ids = None
+        self._label_ids = None
 
         super().reload()
 
@@ -526,12 +594,15 @@ class MongoDBSimilarityIndex(SimilarityIndex):
                 search["filter"] = {
                     "_id": {"$in": [ObjectId(_id) for _id in index_ids]}
                 }
+
+            """
             elif dataset.media_type == fom.GROUP:
                 # $vectorSearch must be the first stage in all pipelines, so we
                 # have to incorporate slice selection as a $filter
                 name_field = dataset.group_field + ".name"
                 group_slice = self.view.group_slice or dataset.group_slice
                 search["filter"] = {name_field: {"$eq": group_slice}}
+            """
 
             project = {"_id": 1}
             # if self.config.patches_field is not None:
@@ -600,25 +671,32 @@ class MongoDBSimilarityIndex(SimilarityIndex):
         return query
 
     def _get_embeddings(self, query_ids):
-        dataset = self._dataset
+        if self._dataset.media_type == fom.GROUP:
+            samples = self._dataset.select_group_slices(_allow_mixed=True)
+        else:
+            samples = self._dataset
+
         patches_field = self.config.patches_field
         embeddings_field = self.config.embeddings_field
         if patches_field is not None:
-            _, embeddings_path = dataset._get_label_field_path(
+            _, embeddings_path = self._dataset._get_label_field_path(
                 patches_field, embeddings_field
             )
-            view = dataset.filter_labels(
+            view = samples.filter_labels(
                 patches_field, F("_id").is_in(query_ids)
             )
             embeddings = view.values(embeddings_path, unwind=True)
         else:
-            view = dataset.select(query_ids)
+            view = samples.select(query_ids)
             embeddings = view.values(embeddings_field)
 
         return embeddings
 
     @staticmethod
     def _parse_data(samples, config):
+        if samples.media_type == fom.GROUP:
+            samples = samples.select_group_slices(_allow_mixed=True)
+
         if config.patches_field is not None:
             samples = samples.filter_labels(
                 config.patches_field, F(config.embeddings_field).exists()

--- a/fiftyone/brain/internal/core/mongodb.py
+++ b/fiftyone/brain/internal/core/mongodb.py
@@ -491,17 +491,9 @@ class MongoDBSimilarityIndex(SimilarityIndex):
             query = [query]
 
         if self.has_view:
-            # https://www.mongodb.com/community/forums/t/258494
-            logger.warning(
-                "The MongoDB backend does not yet support views; the full "
-                "index will instead be queried, which may result in fewer "
-                "matches in your current view"
-            )
-            index_ids = None
+            index_ids = self.current_sample_ids
             # if self.config.patches_field is not None:
             #     index_ids = self.current_label_ids
-            # else:
-            #     index_ids = self.current_sample_ids
         else:
             index_ids = None
 

--- a/fiftyone/brain/internal/core/mongodb.py
+++ b/fiftyone/brain/internal/core/mongodb.py
@@ -435,12 +435,12 @@ class MongoDBSimilarityIndex(SimilarityIndex):
 
         return embeddings, sample_ids, label_ids
 
-    def reload(self, lazy=False):
+    def reload(self):
         sample_ids, label_ids = self._parse_data(self._dataset, self.config)
         self._sample_ids = sample_ids
         self._label_ids = label_ids
 
-        super().reload(lazy=lazy)
+        super().reload()
 
     def cleanup(self):
         if self._index is None:

--- a/fiftyone/brain/internal/core/mosaic.py
+++ b/fiftyone/brain/internal/core/mosaic.py
@@ -546,7 +546,6 @@ class MosaicSimilarityIndex(SimilarityIndex):
         aggregation=None,
         return_dists=False,
     ):
-
         if query is None:
             raise ValueError("Mosaic does not support full index neighbors")
 
@@ -575,45 +574,52 @@ class MosaicSimilarityIndex(SimilarityIndex):
             else:
                 index_ids = list(self.current_sample_ids)
 
-            _filter = {"foid": list(index_ids)}
-            # NOTE: Filtering is supported in Mosaic but is not robust and cannot handle a large number of filters
-            # so we apply the filter after the search
+            # @todo apply filtering in similarity_search(), not post-hoc
+            # As of this writing, filtering is supported in Mosaic but it is
+            # not robust and cannot handle a large number of IDs
+            logger.warning(
+                "The Mosaic backend does not yet support view filters; the "
+                "full index will instead be queried, which may result in "
+                "fewer matches in your current view"
+            )
+
+            _filter = {"foid": set(index_ids)}
         else:
             _filter = None
 
-        ids = []
+        sample_ids = []
+        label_ids = [] if self.config.patches_field is not None else None
         dists = []
         for q in query:
             results = self._index.similarity_search(
-                columns=["foid"],
+                columns=["foid", "sample_id"],
                 query_vector=[float(i) for i in list(q)],
                 num_results=k,
-            )
+            )["result"]["data_array"]
 
-            if _filter:
-                ids.append(
-                    [
-                        res[0]
-                        for res in results["result"]["data_array"]
-                        if res[0] in _filter["foid"]
-                    ]
-                )
+            if _filter is not None:
+                results = [r for r in results if r[0] in _filter["foid"]]
+
+            if self.config.patches_field is not None:
+                sample_ids.append([r[1] for r in results])
+                label_ids.append([r[0] for r in results])
             else:
-                ids.append([res[0] for res in results["result"]["data_array"]])
+                sample_ids.append([r[0] for r in results])
+
             if return_dists:
-                dists.append(
-                    [res[1] for res in results["result"]["data_array"]]
-                )
+                dists.append([r[2] for r in results])
 
         if single_query:
-            ids = ids[0]
+            sample_ids = sample_ids[0]
+            if label_ids is not None:
+                label_ids = label_ids[0]
             if return_dists:
                 dists = dists[0]
 
         if return_dists:
-            return ids, dists
+            return sample_ids, label_ids, dists
 
-        return ids
+        return sample_ids, label_ids
 
     def _parse_neighbors_query(self, query):
         if etau.is_str(query):

--- a/fiftyone/brain/internal/core/mosaic.py
+++ b/fiftyone/brain/internal/core/mosaic.py
@@ -570,9 +570,9 @@ class MosaicSimilarityIndex(SimilarityIndex):
 
         if self.has_view:
             if self.config.patches_field is not None:
-                index_ids = list(self.current_label_ids)
+                index_ids = self.current_label_ids
             else:
-                index_ids = list(self.current_sample_ids)
+                index_ids = self.current_sample_ids
 
             # @todo apply filtering in similarity_search(), not post-hoc
             # As of this writing, filtering is supported in Mosaic but it is

--- a/fiftyone/brain/internal/core/pgvector.py
+++ b/fiftyone/brain/internal/core/pgvector.py
@@ -588,9 +588,9 @@ class PgVectorSimilarityIndex(SimilarityIndex):
         index_ids = None
         if self.has_view:
             if self.config.patches_field is not None:
-                index_ids = self.current_label_ids
+                index_ids = list(self.current_label_ids)
             else:
-                index_ids = self.current_sample_ids
+                index_ids = list(self.current_sample_ids)
 
             _filter = True
         else:
@@ -598,51 +598,57 @@ class PgVectorSimilarityIndex(SimilarityIndex):
 
         sort_order = "DESC" if reverse else "ASC"
 
-        ids = []
+        sample_ids = []
+        label_ids = [] if self.config.patches_field is not None else None
         dists = []
         for q in query:
-            q = q.tolist()
             if _filter:
                 self._cur.execute(
                     f"""
-                    SELECT id, embedding_vector <-> %s::vector AS distance
+                    SELECT id, sample_id, embedding_vector <-> %s::vector AS distance
                     FROM "{self.config.table_name}"
                     WHERE id = ANY(%s)
                     ORDER BY distance {sort_order}
                     LIMIT %s;
                     """,
-                    (q, list(index_ids), k),
+                    (q.tolist(), index_ids, k),
                 )
             else:
                 self._cur.execute(
                     f"""
-                    SELECT id, embedding_vector <-> %s::vector AS distance
+                    SELECT id, sample_id, embedding_vector <-> %s::vector AS distance
                     FROM "{self.config.table_name}"
                     ORDER BY distance {sort_order}
                     LIMIT %s;
                     """,
-                    (q, k),
+                    (q.tolist(), k),
                 )
 
             results = self._cur.fetchall()
-            ids.append([r[0] for r in results])
-            distances = [r[1] for r in results]
+
+            if self.config.patches_field is not None:
+                sample_ids.append([r[1] for r in results])
+                label_ids.append([r[0] for r in results])
+            else:
+                sample_ids.append([r[0] for r in results])
 
             if return_dists:
-                dists.append(distances)
-
-        if single_query:
-            ids = ids[0]
-            if return_dists:
-                dists = dists[0]
+                dists.append([r[2] for r in results])
 
         if close_conn:
             self.close_connections()
 
-        if return_dists:
-            return ids, dists
+        if single_query:
+            sample_ids = sample_ids[0]
+            if label_ids is not None:
+                label_ids = label_ids[0]
+            if return_dists:
+                dists = dists[0]
 
-        return ids
+        if return_dists:
+            return sample_ids, label_ids, dists
+
+        return sample_ids, label_ids
 
     def _parse_neighbors_query(self, query):
         if etau.is_str(query):

--- a/fiftyone/brain/internal/core/pgvector.py
+++ b/fiftyone/brain/internal/core/pgvector.py
@@ -131,10 +131,10 @@ class PgVectorSimilarity(Similarity):
     """
 
     def ensure_requirements(self):
-        fou.ensure_package("psycopg2-binary")
+        fou.ensure_package("psycopg2|psycopg2-binary")
 
     def ensure_usage_requirements(self):
-        fou.ensure_package("psycopg2-binary")
+        fou.ensure_package("psycopg2|psycopg2-binary")
 
     def initialize(self, samples, brain_key):
         return PgVectorSimilarityIndex(

--- a/fiftyone/brain/internal/core/pinecone.py
+++ b/fiftyone/brain/internal/core/pinecone.py
@@ -345,6 +345,7 @@ class PineconeSimilarityIndex(SimilarityIndex):
                 list(zip(_ids, _embeddings, _id_dicts)),
                 namespace=namespace,
             )
+
         if reload:
             self.reload()
 

--- a/fiftyone/brain/internal/core/pinecone.py
+++ b/fiftyone/brain/internal/core/pinecone.py
@@ -567,25 +567,36 @@ class PineconeSimilarityIndex(SimilarityIndex):
         else:
             _filter = None
 
-        ids = []
+        sample_ids = []
+        label_ids = [] if self.config.patches_field is not None else None
         dists = []
         for q in query:
             response = self._index.query(
                 vector=q.tolist(), top_k=k, filter=_filter
             )
-            ids.append([r["id"] for r in response["matches"]])
+
+            if self.config.patches_field is not None:
+                sample_ids.append(
+                    [r["sample_id"] for r in response["matches"]]
+                )
+                label_ids.append([r["id"] for r in response["matches"]])
+            else:
+                sample_ids.append([r["id"] for r in response["matches"]])
+
             if return_dists:
                 dists.append([r["score"] for r in response["matches"]])
 
         if single_query:
-            ids = ids[0]
+            sample_ids = sample_ids[0]
+            if label_ids is not None:
+                label_ids = label_ids[0]
             if return_dists:
                 dists = dists[0]
 
         if return_dists:
-            return ids, dists
+            return sample_ids, label_ids, dists
 
-        return ids
+        return sample_ids, label_ids
 
     def _parse_neighbors_query(self, query):
         if etau.is_str(query):

--- a/fiftyone/brain/internal/core/pinecone.py
+++ b/fiftyone/brain/internal/core/pinecone.py
@@ -572,13 +572,17 @@ class PineconeSimilarityIndex(SimilarityIndex):
         label_ids = [] if self.config.patches_field is not None else None
         dists = []
         for q in query:
+            include_metadata = self.config.patches_field is not None
             response = self._index.query(
-                vector=q.tolist(), top_k=k, filter=_filter
+                vector=q.tolist(),
+                top_k=k,
+                filter=_filter,
+                include_metadata=include_metadata,
             )
 
             if self.config.patches_field is not None:
                 sample_ids.append(
-                    [r["sample_id"] for r in response["matches"]]
+                    [r["metadata"]["sample_id"] for r in response["matches"]]
                 )
                 label_ids.append([r["id"] for r in response["matches"]])
             else:

--- a/fiftyone/brain/internal/core/qdrant.py
+++ b/fiftyone/brain/internal/core/qdrant.py
@@ -593,30 +593,45 @@ class QdrantSimilarityIndex(SimilarityIndex):
         else:
             _filter = None
 
-        ids = []
+        sample_ids = []
+        label_ids = [] if self.config.patches_field is not None else None
         dists = []
         for q in query:
+            with_payload = self.config.patches_field is not None
             results = self._client.search(
                 collection_name=self.config.collection_name,
                 query_vector=q,
                 query_filter=_filter,
-                with_payload=False,
+                with_payload=with_payload,
                 limit=k,
             )
 
-            ids.append(self._to_fiftyone_ids([r.id for r in results]))
+            if self.config.patches_field is not None:
+                sample_ids.append(
+                    self._to_fiftyone_ids([r.sample_id for r in results])
+                )
+                label_ids.append(
+                    self._to_fiftyone_ids([r.id for r in results])
+                )
+            else:
+                sample_ids.append(
+                    self._to_fiftyone_ids([r.id for r in results])
+                )
+
             if return_dists:
                 dists.append([r.score for r in results])
 
         if single_query:
-            ids = ids[0]
+            sample_ids = sample_ids[0]
+            if label_ids is not None:
+                label_ids = label_ids[0]
             if return_dists:
                 dists = dists[0]
 
         if return_dists:
-            return ids, dists
+            return sample_ids, label_ids, dists
 
-        return ids
+        return sample_ids, label_ids
 
     def _parse_neighbors_query(self, query):
         if etau.is_str(query):

--- a/fiftyone/brain/internal/core/qdrant.py
+++ b/fiftyone/brain/internal/core/qdrant.py
@@ -608,7 +608,9 @@ class QdrantSimilarityIndex(SimilarityIndex):
 
             if self.config.patches_field is not None:
                 sample_ids.append(
-                    self._to_fiftyone_ids([r.sample_id for r in results])
+                    self._to_fiftyone_ids(
+                        [r.payload["sample_id"] for r in results]
+                    )
                 )
                 label_ids.append(
                     self._to_fiftyone_ids([r.id for r in results])

--- a/fiftyone/brain/internal/core/sklearn.py
+++ b/fiftyone/brain/internal/core/sklearn.py
@@ -789,7 +789,7 @@ class NeighborsHelper(object):
         return neighbors, dists
 
     def _build_dists(self, embeddings):
-        logger.info("Generating index for %d embeddings...", len(embeddings))
+        logger.debug("Generating index for %d embeddings...", len(embeddings))
 
         # Center embeddings
         embeddings = np.asarray(embeddings)
@@ -798,12 +798,12 @@ class NeighborsHelper(object):
         dists = skm.pairwise_distances(embeddings, metric=self.metric)
         np.fill_diagonal(dists, np.nan)
 
-        logger.info("Index complete")
+        logger.debug("Index complete")
 
         return dists
 
     def _build_neighbors(self, embeddings):
-        logger.info(
+        logger.debug(
             "Generating neighbors graph for %d embeddings...",
             len(embeddings),
         )
@@ -828,7 +828,7 @@ class NeighborsHelper(object):
 
         setattr(neighbors, _COSINE_HACK_ATTR, cosine_hack)
 
-        logger.info("Index complete")
+        logger.debug("Index complete")
 
         return neighbors
 

--- a/fiftyone/brain/internal/core/sklearn.py
+++ b/fiftyone/brain/internal/core/sklearn.py
@@ -618,23 +618,30 @@ class SklearnSimilarityIndex(SimilarityIndex, DuplicatesMixin):
         self, inds, dists, full_index, single_query, return_dists
     ):
         if full_index:
-            return (inds, dists) if return_dists else inds
+            if return_dists:
+                return inds, dists
+
+            return inds
+
+        curr_sample_ids = self.current_sample_ids
+        sample_ids = [[curr_sample_ids[i] for i in _inds] for _inds in inds]
+        if single_query:
+            sample_ids = sample_ids[0]
 
         if self.config.patches_field is not None:
-            index_ids = self.current_label_ids
-        else:
-            index_ids = self.current_sample_ids
+            curr_label_ids = self.current_label_ids
+            label_ids = [[curr_label_ids[i] for i in _inds] for _inds in inds]
+            if single_query:
+                label_ids = label_ids[0]
 
-        ids = [[index_ids[i] for i in _inds] for _inds in inds]
         if return_dists:
             dists = [list(d) for d in dists]
-
-        if single_query:
-            ids = ids[0]
-            if return_dists:
+            if single_query:
                 dists = dists[0]
 
-        return (ids, dists) if return_dists else ids
+            return sample_ids, label_ids, dists
+
+        return sample_ids, label_ids
 
     @staticmethod
     def _parse_data(

--- a/fiftyone/brain/internal/core/sklearn.py
+++ b/fiftyone/brain/internal/core/sklearn.py
@@ -323,7 +323,7 @@ class SklearnSimilarityIndex(SimilarityIndex, DuplicatesMixin):
 
         return embeddings, sample_ids, label_ids
 
-    def reload(self, lazy=False):
+    def reload(self):
         if self.config.embeddings_field is not None:
             embeddings, sample_ids, label_ids = self._parse_data(
                 self._dataset, self.config
@@ -336,7 +336,7 @@ class SklearnSimilarityIndex(SimilarityIndex, DuplicatesMixin):
             self._curr_ids_to_inds = None
             self._neighbors_helper = None
 
-        super().reload(lazy=lazy)
+        super().reload()
 
     def cleanup(self):
         pass

--- a/fiftyone/brain/internal/core/sklearn.py
+++ b/fiftyone/brain/internal/core/sklearn.py
@@ -14,6 +14,7 @@ import sklearn.preprocessing as skp
 
 import eta.core.utils as etau
 
+import fiftyone.core.media as fom
 from fiftyone.brain.similarity import (
     DuplicatesMixin,
     SimilarityConfig,
@@ -654,8 +655,12 @@ class SklearnSimilarityIndex(SimilarityIndex, DuplicatesMixin):
         label_ids=None,
     ):
         if embeddings is None:
+            samples = samples._dataset
+            if samples.media_type == fom.GROUP:
+                samples = samples.select_group_slices(_allow_mixed=True)
+
             embeddings, sample_ids, label_ids = fbu.get_embeddings(
-                samples._dataset,
+                samples,
                 patches_field=config.patches_field,
                 embeddings_field=config.embeddings_field,
             )

--- a/fiftyone/brain/internal/core/sklearn.py
+++ b/fiftyone/brain/internal/core/sklearn.py
@@ -323,7 +323,7 @@ class SklearnSimilarityIndex(SimilarityIndex, DuplicatesMixin):
 
         return embeddings, sample_ids, label_ids
 
-    def reload(self):
+    def reload(self, lazy=False):
         if self.config.embeddings_field is not None:
             embeddings, sample_ids, label_ids = self._parse_data(
                 self._dataset, self.config
@@ -336,7 +336,7 @@ class SklearnSimilarityIndex(SimilarityIndex, DuplicatesMixin):
             self._curr_ids_to_inds = None
             self._neighbors_helper = None
 
-        super().reload()
+        super().reload(lazy=lazy)
 
     def cleanup(self):
         pass

--- a/fiftyone/brain/internal/core/sklearn.py
+++ b/fiftyone/brain/internal/core/sklearn.py
@@ -508,18 +508,18 @@ class SklearnSimilarityIndex(SimilarityIndex, DuplicatesMixin):
         if k is not None:
             inds = inds[:k]
 
-        if self.config.patches_field is not None:
-            ids = self.current_label_ids
-        else:
-            ids = self.current_sample_ids
+        sample_ids = list(self.current_sample_ids[inds])
 
-        ids = list(ids[inds])
+        if self.config.patches_field is not None:
+            label_ids = list(self.current_label_ids[inds])
+        else:
+            label_ids = None
 
         if return_dists:
             dists = list(dists[inds])
-            return ids, dists
+            return sample_ids, label_ids, dists
 
-        return ids
+        return sample_ids, label_ids
 
     def _parse_neighbors_query(self, query):
         # Full index
@@ -633,6 +633,8 @@ class SklearnSimilarityIndex(SimilarityIndex, DuplicatesMixin):
             label_ids = [[curr_label_ids[i] for i in _inds] for _inds in inds]
             if single_query:
                 label_ids = label_ids[0]
+        else:
+            label_ids = None
 
         if return_dists:
             dists = [list(d) for d in dists]

--- a/fiftyone/brain/internal/core/utils.py
+++ b/fiftyone/brain/internal/core/utils.py
@@ -513,6 +513,10 @@ def add_embeddings(
     patches_field=None,
 ):
     dataset = samples._dataset
+    if dataset.media_type == fomm.GROUP:
+        view = dataset.select_group_slices(_allow_mixed=True)
+    else:
+        view = dataset
 
     if patches_field is not None:
         _, embeddings_path = dataset._get_label_field_path(
@@ -520,10 +524,10 @@ def add_embeddings(
         )
 
         values = dict(zip(label_ids, embeddings))
-        dataset.set_label_values(embeddings_path, values, dynamic=True)
+        view.set_label_values(embeddings_path, values, dynamic=True)
     else:
         values = dict(zip(sample_ids, embeddings))
-        dataset.set_values(embeddings_field, values, key_field="id")
+        view.set_values(embeddings_field, values, key_field="id")
 
 
 def remove_ids(
@@ -610,6 +614,10 @@ def remove_embeddings(
     patches_field=None,
 ):
     dataset = samples._dataset
+    if dataset.media_type == fomm.GROUP:
+        view = dataset.select_group_slices(_allow_mixed=True)
+    else:
+        view = dataset
 
     if patches_field is not None:
         _, embeddings_path = dataset._get_label_field_path(
@@ -618,14 +626,14 @@ def remove_embeddings(
 
         if sample_ids is not None and label_ids is None:
             _, id_path = dataset._get_label_field_path(patches_field, "id")
-            label_ids = dataset.select(sample_ids).values(id_path, unwind=True)
+            label_ids = view.select(sample_ids).values(id_path, unwind=True)
 
         if label_ids is not None:
             values = dict(zip(label_ids, itertools.repeat(None)))
-            dataset.set_label_values(embeddings_path, values)
+            view.set_label_values(embeddings_path, values)
     elif sample_ids is not None:
         values = dict(zip(sample_ids, itertools.repeat(None)))
-        dataset.set_values(embeddings_field, values, key_field="id")
+        view.set_values(embeddings_field, values, key_field="id")
 
 
 def filter_values(values, keep_inds, patches_field=None):

--- a/fiftyone/brain/similarity.py
+++ b/fiftyone/brain/similarity.py
@@ -642,22 +642,30 @@ class SimilarityIndex(fob.BrainResults):
         if self._curr_sample_ids is None:
             self._apply_view()
 
-    def clear_view(self):
+    def clear_view(self, lazy=False):
         """Clears the view set by :meth:`use_view`, if any.
 
         Subsequent operations will be performed on the full index.
-        """
-        self.use_view(self._samples)
 
-    def reload(self):
+        Args:
+            lazy (False): whether to lazily reinitialze the index only when
+                necessary
+        """
+        self.use_view(self._samples, lazy=lazy)
+
+    def reload(self, lazy=False):
         """Reloads the index for the current view.
 
         Subclasses may override this method, but by default this method simply
         passes the current :meth:`view` back into :meth:`use_view`, which
         updates the index's current ID set based on any changes to the view
         since the index was last loaded.
+
+        Args:
+            lazy (False): whether to lazily reinitialze the index only when
+                necessary
         """
-        self.use_view(self._curr_view)
+        self.use_view(self._curr_view, lazy=lazy)
 
     def cleanup(self):
         """Deletes the similarity index from the backend."""

--- a/fiftyone/brain/similarity.py
+++ b/fiftyone/brain/similarity.py
@@ -1187,9 +1187,13 @@ class DuplicatesMixin(object):
                 unique_view = self._samples.select(unique_ids)
 
             with self.use_view(unique_view):
-                nearest_ids, dists = self._kneighbors(
+                _sample_ids, _label_ids, dists = self._kneighbors(
                     query=duplicate_ids, k=1, return_dists=True
                 )
+                if self.config.patches_field is not None:
+                    nearest_ids = _label_ids
+                else:
+                    nearest_ids = _sample_ids
 
             neighbors_map = defaultdict(list)
             for dup_id, _ids, _dists in zip(duplicate_ids, nearest_ids, dists):

--- a/tests/intensive/test_similarity.py
+++ b/tests/intensive/test_similarity.py
@@ -4,7 +4,7 @@ Similarity tests.
 Usage::
 
     # Optional: specific backends to test
-    export SIMILARITY_BACKENDS=qdrant,pinecone,milvus,lancedb,redis,elasticsearch,mosaic,pgvector
+    export SIMILARITY_BACKENDS=qdrant,pinecone,milvus,redis,elasticsearch,mosaic,pgvector,lancedb
 
     pytest tests/intensive/test_similarity.py -s -k test_XXX
 
@@ -57,7 +57,7 @@ Elasticsearch setup::
 
 Mosaic setup::
 
-    # In your databricks workspace, generate a personal access token for authentication. You will also need to 
+    # In your databricks workspace, generate a personal access token for authentication. You will also need to
     # create a catalog and schema in your workspace. You will have to create an endpoint under `compute` -> `vector search`
 
     pip install databricks-vectorsearch
@@ -135,11 +135,11 @@ CUSTOM_BACKENDS = [
     "qdrant",
     "pinecone",
     "milvus",
-    "lancedb",
     "redis",
     "elasticsearch",
     "mosaic",
     "pgvector",
+    "lancedb",
 ]
 
 

--- a/tests/intensive/test_similarity.py
+++ b/tests/intensive/test_similarity.py
@@ -57,12 +57,13 @@ Elasticsearch setup::
 
 Mosaic setup::
 
-    # In your databricks workspace, generate a personal access token for authentication. You will also need to
-    # create a catalog and schema in your workspace. You will have to create an endpoint under `compute` -> `vector search`
+    # In your databricks workspace, generate a personal access token for authentication.
+    # You will also need to create a catalog and schema in your workspace.
+    # You will have to create an endpoint under `compute` -> `vector search`
 
     pip install databricks-vectorsearch
 
-PGVector Setup:
+PGVector setup::
 
     # Run a postgres instance locally with pgvector extension
     docker pull pgvector/pgvector:pg17
@@ -70,7 +71,7 @@ PGVector Setup:
 
     # Enter the container and create the vector extension
     docker exec -it postgres ./bin/psql -U postgres
-    CREATE EXTENSION IF NOT EXISTS vector; #Run in container
+    CREATE EXTENSION IF NOT EXISTS vector;  # run in container
 
     pip install psycopg2
 
@@ -112,6 +113,7 @@ Brain config setup at `~/.fiftyone/brain_config.json`::
             "pgvector": {
                 "connection_string": "postgresql://postgres:mysecretpassword@localhost:5432/postgres"
             }
+        }
     }
 
 | Copyright 2017-2025, Voxel51, Inc.


### PR DESCRIPTION
## Change log

- Optimizes `sort_by_similarity()` calls by avoiding unnecessary calls to `values("id")`
- Ensures that `sort_by_similarity()` queries against **grouped datasets** always use the full index

## Background

Currently, many `sort_by_similarity()` invocations implicitly call `values("id")` for one or more of the following reasons:
1. When the index is initially loaded via `dataset.load_brain_results()`, regardless of the query, for certain backends like the default `backend="sklearn"`
2. When `use_view()` is called, even if the view does not actually limit the query results
3. Inside `_kneighbors()` when performing patch similarity queries (to look up corresponding sample IDs)

For large datasets and/or over API connections, the cost of `values("id")` can dwarf the cost of the underlying backend's k-neighbors query, which means large-scale performance can be 😢😢😢

Now `values("id")` is called *only* when strictly necessary (when performing a similarity query against a view subset, we must lookup the IDs in that view so we can pass the necessary ID filter to the underlying backend's k-neighbors query):

```py
# Subset queries must retrieve IDs in the input view

subset_view.sort_by_similarity(...)
```

However, in all other cases the performance of `sort_by_similarity()` is now 1-1 with the performance of the underlying backend's k-neighbors query!  🎉🎉🎉 

```py
# These bread & butter use cases are now scalable!

# Full dataset queries
dataset.sort_by_similarity(...)

# Full index queries
view = dataset.load_brain_view(brain_key)
view.sort_by_similarity(..., brain_key=brain_key)

# Full group slice queries
view = dataset.select_group_slices()
view.sort_by_similarity(...)

# Full patch queries
patches = dataset.to_patches(...)
patches.sort_by_similarity(...)
```

## Tested by

```shell
# I tested these
export SIMILARITY_BACKENDS=qdrant,pinecone,milvus,redis,elasticsearch,pgvector,lancedb

# FYI I haven't tested Mosaic
export SIMILARITY_BACKENDS=mosaic
```

```shell
pytest tests/intensive/test_similarity.py -s -k test_image_similarity_backends
pytest tests/intensive/test_similarity.py -s -k test_patch_similarity_backends
```

## Example usage

### Image similarity

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.brain as fob

backend = "pgvector"

dataset = foz.load_zoo_dataset("quickstart", max_samples=10)

index = fob.compute_similarity(
    dataset,
    model="clip-vit-base32-torch",
    brain_key="img_sim",
    backend=backend,
)

view = dataset.sort_by_similarity(dataset.first().id, k=5)

subset = dataset.take(7)
view = subset.sort_by_similarity(dataset.first().id, k=5)

with index.use_view(subset):
    view = index.sort_by_similarity(dataset.first().id, k=5)

dataset.clear_cache()
index = dataset.load_brain_results("img_sim")

view = index.sort_by_similarity(dataset.first().id, k=5)
```

### Object similarity

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.brain as fob

backend = "pgvector"

dataset = foz.load_zoo_dataset("quickstart", max_samples=10)

index = fob.compute_similarity(
    dataset,
    patches_field="ground_truth",
    model="clip-vit-base32-torch",
    brain_key="gt_sim",
    backend=backend,
)

patches = dataset.to_patches("ground_truth")
subset = patches.take(7)

view = patches.sort_by_similarity(patches.first().id, k=5)

with index.use_view(patches):
    view = index.sort_by_similarity(patches.first().id, k=5)

view = subset.sort_by_similarity(patches.first().id, k=5)

with index.use_view(subset):
    view = index.sort_by_similarity(patches.first().id, k=5)

dataset.clear_cache()
index = dataset.load_brain_results("gt_sim")

view = index.sort_by_similarity(patches.first().id, k=5)
```

### Grouped datasets

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.brain as fob

backend = "mongodb"
# backend = "sklearn"

dataset = foz.load_zoo_dataset("quickstart-groups", max_samples=30)

view = dataset.select_group_slices(["left", "right"])
index = fob.compute_similarity(
    view,
    model="clip-vit-base32-torch",
    brain_key="img_sim",
    backend=backend,
    embeddings="embeddings",
)

assert dataset.group_slice == "left"
assert index.total_index_size == 20

# Query in another slice
query_id = dataset.select_group_slices("right").take(1).first().id
view = dataset.sort_by_similarity(query_id, k=5)

view = dataset.sort_by_similarity("kites high in the sky", k=5)
```
