### PR TITLE
chore: Update svg to be fiftyone-brain

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <a href="https://slack.voxel51.com">Community</a>
 
 [![PyPI python](https://img.shields.io/pypi/pyversions/fiftyone-brain)](https://pypi.org/project/fiftyone-brain)
-[![PyPI version](https://badge.fury.io/py/fiftyone.svg)](https://pypi.org/project/fiftyone-brain)
+[![PyPI version](https://badge.fury.io/py/fiftyone-brain.svg)](https://pypi.org/project/fiftyone-brain)
 [![Downloads](https://static.pepy.tech/badge/fiftyone-brain)](https://pepy.tech/project/fiftyone-brain)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Slack](https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=white)](https://slack.voxel51.com)


### PR DESCRIPTION
The current README shows the `fiftyone` version under `pypi package` (See below)

![image](https://github.com/user-attachments/assets/46b36158-1ed8-42cb-900c-4741942757d4)

But, we should have it show the `fiftyone-brain` version, not the `fiftyone` version.

<img width="1013" alt="Screenshot 2024-12-17 at 11 36 22 AM" src="https://github.com/user-attachments/assets/0e258460-071c-45db-928e-9a3eefc2956c" />
