### PR TITLE
Release/v0.20.1

### DIFF
--- a/fiftyone/brain/internal/core/utils.py
+++ b/fiftyone/brain/internal/core/utils.py
@@ -690,14 +690,14 @@ def parse_data_field(
         return data_field, data_exists
 
     if data_field.startswith(patches_field + "."):
-        _, root = samples._get_label_field_path(patches_field) + "."
-        if not data_field.startswith(root):
+        _, root = samples._get_label_field_path(patches_field)
+        if not data_field.startswith(root + "."):
             raise ValueError(
                 "Invalid %s field '%s' for patches field '%s'"
                 % (data_type, data_field, patches_field)
             )
 
-        data_field = data_field[len(root) + 1]
+        data_field = data_field[len(root) + 1 :]
 
     if "." in data_field:
         _, root = samples._get_label_field_path(patches_field)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import os
 from setuptools import setup
 
 
-VERSION = "0.20.0"
+VERSION = "0.20.1"
 
 
 def get_version():


### PR DESCRIPTION
Fixes a bug in Option 2 below.

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=10)

fob.compute_visualization(
    dataset,
    model="clip-vit-base32-torch",
    patches_field="ground_truth",
    embeddings="patch_emb",
    brain_key="test_patches_viz",
)

# Option 1 (worked before and now)
index1 = fob.compute_similarity(
    dataset,
    patches_field="ground_truth",
    embeddings_field="patch_emb",
    brain_key="test_patches_sim1",
)
assert index1.total_index_size > 0

# Option 2 (previously raised an error; now succeeds)
index2 = fob.compute_similarity(
    dataset,
    patches_field="ground_truth",
    embeddings_field="ground_truth.detections.patch_emb",
    brain_key="test_patches_sim2",
)
assert index2.total_index_size > 0
```
