### PR TITLE
Make compute_visualization with TSNE compatible with scikit-learn versions 1.7.0+

### DIFF
--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -8,7 +8,6 @@ Visualization interface.
 from copy import deepcopy
 import inspect
 import logging
-import functools
 from tabnanny import verbose
 from packaging import version
 
@@ -1044,18 +1043,13 @@ class TSNEVisualization(Visualization):
         verbose = 2 if self.config.verbose else 0
 
         sklearn_version = version.parse(sklearn.__version__)
-
         iter_param = (
             "max_iter"
             if sklearn_version >= version.parse("1.5.0")
             else "n_iter"
         )
 
-        tsne_partial = functools.partial(
-            skm.TSNE, **{iter_param: self.config.max_iters}
-        )
-
-        _tsne = tsne_partial(
+        _tsne = skm.TSNE(
             n_components=self.config.num_dims,
             perplexity=self.config.perplexity,
             learning_rate=self.config.learning_rate,
@@ -1063,6 +1057,7 @@ class TSNEVisualization(Visualization):
             init="pca",
             random_state=self.config.seed,
             verbose=verbose,
+            **{iter_param: self.config.max_iters}
         )
         return _tsne.fit_transform(embeddings)
 

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -1045,7 +1045,7 @@ class TSNEVisualization(Visualization):
             learning_rate=self.config.learning_rate,
             metric=self.config.metric,
             init="pca",  # "random" or "pca"
-            n_iter=self.config.max_iters,
+            max_iter=self.config.max_iters,
             random_state=self.config.seed,
             verbose=verbose,
         )

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -8,8 +8,12 @@ Visualization interface.
 from copy import deepcopy
 import inspect
 import logging
+import functools
+from tabnanny import verbose
+from packaging import version
 
 import numpy as np
+import sklearn
 import sklearn.decomposition as skd
 import sklearn.manifold as skm
 
@@ -1039,13 +1043,24 @@ class TSNEVisualization(Visualization):
 
         verbose = 2 if self.config.verbose else 0
 
-        _tsne = skm.TSNE(
+        sklearn_version = version.parse(sklearn.__version__)
+
+        iter_param = (
+            "max_iter"
+            if sklearn_version >= version.parse("1.5.0")
+            else "n_iter"
+        )
+
+        tsne_partial = functools.partial(
+            skm.TSNE, **{iter_param: self.config.max_iters}
+        )
+
+        _tsne = tsne_partial(
             n_components=self.config.num_dims,
             perplexity=self.config.perplexity,
             learning_rate=self.config.learning_rate,
             metric=self.config.metric,
-            init="pca",  # "random" or "pca"
-            max_iter=self.config.max_iters,
+            init="pca",
             random_state=self.config.seed,
             verbose=verbose,
         )

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -8,7 +8,6 @@ Visualization interface.
 from copy import deepcopy
 import inspect
 import logging
-from tabnanny import verbose
 from packaging import version
 
 import numpy as np


### PR DESCRIPTION
TL;DR This PR renames 'n_iter' to 'max_iter'


when running  `fob.compute_visualization(ds, method='tsne', brain_key='tsne_test_171') `on scikit-learn version  1.7.1. The following error occurs 

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    fob.compute_visualization(ds, method='tsne', brain_key='tsne_test_sdk_171')
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/siddharthmehta/sid_foe/fot/lib/python3.13/site-packages/fiftyone/brain/__init__.py", line 540, in compute_visualization
    return fbv.compute_visualization(
           ~~~~~~~~~~~~~~~~~~~~~~~~~^
        samples,
        ^^^^^^^^
    ...<17 lines>...
        **kwargs,
        ^^^^^^^^^
    )
    ^
  File "/Users/siddharthmehta/sid_foe/fot/lib/python3.13/site-packages/fiftyone/brain/visualization.py", line 150, in compute_visualization
    points = brain_method.fit(embeddings)
  File "/Users/siddharthmehta/sid_foe/fot/lib/python3.13/site-packages/fiftyone/brain/visualization.py", line 1042, in fit
    _tsne = skm.TSNE(
        n_components=self.config.num_dims,
    ...<6 lines>...
        verbose=verbose,
    )
TypeError: TSNE.__init__() got an unexpected keyword argument 'n_iter'
```
when using an older version of scikit-learn (1.6.1), it works but we get this warning 

`/Users/siddharthmehta/sid_foe/fot/lib/python3.13/site-packages/sklearn/manifold/_t_sne.py:1164: FutureWarning: 'n_iter' was renamed to 'max_iter' in version 1.5 and will be removed in 1.7`


