### PR TITLE
build(actions): AS-898 utilizing trusted publisher workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: release # For trusted publishing. See below.
+    permissions:
+      id-token: write
     steps:
       - name: Download wheels
         uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: release # For trusted publishing. See below.
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Download wheels

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,27 +121,16 @@ jobs:
     needs: [build, test]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    environment: release # For trusted publishing. See below.
     steps:
       - name: Download wheels
         uses: actions/download-artifact@v4
         with:
           path: dist
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          pip3 install --upgrade importlib-metadata pip setuptools wheel typing-extensions packaging twine
-      - name: Set environment
-        env:
-          RELEASE_TAG: ${{ github.ref }}
-        run: |
-          echo "TWINE_PASSWORD=${{ secrets.FIFTYONE_PYPI_TOKEN }}" >> $GITHUB_ENV
-          echo "TWINE_REPOSITORY=pypi" >> $GITHUB_ENV
-      - name: Upload to pypi
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_NON_INTERACTIVE: 1
-        run: |
-          python3 -m twine upload dist/artifact/*
+      # Utilize
+      # [trusted publishers](https://docs.pypi.org/trusted-publishers/)
+      # This will use OIDC to publish the dists/ package to pypi.
+      # See
+      # [fiftyone-brain](https://pypi.org/manage/project/fiftyone-brain/settings/publishing/)
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@v1.13.0

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,18 +1,18 @@
 {
-    "overrides": [
-        {
-            "files": "*.md",
-            "options": {
-                "printWidth": 79,
-                "proseWrap": "always",
-                "tabWidth": 4
-            }
-        },
-        {
-            "files": "*.json",
-            "options": {
-                "tabWidth": 4
-            }
-        }
-    ]
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "printWidth": 79,
+        "proseWrap": "always",
+        "tabWidth": 4
+      }
+    },
+    {
+      "files": "*.json",
+      "options": {
+        "tabWidth": 4
+      }
+    }
+  ]
 }

--- a/fiftyone/brain/config.py
+++ b/fiftyone/brain/config.py
@@ -41,7 +41,6 @@ class BrainConfig(EnvConfig):
         "pgvector": {
             "config_cls": "fiftyone.brain.internal.core.pgvector.PgVectorSimilarityConfig",
         },
-
         "mosaic": {
             "config_cls": "fiftyone.brain.internal.core.mosaic.MosaicSimilarityConfig",
         },


### PR DESCRIPTION
Recently, I came across [trusted pypi publishers](https://docs.pypi.org/trusted-publishers/). They utilize OIDC to authenticate with PyPi so that we don't need to keep tokens around for individual users. 

Using short-lived credentials reduces things like attach surface areas and makes maintaining user credentials much easier!

This was tested with a private repository that published to [the PyPi test site](https://test.pypi.org/project/v51-trusted-workflow-package/).

A trusted publisher has also been added to the `fiftyone-brain` project.

Some other changes in this PR came from `black` and `prettier` pre-commit hooks. Nothing functional changed.