### PR TITLE
Fix `compute_uniqueness()` with custom `similarity_index` 

### DIFF
--- a/fiftyone/brain/internal/core/uniqueness.py
+++ b/fiftyone/brain/internal/core/uniqueness.py
@@ -171,7 +171,7 @@ def _compute_uniqueness(
         dists = []
         with fou.ProgressBar(total=num_embeddings, progress=progress) as pb:
             for _embeddings in fou.iter_slices(embeddings, batch_size):
-                _, _dists = similarity_index._kneighbors(
+                _, _, _dists = similarity_index._kneighbors(
                     query=_embeddings, k=K + 1, return_dists=True
                 )
                 dists.extend(_dists)


### PR DESCRIPTION
Fixes a syntax bug introduced in `fiftyone-brain==0.21.0` when passing a custom non-sklearn `similarity_index` to `compute_uniqueness()`:

```py
index = fob.compute_similarity(..., backend="<not-sklearn>")
fob.compute_uniqueness(..., similarity_index=index)
```
