### PR TITLE
[Needs reproducing] Handle one-dimensional embeddings for clustering

### DIFF
--- a/fiftyone/brain/internal/core/representativeness.py
+++ b/fiftyone/brain/internal/core/representativeness.py
@@ -185,6 +185,8 @@ def _compute_representativeness(embeddings, method="cluster-center"):
 def _cluster_ranker(
     embeddings, cluster_algorithm="kmeans", N=20, norm_method="local"
 ):
+    if np.linalg.matrix_rank(embeddings) == 1:
+        embeddings = np.reshape(embeddings, (-1, 1))
     # Cluster
     if cluster_algorithm == "meanshift":
         bandwidth = skc.estimate_bandwidth(


### PR DESCRIPTION
Hi folks

I was playing around with Brain for a dataset at work, and I noticed that when I provided a `roi_field` (the detection labels) for a method that relies on clustering, I got this error. 

```python
fob.compute_representativeness(dataset, roi_field="ground_truth")
```

```
ValueError: Expected 2D array, got 1D array instead:
array=[0.06107287 0.06011039 0.06012045 0.05879862 0.05759485 0.05654685
0.05719245 0.0446697  0.04646276 0.04628405 0.04667709 0.04758289
0.04678112 0.04675514 0.04684635 0.04685971 0.04689653 0.04614001
0.04592452 0.04747253 0.04706833 0.04716367 0.04662085 0.04660043
0.04788357 0.03245687 0.04705974 0.04701892 0.04882907 0.05358888
0.05417315 0.05604687 0.05566651 0.04973941 0.04815942 0.04763582
0.04768014 0.0472154  0.04717452 0.04974527 0.04951364 0.04999169
0.04736153 0.04292721 0.03433677 0.03456343 0.04151432 0.03937531
0.04073388 0.04284388].
Reshape your data either using array.reshape(-1, 1) if your data has a single feature or array.reshape(1, -1) if it contains a single sample.
```

This is computed for a slice of 50 dataset samples, so we're in the first case of the error.

I also noticed this for uniqueness with the brain version we use (0.16), but by cloning the latest locally, I see that uniqueness no longer works the same way, so I did not test it. Possibly other methods that rely on clustering as well.

I can't provide the dataset and did not test this on a zoo dataset.

I will leave this as a draft until I know better, but you can let me know if you'd rather have this as an issue.