### PR TITLE
Always register full dataset for similarity indexes

### DIFF
--- a/fiftyone/brain/similarity.py
+++ b/fiftyone/brain/similarity.py
@@ -114,13 +114,18 @@ def compute_similarity(
     brain_method = config.build()
     brain_method.ensure_requirements()
 
+    # Similarity indexes can be modified after creation, so we always register
+    # the index on the full dataset so that queries will always be performed
+    # against the full index by default
+    dataset = samples._root_dataset
+
     if brain_key is not None:
         # Don't allow overwriting an existing run with same key, since we
         # need the existing run in order to perform workflows like
         # automatically cleaning up the backend's index
-        brain_method.register_run(samples, brain_key, overwrite=False)
+        brain_method.register_run(dataset, brain_key, overwrite=False)
 
-    results = brain_method.initialize(samples, brain_key)
+    results = brain_method.initialize(dataset, brain_key)
 
     get_embeddings = embeddings is not False
     if not results.is_external and results.total_index_size > 0:
@@ -160,7 +165,7 @@ def compute_similarity(
     if embeddings is not None:
         results.add_to_index(embeddings, sample_ids, label_ids=label_ids)
 
-    brain_method.save_run_results(samples, brain_key, results)
+    brain_method.save_run_results(dataset, brain_key, results)
 
     return results
 


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone-brain/issues/237.

Similarity indexes can be modified after creation, so for the reasons described in https://github.com/voxel51/fiftyone-brain/issues/237, it is better to always register the index on the full dataset so that queries will always be performed against the full index by default.

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
view = dataset.limit(100)

index = fob.compute_similarity(view, brain_key="img_sim")

assert index.samples is dataset
assert index.total_index_size == 100
```

Note that it is still possible to perform similarity queries on subsets via either of these syntaxes:

```py
matches = view.sort_by_similarity(...)

with index.use_view(view):
    matches = index.sort_by_similarity(...)
```