### PR TITLE
Updating similarity computation when sample_collection is a frames collection

### DIFF
--- a/fiftyone/brain/similarity.py
+++ b/fiftyone/brain/similarity.py
@@ -123,7 +123,7 @@ def compute_similarity(
     # against the full index by default
     dataset = samples._root_dataset
     if samples._is_frames:
-        dataset = samples
+        dataset = samples._base_view
 
     if brain_key is not None:
         # Don't allow overwriting an existing run with same key, since we

--- a/fiftyone/brain/similarity.py
+++ b/fiftyone/brain/similarity.py
@@ -122,6 +122,8 @@ def compute_similarity(
     # the index on the full dataset so that queries will always be performed
     # against the full index by default
     dataset = samples._root_dataset
+    if samples._is_frames:
+        dataset = samples
 
     if brain_key is not None:
         # Don't allow overwriting an existing run with same key, since we


### PR DESCRIPTION
Currently this does not work - specifically when `compute_similarity` is called on a frames collection with `embeddings` field name passed in -

```py
import fiftyone as fo
import fiftyone.brain as fob

dataset = fo.load_dataset("quickstart-video")
frames_view = dataset.to_frames(sample_frames=True)
dataset.save_view("frames_view", frames_view)

fob.compute_similarity(
    frames_view,
    model = "clip-vit-base32-torch",
    backend="sklearn",
    brain_key="sk_index_1",
    embeddings="clip_embeddings_frames"
)
```

Now open the app (has to be the app so it loads the similarity brain run from scratch) and try to sort by similarity using the plugin/builtin feature -> it errors out with  a ValueError which looks something like -
`ValueError: Query IDs [np.str_('6320b09592917521cba1cbd4')] do not exist in this index`

The fix in this PR addresses this issue