### PR TITLE
chore(.github): AS-1099 add templates/code-owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+* @voxel51/developers
+
+# Aloha!
+.github/  @voxel51/aloha-shirts
+setup.py  @voxel51/aloha-shirts

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,7 @@
 * @voxel51/developers
 
 # Aloha!
-.github/  @voxel51/aloha-shirts
-setup.py  @voxel51/aloha-shirts
+.github/        @voxel51/aloha-shirts
+pyproject.toml  @voxel51/aloha-shirts
+RELEASING.md    @voxel51/aloha-shirts
+setup.py        @voxel51/aloha-shirts

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+# Rationale
+
+<!-- Explain why you are making this change. Describe the problem. -->
+
+## Changes
+
+<!-- Describe the changes. -->
+
+## Testing
+
+<!-- Describe the way the changes were tested. -->
+
+<!-- Optional Sections:
+
+## Screenshots
+## To Do
+## Notes
+## Related
+
+-->
+
+<!-- Template for collapsed sections
+<details>
+<summary></summary>
+</details>
+-->


### PR DESCRIPTION
We utilize dependabot in other repos to keep our github actions up-to-date and somewhat in sync. This helps us get a consistent look/feel across our actions (as params change between versions). DB was added to this repo recently (https://github.com/voxel51/fiftyone-brain/pull/268).

This PR adds CODEOWNERS and a PR template. These likely aren't going to be used too much, but CODEOWNERS with the dependabot things makes sure that the DB PRs are routed to aloha for review.