### PR TITLE
chore: Publish should happen after test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
           pytest --verbose tests/ --ignore tests/intensive/
 
   publish:
-    needs: [build]
+    needs: [build, test]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
# Rationale

The publishing of the package should happen after successful tests.

## Changes

Adds a `needs: test` entry for `publish`.