### PR TITLE
Adding limit to query

### DIFF
--- a/fiftyone/brain/internal/core/redis.py
+++ b/fiftyone/brain/internal/core/redis.py
@@ -550,6 +550,7 @@ class RedisSimilarityIndex(SimilarityIndex):
                 .sort_by("score")
                 .return_fields("score", "foid")
                 .dialect(2)
+                .paging(0, k)
             )
             _q = q.astype(np.float32).tobytes()
             docs = self._index.search(_query, {"query": _q}).docs


### PR DESCRIPTION
Currently Redis backend only returns 10 results - from redis vector search [documentation ](https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/vectors/#search-with-vectors)

> When performing a KNN vector search, you specify <top_k> nearest neighbors. However, the default Redis query LIMIT parameter (used for pagination) is 10. In order to get <top_k> returned results, you must also specify LIMIT 0 <top_k> in your search command