### PR TITLE
remove normalize_path to support cloud object storage URIs

### DIFF
--- a/fiftyone/brain/internal/core/lancedb.py
+++ b/fiftyone/brain/internal/core/lancedb.py
@@ -63,7 +63,7 @@ class LanceDBSimilarityConfig(SimilarityConfig):
         self.metric = metric
 
         # store privately so these aren't serialized
-        self._uri = fos.normalize_path(uri)
+        self._uri = uri
 
     @property
     def method(self):


### PR DESCRIPTION
Follow up on [this issue](https://github.com/voxel51/fiftyone-brain/issues/227).

