### PR TITLE
chore(actions): Update old actions and introduce DB

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "14:00"
+      timezone: "UTC"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone fiftyone-brain
-        uses: actions/checkout@v1
+        uses: actions/checkout@v5
         with:
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
       - name: Check Python version
@@ -42,7 +42,7 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
       - name: Upload wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: dist
           retention-days: 1
@@ -63,18 +63,18 @@ jobs:
           - "3.11"
     steps:
       - name: Clone fiftyone-brain
-        uses: actions/checkout@v1
+        uses: actions/checkout@v5
         with:
           submodules: true
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel
       - name: Download fiftyone-brain wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: dist
       - name: Install fiftyone
@@ -127,9 +127,10 @@ jobs:
       id-token: write
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
-          path: dist
+          name: dist
+          path: dist/
       # Utilize
       # [trusted publishers](https://docs.pypi.org/trusted-publishers/)
       # This will use OIDC to publish the dists/ package to pypi.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
           pip install ./dist/*.whl --force-reinstall
       - name: Reinstall fiftyone-brain
         run: |
-          pip install --force-reinstall --no-deps dist/artifact/*.whl
+          pip install --force-reinstall --no-deps dist/*.whl
       - name: Set up ETA credentials
         env:
           FIFTYONE_GOOGLE_CREDENTIALS: ${{ secrets.FIFTYONE_GOOGLE_CREDENTIALS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
       - name: Upload wheel
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v5
         with:
           path: dist
           retention-days: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,8 @@ jobs:
       - name: Upload wheel
         uses: actions/upload-artifact@v5
         with:
-          path: dist
+          name: dist
+          path: dist/
           retention-days: 1
 
   test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,8 @@ jobs:
       - name: Download fiftyone-brain wheel
         uses: actions/download-artifact@v6
         with:
-          path: dist
+          name: dist
+          path: dist/
       - name: Install fiftyone
         run: |
           git clone https://${{ secrets.FIFTYONE_GITHUB_TOKEN }}@github.com/voxel51/fiftyone fiftyone-src --depth 1 --branch develop


### PR DESCRIPTION
Our recent publish actions broke: https://github.com/voxel51/fiftyone-brain/actions/runs/19037425065/job/54365892264. This isn't directly tied to the old versions, but I was basing assumptions off of newer versions.

Let's update some of them and add dependabot. In the meantime, I will manually publish the artifacts with twine.