### PR TITLE
Optimize filter_ids

### DIFF
--- a/fiftyone/brain/internal/core/utils.py
+++ b/fiftyone/brain/internal/core/utils.py
@@ -234,9 +234,14 @@ def filter_ids(
 
     if patches_field is None:
         if samples._is_patches:
-            sample_ids = np.array(samples.values("sample_id"))
+            sample_ids = np.array(
+                samples.values("sample_id", _enforce_natural_order=False),
+                copy=False,
+            )
         else:
-            sample_ids = np.array(samples.values("id"))
+            sample_ids = np.array(
+                samples.values("id", _enforce_natural_order=False), copy=False
+            )
 
         if index_sample_ids is None:
             return sample_ids, None, None, None


### PR DESCRIPTION
Optimize call to get sample_ids by forcing `values()` to use the index if possible and also avoid copying into a new array.

```
import fiftyone as fo
ds=fo.load_dataset('places')
res=ds.load_brain_results('viz')
len(res.sample_ids). # 2168412

# (note all caching is disabled for these runs)
# current time:
7min 12s ± 8.56 s per loop (mean ± std. dev. of 7 runs, 1 loop each)

# after this change:
53 s ± 2.87 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

If you enable pymongo.command debug logs, you can see the significant different in query execution times: 
```
# current:
{
 'message': 'Command succeeded',
 'durationMS': 50653.55,
 'reply': '{"cursor": {"nextBatch": [{"_id": {"$oid": "67b92f9a0eff73f0a1abc480"}, "value0": "67b92f9a0eff73f0a1abc480"}, {"_id": {"$oid": "67b92f9a0eff73f0a1abc484"}, "value0": "67b92f9a0eff73f0a1abc484"}, {"_id": {"$oid": "67b92f9a0eff73f0a1abc486"}, "value0": "67b92f9a0eff73f0a1abc486"}, {"_id": {"$oid": "67b92f9a0eff73f0a1abc487"}, "value0": "67b92f9a0eff73f0a1abc487"}, {"_id": {"$oid": "67b92f9a0eff73f0a1abc488"}, "value0": "67b92f9a0eff73f0a1abc488"}, {"_id": {"$oid": "67b92f9a0eff73f0a1abc48a"}, "value0": "67b92f9a0eff73f0a1abc48a"}, {"_id": {"$oid": "67b92f9a0eff73f0a1abc489"}, "value0": "67b92f9a0eff73f0a1abc489"}, {"_id": {"$oid": "67b92f9a0eff73f0a1abc48b"}, "value0": "67b92f9a0eff73f0a1abc48b"}, {"_id": {"$oid": "67b92f9a0eff73f0a1abc485"}, "value0": "67b92f9a0eff73f0a1abc485"}, {"_id": {"$oid": "67b92f9a0eff73f0a1abc48c"}, "value0": "67b92f9a0eff73f0a1abc48c"}, {"_id": {"$oid": "67b92f9a0eff73f0a1abc48d"}, "value0": "67b92f9a0eff73f0a1abc48d"}, {"_id": {"$oid": "67b92f9a0eff73f0a1abc...',
 'commandName': 'getMore',
 'databaseName': 'kacey-ephem',
 'driverConnectionId': 3,
 'serverHost': 'mongodb.fiftyone.ai',
 'serverPort': 27017}


# using index
{
 'message': 'Command succeeded',
 'durationMS': 2951.7090000000003,
 'reply': '{"cursor": {"nextBatch": [{"_id": {"$oid": "67b92f300eff73f0a1a6b7ef"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b7f0"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b7f1"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b7f2"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b7f3"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b7f4"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b7f5"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b7f6"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b7f7"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b7f8"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b7f9"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b7fa"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b7fb"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b7fc"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b7fd"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b7fe"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b7ff"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b800"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b801"}}, {"_id": {"$oid": "67b92f300eff73f0a1a6b802"}}, {"_id": {"$oid": "67b92f300eff73f0...',
 'commandName': 'getMore',
 'databaseName': 'kacey-ephem',
 'driverConnectionId': 3,
 'serverHost': 'mongodb.fiftyone.ai',
 'serverPort': 27017}
