### PR TITLE
Compute near duplicates + ROI fields

### DIFF
--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -721,7 +721,7 @@ def compute_near_duplicates(
             :class:`fiftyone.core.labels.Detections`,
             :class:`fiftyone.core.labels.Polyline`, or
             :class:`fiftyone.core.labels.Polylines` field defining a region of
-            interest within each image to use to compute leaks
+            interest within each image to use to compute embeddings
         embeddings (None): if no ``model`` is provided, this argument specifies
             pre-computed embeddings to use, which can be any of the following:
 

--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -539,6 +539,7 @@ def compute_visualization(
 def compute_similarity(
     samples,
     patches_field=None,
+    roi_field=None,
     embeddings=None,
     brain_key=None,
     model=None,
@@ -592,6 +593,11 @@ def compute_similarity(
             :class:`fiftyone.core.labels.Detections`,
             :class:`fiftyone.core.labels.Polyline`, or
             :class:`fiftyone.core.labels.Polylines`
+        roi_field (None): an optional :class:`fiftyone.core.labels.Detection`,
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polyline`, or
+            :class:`fiftyone.core.labels.Polylines` field defining a region of
+            interest within each image to use to compute embeddings
         embeddings (None): embeddings to feed the index. This argument's
             behavior depends on whether a ``model`` is provided, as described
             below.
@@ -600,8 +606,9 @@ def compute_similarity(
             embeddings to use:
 
             -   a ``num_samples x num_dims`` array of embeddings
-            -   if ``patches_field`` is specified,  a dict mapping sample IDs
-                to ``num_patches x num_dims`` arrays of patch embeddings
+            -   if ``patches_field``/``roi_field`` is specified,  a dict
+                mapping sample IDs to ``num_patches x num_dims`` arrays of
+                patch embeddings
             -   the name of a dataset field from which to load embeddings
             -   ``None``: use the default model to compute embeddings
             -   ``False``: **do not** compute embeddings right now
@@ -614,7 +621,7 @@ def compute_similarity(
 
             In either case, when working with patch embeddings, you can provide
             either the fully-qualified path to the patch embeddings or just the
-            name of the label attribute in ``patches_field``
+            name of the label attribute in ``patches_field``/``roi_field``
         brain_key (None): a brain key under which to store the results of this
             method
         model (None): a :class:`fiftyone.core.models.Model` or the name of a
@@ -626,14 +633,14 @@ def compute_similarity(
             to the model's ``Config`` when a model name is provided
         force_square (False): whether to minimally manipulate the patch
             bounding boxes into squares prior to extraction. Only applicable
-            when a ``model`` and ``patches_field`` are specified
+            when a ``model`` and ``patches_field``/``roi_field`` are specified
         alpha (None): an optional expansion/contraction to apply to the patches
             before extracting them, in ``[-1, inf)``. If provided, the length
             and width of the box are expanded (or contracted, when
             ``alpha < 0``) by ``(100 * alpha)%``. For example, set
             ``alpha = 0.1`` to expand the boxes by 10%, and set
             ``alpha = -0.1`` to contract the boxes by 10%. Only applicable when
-            a ``model`` and ``patches_field`` are specified
+            a ``model`` and ``patches_field``/``roi_field`` are specified
         batch_size (None): an optional batch size to use when computing
             embeddings. Only applicable when a ``model`` is provided
         num_workers (None): the number of workers to use when loading images.
@@ -660,6 +667,7 @@ def compute_similarity(
     return fbs.compute_similarity(
         samples,
         patches_field,
+        roi_field,
         embeddings,
         brain_key,
         model,
@@ -675,6 +683,111 @@ def compute_similarity(
     )
 
 
+def compute_near_duplicates(
+    samples,
+    threshold=0.2,
+    roi_field=None,
+    embeddings=None,
+    similarity_index=None,
+    model=None,
+    model_kwargs=None,
+    force_square=False,
+    alpha=None,
+    batch_size=None,
+    num_workers=None,
+    skip_failures=True,
+    progress=None,
+):
+    """Detects potential duplicates in the given sample collection.
+
+    Calling this method only initializes the index. You can then call the
+    methods exposed on the returned object to perform the following operations:
+
+    -   :meth:`duplicate_ids <fiftyone.brain.similarity.DuplicatesMixin.duplicate_ids>`:
+        A list of duplicate IDs
+
+    -   :meth:`neighbors_map <fiftyone.brain.similarity.DuplicatesMixin.neighbors_map>`:
+        A dictionary mapping IDs to lists of ``(dup_id, dist)`` tuples
+
+    -   :meth:`duplicates_view() <fiftyone.brain.similarity.DuplicatesMixin.duplicates_view>`:
+        Returns a view of all duplicates in the input collection
+
+    Args:
+        samples: a :class:`fiftyone.core.collections.SampleCollection`
+        threshold (0.2): the similarity distance threshold to use when
+            detecting duplicates. Values in ``[0.1, 0.25]`` work well for the
+            default setup
+        roi_field (None): an optional :class:`fiftyone.core.labels.Detection`,
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polyline`, or
+            :class:`fiftyone.core.labels.Polylines` field defining a region of
+            interest within each image to use to compute leaks
+        embeddings (None): if no ``model`` is provided, this argument specifies
+            pre-computed embeddings to use, which can be any of the following:
+
+            -   a ``num_samples x num_dims`` array of embeddings
+            -   if ``roi_field`` is specified,  a dict mapping sample IDs to
+                ``num_patches x num_dims`` arrays of patch embeddings
+            -   the name of a dataset field containing the embeddings to use
+
+            If a ``model`` is provided, this argument specifies the name of a
+            field in which to store the computed embeddings. In either case,
+            when working with patch embeddings, you can provide either the
+            fully-qualified path to the patch embeddings or just the name of
+            the label attribute in ``roi_field``
+        similarity_index (None): a
+            :class:`fiftyone.brain.similarity.SimilarityIndex` or the brain key
+            of a similarity index to use to load pre-computed embeddings
+        model (None): a :class:`fiftyone.core.models.Model` or the name of a
+            model from the
+            `FiftyOne Model Zoo <https://docs.voxel51.com/user_guide/model_zoo/models.html>`_
+            to use to generate embeddings. The model must expose embeddings
+            (``model.has_embeddings = True``)
+        model_kwargs (None): a dictionary of optional keyword arguments to pass
+            to the model's ``Config`` when a model name is provided
+        force_square (False): whether to minimally manipulate the patch
+            bounding boxes into squares prior to extraction. Only applicable
+            when a ``model`` and ``roi_field`` are specified
+        alpha (None): an optional expansion/contraction to apply to the patches
+            before extracting them, in ``[-1, inf)``. If provided, the length
+            and width of the box are expanded (or contracted, when
+            ``alpha < 0``) by ``(100 * alpha)%``. For example, set
+            ``alpha = 0.1`` to expand the boxes by 10%, and set
+            ``alpha = -0.1`` to contract the boxes by 10%. Only applicable when
+            a ``model`` and ``roi_field`` are specified
+        batch_size (None): a batch size to use when computing embeddings. Only
+            applicable when a ``model`` is provided
+        num_workers (None): the number of workers to use when loading images.
+            Only applicable when a Torch-based model is being used to compute
+            embeddings
+        skip_failures (True): whether to gracefully continue without raising an
+            error if embeddings cannot be generated for a sample
+        progress (None): whether to render a progress bar (True/False), use the
+            default value ``fiftyone.config.show_progress_bars`` (None), or a
+            progress callback function to invoke instead
+
+    Returns:
+        a :class:`fiftyone.brain.similarity.SimilarityIndex`
+    """
+    import fiftyone.brain.internal.core.duplicates as fbd
+
+    return fbd.compute_near_duplicates(
+        samples,
+        threshold=threshold,
+        roi_field=roi_field,
+        embeddings=embeddings,
+        similarity_index=similarity_index,
+        model=model,
+        model_kwargs=model_kwargs,
+        force_square=force_square,
+        alpha=alpha,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        skip_failures=skip_failures,
+        progress=progress,
+    )
+
+
 def compute_exact_duplicates(
     samples,
     num_workers=None,
@@ -684,7 +797,7 @@ def compute_exact_duplicates(
     """Detects duplicate media in a sample collection.
 
     This method detects exact duplicates with the same filehash. Use
-    :meth:`compute_similarity` to detect near-duplicate images.
+    :meth:`compute_near_duplicates` to detect near-duplicates.
 
     If duplicates are found, the first instance in ``samples`` will be the key
     in the returned dictionary, while the subsequent duplicates will be the
@@ -714,10 +827,13 @@ def compute_leaky_splits(
     samples,
     splits,
     threshold=0.2,
+    roi_field=None,
     embeddings=None,
     similarity_index=None,
     model=None,
     model_kwargs=None,
+    force_square=False,
+    alpha=None,
     batch_size=None,
     num_workers=None,
     skip_failures=True,
@@ -752,14 +868,24 @@ def compute_leaky_splits(
         threshold (0.2): the similarity distance threshold to use when
             detecting leaks. Values in ``[0.1, 0.25]`` work well for the
             default setup
+        roi_field (None): an optional :class:`fiftyone.core.labels.Detection`,
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polyline`, or
+            :class:`fiftyone.core.labels.Polylines` field defining a region of
+            interest within each image to use to compute leaks
         embeddings (None): if no ``model`` is provided, this argument specifies
             pre-computed embeddings to use, which can be any of the following:
 
             -   a ``num_samples x num_dims`` array of embeddings
+            -   if ``roi_field`` is specified,  a dict mapping sample IDs to
+                ``num_patches x num_dims`` arrays of patch embeddings
             -   the name of a dataset field containing the embeddings to use
 
             If a ``model`` is provided, this argument specifies the name of a
-            field in which to store the computed embeddings
+            field in which to store the computed embeddings. In either case,
+            when working with patch embeddings, you can provide either the
+            fully-qualified path to the patch embeddings or just the name of
+            the label attribute in ``roi_field``
         similarity_index (None): a
             :class:`fiftyone.brain.similarity.SimilarityIndex` or the brain key
             of a similarity index to use to load pre-computed embeddings
@@ -770,6 +896,16 @@ def compute_leaky_splits(
             (``model.has_embeddings = True``)
         model_kwargs (None): a dictionary of optional keyword arguments to pass
             to the model's ``Config`` when a model name is provided
+        force_square (False): whether to minimally manipulate the patch
+            bounding boxes into squares prior to extraction. Only applicable
+            when a ``model`` and ``roi_field`` are specified
+        alpha (None): an optional expansion/contraction to apply to the patches
+            before extracting them, in ``[-1, inf)``. If provided, the length
+            and width of the box are expanded (or contracted, when
+            ``alpha < 0``) by ``(100 * alpha)%``. For example, set
+            ``alpha = 0.1`` to expand the boxes by 10%, and set
+            ``alpha = -0.1`` to contract the boxes by 10%. Only applicable when
+            a ``model`` and ``roi_field`` are specified
         batch_size (None): a batch size to use when computing embeddings. Only
             applicable when a ``model`` is provided
         num_workers (None): the number of workers to use when loading images.
@@ -790,10 +926,13 @@ def compute_leaky_splits(
         samples,
         splits,
         threshold=threshold,
+        roi_field=roi_field,
         embeddings=embeddings,
         similarity_index=similarity_index,
         model=model,
         model_kwargs=model_kwargs,
+        force_square=force_square,
+        alpha=alpha,
         batch_size=batch_size,
         num_workers=num_workers,
         skip_failures=skip_failures,

--- a/fiftyone/brain/internal/core/elasticsearch.py
+++ b/fiftyone/brain/internal/core/elasticsearch.py
@@ -52,7 +52,8 @@ class ElasticsearchSimilarityConfig(SimilarityConfig):
         bearer_auth (None): a bearer token to use
         ssl_assert_fingerprint (None): a SHA256 fingerprint to use
         verify_certs (None): whether to verify SSL certificates
-        **kwargs: keyword arguments for :class:`SimilarityConfig`
+        **kwargs: keyword arguments for
+            :class:`fiftyone.brain.similarity.SimilarityConfig`
     """
 
     def __init__(

--- a/fiftyone/brain/internal/core/elasticsearch.py
+++ b/fiftyone/brain/internal/core/elasticsearch.py
@@ -37,12 +37,6 @@ class ElasticsearchSimilarityConfig(SimilarityConfig):
     """Configuration for a Elasticsearch similarity instance.
 
     Args:
-        embeddings_field (None): the sample field containing the embeddings
-        model (None): the :class:`fiftyone.core.models.Model` or name of the
-            zoo model that was used to compute embeddings, if known
-        patches_field (None): the sample field defining the patches being
-            analyzed, if any
-        supports_prompts (None): whether this run supports prompt queries
         index_name (None): the name of the Elasticsearch index to use or
             create. If none is provided, a new index will be created
         metric ("cosine"): the embedding distance metric to use when creating a
@@ -63,10 +57,6 @@ class ElasticsearchSimilarityConfig(SimilarityConfig):
 
     def __init__(
         self,
-        embeddings_field=None,
-        model=None,
-        patches_field=None,
-        supports_prompts=None,
         index_name=None,
         metric="cosine",
         hosts=None,
@@ -86,13 +76,7 @@ class ElasticsearchSimilarityConfig(SimilarityConfig):
                 % (metric, tuple(_SUPPORTED_METRICS.keys()))
             )
 
-        super().__init__(
-            embeddings_field=embeddings_field,
-            model=model,
-            patches_field=patches_field,
-            supports_prompts=supports_prompts,
-            **kwargs,
-        )
+        super().__init__(**kwargs)
 
         self.index_name = index_name
         self.metric = metric

--- a/fiftyone/brain/internal/core/lancedb.py
+++ b/fiftyone/brain/internal/core/lancedb.py
@@ -36,13 +36,6 @@ class LanceDBSimilarityConfig(SimilarityConfig):
     """Configuration for a LanceDB similarity instance.
 
     Args:
-        embeddings_field (None): the sample field containing the embeddings,
-            if one was provided
-        model (None): the :class:`fiftyone.core.models.Model` or name of the
-            zoo model that was used to compute embeddings, if known
-        patches_field (None): the sample field defining the patches being
-            analyzed, if any
-        supports_prompts (None): whether this run supports prompt queries
         table_name (None): the name of the LanceDB table to use. If none is
             provided, a new table will be created
         metric ("cosine"): the embedding distance metric to use when creating a
@@ -53,10 +46,6 @@ class LanceDBSimilarityConfig(SimilarityConfig):
 
     def __init__(
         self,
-        embeddings_field=None,
-        model=None,
-        patches_field=None,
-        supports_prompts=None,
         table_name=None,
         metric="cosine",
         uri="/tmp/lancedb",
@@ -68,13 +57,7 @@ class LanceDBSimilarityConfig(SimilarityConfig):
                 % (metric, tuple(_SUPPORTED_METRICS.keys()))
             )
 
-        super().__init__(
-            embeddings_field=embeddings_field,
-            model=model,
-            patches_field=patches_field,
-            supports_prompts=supports_prompts,
-            **kwargs,
-        )
+        super().__init__(**kwargs)
 
         self.table_name = table_name
         self.metric = metric

--- a/fiftyone/brain/internal/core/leaky_splits.py
+++ b/fiftyone/brain/internal/core/leaky_splits.py
@@ -30,10 +30,13 @@ def compute_leaky_splits(
     samples,
     splits,
     threshold=None,
+    roi_field=None,
     embeddings=None,
     similarity_index=None,
     model=None,
     model_kwargs=None,
+    force_square=False,
+    alpha=None,
     batch_size=None,
     num_workers=None,
     skip_failures=True,
@@ -41,7 +44,7 @@ def compute_leaky_splits(
 ):
     """See ``fiftyone/brain/__init__.py``."""
 
-    fov.validate_image_collection(samples)
+    fov.validate_collection(samples)
 
     if etau.is_str(embeddings):
         embeddings_field, embeddings_exist = fbu.parse_embeddings_field(
@@ -80,9 +83,12 @@ def compute_leaky_splits(
         similarity_index = fb.compute_similarity(
             samples,
             backend="sklearn",
+            roi_field=roi_field,
+            embeddings=embeddings_field or embeddings,
             model=model,
             model_kwargs=model_kwargs,
-            embeddings=embeddings_field or embeddings,
+            force_square=force_square,
+            alpha=alpha,
             batch_size=batch_size,
             num_workers=num_workers,
             skip_failures=skip_failures,

--- a/fiftyone/brain/internal/core/leaky_splits.py
+++ b/fiftyone/brain/internal/core/leaky_splits.py
@@ -342,7 +342,7 @@ class LeakySplitsIndex(fob.BrainResults):
             if missing_ids:
                 logger.warning(
                     "The provided splits contain %d samples (eg '%s') that "
-                    "are not present in the provided index",
+                    "are not present in the index",
                     len(missing_ids),
                     next(iter(missing_ids)),
                 )

--- a/fiftyone/brain/internal/core/milvus.py
+++ b/fiftyone/brain/internal/core/milvus.py
@@ -57,7 +57,8 @@ class MilvusSimilarityConfig(SimilarityConfig):
         ca_pem_path (None): a ca.pem path for TLS two-way
         server_pem_path (None): a server.pem path for TLS one-way
         server_name (None): the server name, for TLS
-        **kwargs: keyword arguments for :class:`SimilarityConfig`
+        **kwargs: keyword arguments for
+            :class:`fiftyone.brain.similarity.SimilarityConfig`
     """
 
     def __init__(

--- a/fiftyone/brain/internal/core/milvus.py
+++ b/fiftyone/brain/internal/core/milvus.py
@@ -36,13 +36,6 @@ class MilvusSimilarityConfig(SimilarityConfig):
     """Configuration for the Milvus similarity backend.
 
     Args:
-        embeddings_field (None): the sample field containing the embeddings,
-            if one was provided
-        model (None): the :class:`fiftyone.core.models.Model` or name of the
-            zoo model that was used to compute embeddings, if known
-        patches_field (None): the sample field defining the patches being
-            analyzed, if any
-        supports_prompts (None): whether this run supports prompt queries
         collection_name (None): the name of a Milvus collection to use or
             create. If none is provided, a new collection will be created
         metric ("dotproduct"): the embedding distance metric to use when
@@ -64,14 +57,11 @@ class MilvusSimilarityConfig(SimilarityConfig):
         ca_pem_path (None): a ca.pem path for TLS two-way
         server_pem_path (None): a server.pem path for TLS one-way
         server_name (None): the server name, for TLS
+        **kwargs: keyword arguments for :class:`SimilarityConfig`
     """
 
     def __init__(
         self,
-        embeddings_field=None,
-        model=None,
-        patches_field=None,
-        supports_prompts=None,
         collection_name=None,
         metric="dotproduct",
         consistency_level="Session",
@@ -94,13 +84,7 @@ class MilvusSimilarityConfig(SimilarityConfig):
                 % (metric, tuple(_SUPPORTED_METRICS.keys()))
             )
 
-        super().__init__(
-            embeddings_field=embeddings_field,
-            model=model,
-            patches_field=patches_field,
-            supports_prompts=supports_prompts,
-            **kwargs,
-        )
+        super().__init__(**kwargs)
 
         self.collection_name = collection_name
         self.metric = metric

--- a/fiftyone/brain/internal/core/mongodb.py
+++ b/fiftyone/brain/internal/core/mongodb.py
@@ -38,12 +38,6 @@ class MongoDBSimilarityConfig(SimilarityConfig):
     """Configuration for a MongoDB similarity instance.
 
     Args:
-        embeddings_field (None): the sample field containing the embeddings
-        model (None): the :class:`fiftyone.core.models.Model` or name of the
-            zoo model that was used to compute embeddings, if known
-        patches_field (None): the sample field defining the patches being
-            analyzed, if any
-        supports_prompts (None): whether this run supports prompt queries
         index_name (None): the name of the MongoDB vector index to use or
             create. If none is provided, a new index will be created
         metric ("cosine"): the embedding distance metric to use when creating a
@@ -52,17 +46,8 @@ class MongoDBSimilarityConfig(SimilarityConfig):
         **kwargs: keyword arguments for :class:`SimilarityConfig`
     """
 
-    def __init__(
-        self,
-        embeddings_field=None,
-        model=None,
-        patches_field=None,
-        supports_prompts=None,
-        index_name=None,
-        metric="cosine",
-        **kwargs,
-    ):
-        if embeddings_field is None and index_name is None:
+    def __init__(self, index_name=None, metric="cosine", **kwargs):
+        if kwargs.get("embeddings_field") is None and index_name is None:
             raise ValueError(
                 "You must provide either the name of a field to read/write "
                 "embeddings for this index by passing the `embeddings` "
@@ -72,7 +57,7 @@ class MongoDBSimilarityConfig(SimilarityConfig):
 
         # @todo support this. Will likely require copying embeddings to a new
         # collection as vector search indexes do not yet support array fields
-        if patches_field is not None:
+        if kwargs.get("patches_field") is not None:
             raise ValueError(
                 "The MongoDB backend does not yet support patch embeddings"
             )
@@ -83,13 +68,7 @@ class MongoDBSimilarityConfig(SimilarityConfig):
                 % (metric, tuple(_SUPPORTED_METRICS.keys()))
             )
 
-        super().__init__(
-            embeddings_field=embeddings_field,
-            model=model,
-            patches_field=patches_field,
-            supports_prompts=supports_prompts,
-            **kwargs,
-        )
+        super().__init__(**kwargs)
 
         self.index_name = index_name
         self.metric = metric

--- a/fiftyone/brain/internal/core/mongodb.py
+++ b/fiftyone/brain/internal/core/mongodb.py
@@ -43,7 +43,8 @@ class MongoDBSimilarityConfig(SimilarityConfig):
         metric ("cosine"): the embedding distance metric to use when creating a
             new index. Supported values are
             ``("cosine", "dotproduct", "euclidean")``
-        **kwargs: keyword arguments for :class:`SimilarityConfig`
+        **kwargs: keyword arguments for
+            :class:`fiftyone.brain.similarity.SimilarityConfig`
     """
 
     def __init__(self, index_name=None, metric="cosine", **kwargs):

--- a/fiftyone/brain/internal/core/pinecone.py
+++ b/fiftyone/brain/internal/core/pinecone.py
@@ -31,13 +31,6 @@ class PineconeSimilarityConfig(SimilarityConfig):
     """Configuration for the Pinecone similarity backend.
 
     Args:
-        embeddings_field (None): the sample field containing the embeddings,
-            if one was provided
-        model (None): the :class:`fiftyone.core.models.Model` or name of the
-            zoo model that was used to compute embeddings, if known
-        patches_field (None): the sample field defining the patches being
-            analyzed, if any
-        supports_prompts (None): whether this run supports prompt queries
         index_name (None): the name of a Pinecone index to use or create. If
             none is provided, a new index will be created
         index_type (None): the index type to use when creating a new index.
@@ -61,14 +54,11 @@ class PineconeSimilarityConfig(SimilarityConfig):
         region (None): a region to use when creating serverless indexes
         environment (None): an environment to use when creating pod-based
             indexes
+        **kwargs: keyword arguments for :class:`SimilarityConfig`
     """
 
     def __init__(
         self,
-        embeddings_field=None,
-        model=None,
-        patches_field=None,
-        supports_prompts=None,
         index_name=None,
         index_type=None,
         namespace=None,
@@ -89,13 +79,7 @@ class PineconeSimilarityConfig(SimilarityConfig):
                 % (metric, _SUPPORTED_METRICS)
             )
 
-        super().__init__(
-            embeddings_field=embeddings_field,
-            model=model,
-            patches_field=patches_field,
-            supports_prompts=supports_prompts,
-            **kwargs,
-        )
+        super().__init__(**kwargs)
 
         self.index_name = index_name
         self.index_type = index_type

--- a/fiftyone/brain/internal/core/pinecone.py
+++ b/fiftyone/brain/internal/core/pinecone.py
@@ -54,7 +54,8 @@ class PineconeSimilarityConfig(SimilarityConfig):
         region (None): a region to use when creating serverless indexes
         environment (None): an environment to use when creating pod-based
             indexes
-        **kwargs: keyword arguments for :class:`SimilarityConfig`
+        **kwargs: keyword arguments for
+            :class:`fiftyone.brain.similarity.SimilarityConfig`
     """
 
     def __init__(
@@ -203,8 +204,9 @@ class PineconeSimilarityIndex(SimilarityIndex):
             ) from e
 
         if self.config.index_name is None:
+            # https://docs.pinecone.io/troubleshooting/restrictions-on-index-names
             root = "fiftyone-" + fou.to_slug(self.samples._root_dataset.name)
-            index_name = fbu.get_unique_name(root, index_names)
+            index_name = fbu.get_unique_name(root, index_names, max_len=45)
 
             self.config.index_name = index_name
             self.save_config()

--- a/fiftyone/brain/internal/core/qdrant.py
+++ b/fiftyone/brain/internal/core/qdrant.py
@@ -57,7 +57,8 @@ class QdrantSimilarityConfig(SimilarityConfig):
         api_key (None): a Qdrant API key to use
         grpc_port (None): Port of Qdrant gRPC interface
         prefer_grpc (None): If `true`, use gRPC interface when possible
-        **kwargs: keyword arguments for :class:`SimilarityConfig`
+        **kwargs: keyword arguments for
+            :class:`fiftyone.brain.similarity.SimilarityConfig`
     """
 
     def __init__(

--- a/fiftyone/brain/internal/core/qdrant.py
+++ b/fiftyone/brain/internal/core/qdrant.py
@@ -36,13 +36,6 @@ class QdrantSimilarityConfig(SimilarityConfig):
     """Configuration for the Qdrant similarity backend.
 
     Args:
-        embeddings_field (None): the sample field containing the embeddings,
-            if one was provided
-        model (None): the :class:`fiftyone.core.models.Model` or name of the
-            zoo model that was used to compute embeddings, if known
-        patches_field (None): the sample field defining the patches being
-            analyzed, if any
-        supports_prompts (None): whether this run supports prompt queries
         collection_name (None): the name of a Qdrant collection to use or
             create. If none is provided, a new collection will be created
         metric (None): the embedding distance metric to use when creating a
@@ -64,14 +57,11 @@ class QdrantSimilarityConfig(SimilarityConfig):
         api_key (None): a Qdrant API key to use
         grpc_port (None): Port of Qdrant gRPC interface
         prefer_grpc (None): If `true`, use gRPC interface when possible
+        **kwargs: keyword arguments for :class:`SimilarityConfig`
     """
 
     def __init__(
         self,
-        embeddings_field=None,
-        model=None,
-        patches_field=None,
-        supports_prompts=None,
         collection_name=None,
         metric=None,
         replication_factor=None,
@@ -92,13 +82,7 @@ class QdrantSimilarityConfig(SimilarityConfig):
                 % (metric, tuple(_SUPPORTED_METRICS.keys()))
             )
 
-        super().__init__(
-            embeddings_field=embeddings_field,
-            model=model,
-            patches_field=patches_field,
-            supports_prompts=supports_prompts,
-            **kwargs,
-        )
+        super().__init__(**kwargs)
 
         self.collection_name = collection_name
         self.metric = metric

--- a/fiftyone/brain/internal/core/redis.py
+++ b/fiftyone/brain/internal/core/redis.py
@@ -35,13 +35,6 @@ class RedisSimilarityConfig(SimilarityConfig):
     """Configuration for the Redis similarity backend.
 
     Args:
-        embeddings_field (None): the sample field containing the embeddings,
-            if one was provided
-        model (None): the :class:`fiftyone.core.models.Model` or name of the
-            zoo model that was used to compute embeddings, if known
-        patches_field (None): the sample field defining the patches being
-            analyzed, if any
-        supports_prompts (None): whether this run supports prompt queries
         index_name (None): the name of a Redis index to use or create. If none
             is provided, a new index will be created
         metric ("cosine"): the embedding distance metric to use when creating a
@@ -54,14 +47,11 @@ class RedisSimilarityConfig(SimilarityConfig):
         db (0): the database to use
         username (None): a username to use
         password (None): a password to use
+        **kwargs: keyword arguments for :class:`SimilarityConfig`
     """
 
     def __init__(
         self,
-        embeddings_field=None,
-        model=None,
-        patches_field=None,
-        supports_prompts=None,
         index_name=None,
         metric="cosine",
         algorithm="FLAT",
@@ -78,13 +68,7 @@ class RedisSimilarityConfig(SimilarityConfig):
                 % (metric, tuple(_SUPPORTED_METRICS.keys()))
             )
 
-        super().__init__(
-            embeddings_field=embeddings_field,
-            model=model,
-            patches_field=patches_field,
-            supports_prompts=supports_prompts,
-            **kwargs,
-        )
+        super().__init__(**kwargs)
 
         self.index_name = index_name
         self.metric = metric

--- a/fiftyone/brain/internal/core/redis.py
+++ b/fiftyone/brain/internal/core/redis.py
@@ -47,7 +47,8 @@ class RedisSimilarityConfig(SimilarityConfig):
         db (0): the database to use
         username (None): a username to use
         password (None): a password to use
-        **kwargs: keyword arguments for :class:`SimilarityConfig`
+        **kwargs: keyword arguments for
+            :class:`fiftyone.brain.similarity.SimilarityConfig`
     """
 
     def __init__(

--- a/fiftyone/brain/internal/core/representativeness.py
+++ b/fiftyone/brain/internal/core/representativeness.py
@@ -63,7 +63,7 @@ def compute_representativeness(
     # ranking and points on the outliers with low ranking.
     #
 
-    fov.validate_image_collection(samples)
+    fov.validate_collection(samples)
 
     if roi_field is not None:
         fov.validate_collection_label_fields(

--- a/fiftyone/brain/internal/core/sklearn.py
+++ b/fiftyone/brain/internal/core/sklearn.py
@@ -42,7 +42,8 @@ class SklearnSimilarityConfig(SimilarityConfig):
     Args:
         metric ("cosine"): the embedding distance metric to use. See
             ``sklearn.metrics.pairwise_distance`` for supported values
-        **kwargs: keyword arguments for :class:`SimilarityConfig`
+        **kwargs: keyword arguments for
+            :class:`fiftyone.brain.similarity.SimilarityConfig`
     """
 
     def __init__(self, metric="cosine", **kwargs):

--- a/fiftyone/brain/internal/core/sklearn.py
+++ b/fiftyone/brain/internal/core/sklearn.py
@@ -40,33 +40,13 @@ class SklearnSimilarityConfig(SimilarityConfig):
     """Configuration for the sklearn similarity backend.
 
     Args:
-        embeddings_field (None): the sample field containing the embeddings,
-            if one was provided
-        model (None): the :class:`fiftyone.core.models.Model` or name of the
-            zoo model that was used to compute embeddings, if known
-        patches_field (None): the sample field defining the patches being
-            analyzed, if any
-        supports_prompts (None): whether this run supports prompt queries
         metric ("cosine"): the embedding distance metric to use. See
             ``sklearn.metrics.pairwise_distance`` for supported values
+        **kwargs: keyword arguments for :class:`SimilarityConfig`
     """
 
-    def __init__(
-        self,
-        embeddings_field=None,
-        model=None,
-        patches_field=None,
-        supports_prompts=None,
-        metric="cosine",
-        **kwargs,
-    ):
-        super().__init__(
-            embeddings_field=embeddings_field,
-            model=model,
-            patches_field=patches_field,
-            supports_prompts=supports_prompts,
-            **kwargs,
-        )
+    def __init__(self, metric="cosine", **kwargs):
+        super().__init__(**kwargs)
         self.metric = metric
 
     @property

--- a/fiftyone/brain/internal/core/uniqueness.py
+++ b/fiftyone/brain/internal/core/uniqueness.py
@@ -64,7 +64,7 @@ def compute_uniqueness(
     # to dense clusters of related samples.
     #
 
-    fov.validate_image_collection(samples)
+    fov.validate_collection(samples)
 
     if roi_field is not None:
         fov.validate_collection_label_fields(

--- a/fiftyone/brain/internal/core/utils.py
+++ b/fiftyone/brain/internal/core/utils.py
@@ -835,7 +835,18 @@ def get_embeddings(
     return embeddings, sample_ids, label_ids
 
 
-def get_unique_name(name, ref_names_or_fcn):
+def get_unique_name(name, ref_names_or_fcn, max_len=None):
+    unique_name = _get_unique_name(name, ref_names_or_fcn)
+
+    if max_len is not None:
+        while name and len(unique_name) > max_len:
+            name = name[:-1]
+            unique_name = _get_unique_name(name, ref_names_or_fcn)
+
+    return unique_name
+
+
+def _get_unique_name(name, ref_names_or_fcn):
     if etau.is_container(ref_names_or_fcn):
         return _get_unique_name_from_list(name, ref_names_or_fcn)
 

--- a/tests/intensive/test_similarity.py
+++ b/tests/intensive/test_similarity.py
@@ -4,7 +4,7 @@ Similarity tests.
 Usage::
 
     # Optional: specific backends to test
-    export SIMILARITY_BACKENDS=qdrant,pinecone,milvus,lancedb,redis
+    export SIMILARITY_BACKENDS=qdrant,pinecone,milvus,lancedb,redis,elasticsearch
 
     pytest tests/intensive/test_similarity.py -s -k test_XXX
 


### PR DESCRIPTION
## Change log

- Adds a `fob.compute_near_duplicates()` method that provides a use case-centric interface to the existing `DuplicatesMixin.find_duplicates()` method
- Also adds `roi_field` arguments to `compute_similarity()` and `compute_leaky_splits()` for consistency with `compute_uniqueness()` and `compute_representativeness()`

## Example near duplicates usage

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz

# Load some COCO data
dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    max_samples=1000,
    persistent=True,
)

# Compute embeddings
model = foz.load_zoo_model("mobilenet-v2-imagenet-torch")
dataset.compute_embeddings(model, embeddings_field="embeddings")

# Find near duplicates
index = fob.compute_near_duplicates(dataset, embeddings="embeddings")

print(index.thresh)  # 0.2
print(index.duplicate_ids)  # ['XXXX', ...]

duplicates = index.duplicates_view()

session = fo.launch_app(duplicates)
```

## Example `roi_field` usage

### Setup

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz
import fiftyone.utils.random as four

dataset = foz.load_zoo_dataset("quickstart")

# model = foz.load_zoo_model("mobilenet-v2-imagenet-torch")
# dataset.compute_patch_embeddings(model, "ground_truth", embeddings_field="embeddings")
```

###  Similarity w/ ROI

```py
index = fob.compute_similarity(
    dataset[:100],
    roi_field="ground_truth",
    # embeddings="embeddings",
)

print(index.total_index_size)  # 100

embeddings, sample_ids, _ = index.compute_embeddings(dataset[100:])
index.add_to_index(embeddings, sample_ids)

print(index.total_index_size)  # 200
```

### Near duplicates w/ ROI

```py
index = fob.compute_near_duplicates(
    dataset,
    roi_field="ground_truth",
    # embeddings="embeddings",
)

print(index.thresh)  # 0.2
print(index.duplicate_ids)  # ['XXXX', ...]

duplicates = index.duplicates_view()
```

### Leaky splits w/ ROI

```py
dataset.untag_samples(dataset.distinct("tags"))
four.random_split(dataset, {"train": 0.7, "test": 0.3})
index = fob.compute_leaky_splits(
    dataset,
    ["train", "test"],
    roi_field="ground_truth",
    # embeddings="embeddings",
)

print(index.thresh)  # 0.2
print(index.leak_ids)  # ['XXXX', ...]

leaks = index.leaks_view()
```
