### PR TITLE
Add support for MongoDB similarity queries on filtered views

### DIFF
--- a/fiftyone/brain/internal/core/mongodb.py
+++ b/fiftyone/brain/internal/core/mongodb.py
@@ -265,7 +265,11 @@ class MongoDBSimilarityIndex(SimilarityIndex):
                 "numDimensions": dimension,
                 "path": self.config.embeddings_field,
                 "similarity": metric,
-            }
+            },
+            {
+                "type": "filter",
+                "path": "_id",
+            },
         ]
 
         """
@@ -559,17 +563,9 @@ class MongoDBSimilarityIndex(SimilarityIndex):
             query = [query]
 
         if self.has_view:
-            # https://www.mongodb.com/community/forums/t/258494
-            logger.warning(
-                "The MongoDB backend does not yet support views; the full "
-                "index will instead be queried, which may result in fewer "
-                "matches in your current view"
-            )
-            index_ids = None
+            index_ids = self.current_sample_ids
             # if self.config.patches_field is not None:
             #     index_ids = self.current_label_ids
-            # else:
-            #     index_ids = self.current_sample_ids
         else:
             index_ids = None
 
@@ -612,9 +608,23 @@ class MongoDBSimilarityIndex(SimilarityIndex):
 
             # https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-stage
             pipeline = [{"$vectorSearch": search}, {"$project": project}]
-            matches = list(
-                dataset._aggregate(pipeline=pipeline, manual_group_select=True)
-            )
+
+            try:
+                matches = list(
+                    dataset._aggregate(
+                        pipeline=pipeline, manual_group_select=True
+                    )
+                )
+            except OperationFailure as e:
+                if index_ids is not None:
+                    raise OperationFailure(
+                        "This legacy search index does not yet support views. "
+                        "Please follow the instructions at "
+                        "https://github.com/voxel51/fiftyone-brain/pull/248 "
+                        "to upgrade it"
+                    ) from e
+                else:
+                    raise e
 
             sample_ids.append([str(m["_id"]) for m in matches])
             # if self.config.patches_field is not None:


### PR DESCRIPTION
## Change log

Updates the [MongoDB similarity backend](https://docs.voxel51.com/integrations/mongodb.html) to support similarity queries on filtered views

```py
fob.compute_similarity(dataset, ..., backend="mongodb")

view = dataset.add_stage(...)

# Previously this would raise a warning about limited functionality, but now is fully supported
view.sort_by_similarity(...)
```

We could not originally support this, but MongoDB recently added [support for ObjectID filters on search indexes](https://www.mongodb.com/docs/atlas/atlas-search/field-types/object-id-type/#define-the-index-for-the-fts-field-type-type), so now we can! 🎉 

## Upgrading an existing MongoDB similarity index

If you created a MongoDB similarity index with `fiftyone<1.5` or `FiftyOne Enterprise < 2.8`, then you will see the following error when performing a similarity query on a filtered view with this existing index when running newer FiftyOne versions:

```py
view.sort_by_similarity(...)
```

```
OperationFailure: PlanExecutor error during aggregation :: caused by :: Path '_id' needs to be indexed as objectId...
The above exception was the direct cause of the following exception:
OperationFailure: This legacy search index does not yet support views. Please follow the instructions at https://github.com/voxel51/fiftyone-brain/pull/248 to upgrade it
```

You can rectify this in either of the following ways:

### Option 1: Patch your existing search index in-place

Run the following method on your dataset to patch the existing search index in-place:

```py
add_id_filter_to_mongodb_search_index(dataset, brain_key)
```

```py
def add_id_filter_to_mongodb_search_index(dataset, brain_key):
    coll = dataset._sample_collection
    info = dataset.get_brain_info(brain_key)
    index_name = info.config.index_name

    found_index = False
    patched_index = False
    for index in coll.list_search_indexes():
        if index["name"] == index_name:
            found_index = True
            definition = index["latestDefinition"]

            found_id_filter = False
            for field in definition["fields"]:
                found_id_filter |= field.get("path", None) == "_id"

            if not found_id_filter:
                print(f"Adding '_id' filter to search index '{index_name}'")
                definition["fields"].append({"type": "filter", "path": "_id"})
                coll.update_search_index(index_name, definition)
                patched_index = True

    if not found_index:
        print(f"Search index '{index_name}' does not exist")
    elif not patched_index:
        print(f"Search index '{index_name}' already contains '_id' filter")
```

### Option 2: Delete and recreate the index

```py
# Delete the old search index
# This does *not* delete the embeddings from your samples; you can reuse those below
index = dataset.load_brain_results(brain_key)
index.cleanup()

# Delete the old similarity index's record
dataset.delete_brain_run(brain_key)

# Now recreate the index
fob.compute_similarity(
    ...,
    brain_key=brain_key,
    embeddings="...",  # reuse existing embeddings
    backend="mongodb",
)
```

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.brain as fob

dataset = foz.load_zoo_dataset("quickstart", max_samples=10)

index = fob.compute_similarity(
    dataset,
    model="clip-vit-base32-torch",
    brain_key="img_sim",
    backend="mongodb",
    embeddings="embeddings",
)

# Full index query
view = dataset.sort_by_similarity(dataset.first().id, k=5)

# Filtered view query
subset = dataset.take(7)
view = subset.sort_by_similarity(dataset.first().id, k=5)

# Another syntax for the same filtered view query
with index.use_view(subset):
    view = index.sort_by_similarity(dataset.first().id, k=5)
```
