### PR TITLE
Redaction method for sensitive media in datasets

### DIFF
--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -988,7 +988,7 @@ def create_redaction(
         label_field: the name of the label field to process. Can be of type
             :class:`fiftyone.core.labels.Detection` or
             :class:`fiftyone.core.labels.Detections`
-        label_classes: a list or a comma-separated string of the label classes to redact, containing sensitive data
+        label_classes: a list of the label classes to redact, containing sensitive data
         redaction_type: the area in which to perform the redaction. Can be one of the following:
             "bounding_box": apply to the bounding box of the label class
             "segmentation_mask": apply to the segmentation mask of the label class
@@ -996,10 +996,9 @@ def create_redaction(
             "mask": mask the sensitive data
             "gaussian_blur": blur the sensitive data using a Gaussian blur
             "stack_blur": blur the sensitive data using a moving stack of colors
-            "pixelate": pixelate the sensitive data region
         redaction_field: the name of the field to store the redaction in.
             If None: the redaction will be stored in a new field with the name
-            "redacted_{label_field}_{label_classes}_{redaction_type}_{redaction_method}"
+            "redacted_{label_field}_{redaction_type}_{redaction_method}"
         force_recreate: whether to force the redaction to be recreated even if it already exists
         create_as_new_sample: whether to create a new sample with the redaction.
             If False: the path to the redacted media will be added

--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -971,7 +971,6 @@ def create_redaction(
     redaction_type="bounding_box",
     redaction_method="gaussian_blur",
     redaction_field=None,
-    force_recreate=False,
     progress=None,
 ):
     """Creates a redacted media file for the specified label classes in the specified label field.
@@ -980,8 +979,7 @@ def create_redaction(
     Replaces the regions (based on the redaction_type = bounding_box/segmentation_mask)
     with a blurred/masked image based on the redaction_method.
 
-    The redacted media is added as a new media field specified by the redaction_field
-    and also added to the tags of the sample for easy filtering.
+    The redacted media is added as a new media field specified by the redaction_field.
 
     Args:
         samples: a :class:`fiftyone.core.collections.SampleCollection`
@@ -999,7 +997,6 @@ def create_redaction(
         redaction_field: the name of the field to store the redaction in.
             If None: the redaction will be stored in a new field with the name
             "redacted_{label_field}_{redaction_type}_{redaction_method}"
-        force_recreate: whether to force the redaction to be recreated even if it already exists
         progress: whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
@@ -1016,6 +1013,5 @@ def create_redaction(
         redaction_type,
         redaction_method,
         redaction_field,
-        force_recreate,
         progress,
     )

--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -972,6 +972,8 @@ def create_redaction(
     redaction_method="gaussian_blur",
     redaction_field=None,
     remote_redacted_media_dir=None,
+    num_workers=None,
+    skip_failures=True,
     progress=None,
 ):
     """Creates a redacted media file for the specified label classes in the specified label field.
@@ -1001,6 +1003,12 @@ def create_redaction(
         remote_redacted_media_dir: the remote directory to store the redacted media in.
             Only available with FiftyOne Teams.
             If None: the redacted media will not be uploaded to the cloud.
+        num_workers (None): the number of worker processes to use when processing
+            samples. If None, uses the default from ``map_samples``. Only applicable
+            if ``map_samples`` supports multiprocessing.
+        skip_failures (True): whether to gracefully continue without raising an
+            error if redaction cannot be performed for a sample. Only applicable
+            if ``map_samples`` supports this parameter.
         progress: whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
@@ -1018,5 +1026,7 @@ def create_redaction(
         redaction_method,
         redaction_field,
         remote_redacted_media_dir,
+        num_workers,
+        skip_failures,
         progress,
     )

--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -1000,13 +1000,6 @@ def create_redaction(
             If None: the redaction will be stored in a new field with the name
             "redacted_{label_field}_{redaction_type}_{redaction_method}"
         force_recreate: whether to force the redaction to be recreated even if it already exists
-        create_as_new_sample: whether to create a new sample with the redaction.
-            If False: the path to the redacted media will be added
-                to the redaction_field of the original sample.
-            If True: a new sample will be created with the redaction;
-                the redaction_field will point to its ID
-                and the new sample's original_sample_id will point to the original sample
-            Note: The redaction_field will be unique function of the label, method & type args
         progress: whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead

--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -970,6 +970,7 @@ def create_redaction(
     label_classes=None,
     redaction_type="bounding_box",
     redaction_method="gaussian_blur",
+    redaction_field=None,
     force_recreate=False,
     create_as_new_sample=False,
     num_workers=None,
@@ -991,7 +992,7 @@ def create_redaction(
             :class:`fiftyone.core.labels.Polylines`,
             :class:`fiftyone.core.labels.Keypoints`, or
             :class:`fiftyone.core.labels.TemporalDetections`
-        label_classes: the comma-separated string of the list of label classes to redact, containing sensitive data
+        label_classes: a list or a comma-separated string of the label classes to redact, containing sensitive data
         redaction_type: the area in which to perform the redaction. Can be one of the following:
             "bounding_box": apply to the bounding box of the label class
             "segmentation_mask": apply to the segmentation mask of the label class
@@ -1000,6 +1001,9 @@ def create_redaction(
             "gaussian_blur": blur the sensitive data using a Gaussian blur
             "stack_blur": blur the sensitive data using a moving stack of colors
             "pixelate": pixelate the sensitive data region
+        redaction_field: the name of the field to store the redaction in.
+            If None: the redaction will be stored in a new field with the name
+            "redacted_{label_field}_{label_classes}_{redaction_type}_{redaction_method}"
         force_recreate: whether to force the redaction to be recreated even if it already exists
         create_as_new_sample: whether to create a new sample with the redaction.
             If False: the path to the redacted media will be added
@@ -1021,6 +1025,7 @@ def create_redaction(
         label_classes,
         redaction_type,
         redaction_method,
+        redaction_field,
         force_recreate,
         create_as_new_sample,
         num_workers,

--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -972,7 +972,6 @@ def create_redaction(
     redaction_method="gaussian_blur",
     redaction_field=None,
     force_recreate=False,
-    num_workers=None,
     progress=None,
 ):
     """Creates a redacted media file for the specified label classes in the specified label field.
@@ -987,10 +986,8 @@ def create_redaction(
     Args:
         samples: a :class:`fiftyone.core.collections.SampleCollection`
         label_field: the name of the label field to process. Can be of type
-            :class:`fiftyone.core.labels.Detections`,
-            :class:`fiftyone.core.labels.Polylines`,
-            :class:`fiftyone.core.labels.Keypoints`, or
-            :class:`fiftyone.core.labels.TemporalDetections`
+            :class:`fiftyone.core.labels.Detection` or
+            :class:`fiftyone.core.labels.Detections`
         label_classes: a list or a comma-separated string of the label classes to redact, containing sensitive data
         redaction_type: the area in which to perform the redaction. Can be one of the following:
             "bounding_box": apply to the bounding box of the label class
@@ -1011,7 +1008,6 @@ def create_redaction(
                 the redaction_field will point to its ID
                 and the new sample's original_sample_id will point to the original sample
             Note: The redaction_field will be unique function of the label, method & type args
-        num_workers: the number of workers to use when performing the redaction
         progress: whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
@@ -1029,6 +1025,5 @@ def create_redaction(
         redaction_method,
         redaction_field,
         force_recreate,
-        num_workers,
         progress,
     )

--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -962,3 +962,67 @@ def compute_leaky_splits(
         skip_failures=skip_failures,
         progress=progress,
     )
+
+
+def create_redaction(
+    samples,
+    label_field=None,
+    label_classes=None,
+    redaction_type="bounding_box",
+    redaction_method="gaussian_blur",
+    force_recreate=False,
+    create_as_new_sample=False,
+    num_workers=None,
+    progress=None,
+):
+    """Creates a redacted media file for the specified label classes in the specified label field.
+
+    TODO: Add detailed docstring describing what redaction does.
+
+    .. note::
+
+        Runs of this method can be referenced later via brain key
+        ``redaction_field``.
+
+    Args:
+        samples: a :class:`fiftyone.core.collections.SampleCollection`
+        label_field: the name of the label field to process. Can be of type
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polylines`,
+            :class:`fiftyone.core.labels.Keypoints`, or
+            :class:`fiftyone.core.labels.TemporalDetections`
+        label_classes: the comma-separated string of the list of label classes to redact, containing sensitive data
+        redaction_type: the area in which to perform the redaction. Can be one of the following:
+            "bounding_box": apply to the bounding box of the label class
+            "segmentation_mask": apply to the segmentation mask of the label class
+        redaction_method: the method to use to perform the redaction. Can be one of the following:
+            "mask": mask the sensitive data
+            "gaussian_blur": blur the sensitive data using a Gaussian blur
+            "stack_blur": blur the sensitive data using a moving stack of colors
+            "pixelate": pixelate the sensitive data region
+        force_recreate: whether to force the redaction to be recreated even if it already exists
+        create_as_new_sample: whether to create a new sample with the redaction.
+            If False: the path to the redacted media will be added
+                to the redaction_field of the original sample.
+            If True: a new sample will be created with the redaction;
+                the redaction_field will point to its ID
+                and the new sample's original_sample_id will point to the original sample
+            Note: The redaction_field will be unique function of the label, method & type args
+        num_workers: the number of workers to use when performing the redaction
+        progress: whether to render a progress bar (True/False), use the
+            default value ``fiftyone.config.show_progress_bars`` (None), or a
+            progress callback function to invoke instead
+    """
+    import fiftyone.brain.internal.core.redaction as fbr
+
+    return fbr.create_redaction(
+        samples,
+        label_field,
+        label_classes,
+        redaction_type,
+        redaction_method,
+        force_recreate,
+        create_as_new_sample,
+        num_workers,
+        progress,
+    )

--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -971,6 +971,7 @@ def create_redaction(
     redaction_type="bounding_box",
     redaction_method="gaussian_blur",
     redaction_field=None,
+    remote_redacted_media_dir=None,
     progress=None,
 ):
     """Creates a redacted media file for the specified label classes in the specified label field.
@@ -997,6 +998,9 @@ def create_redaction(
         redaction_field: the name of the field to store the redaction in.
             If None: the redaction will be stored in a new field with the name
             "redacted_{label_field}_{redaction_type}_{redaction_method}"
+        remote_redacted_media_dir: the remote directory to store the redacted media in.
+            Only available with FiftyOne Teams.
+            If None: the redacted media will not be uploaded to the cloud.
         progress: whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
@@ -1013,5 +1017,6 @@ def create_redaction(
         redaction_type,
         redaction_method,
         redaction_field,
+        remote_redacted_media_dir,
         progress,
     )

--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -976,13 +976,13 @@ def create_redaction(
     progress=None,
 ):
     """Creates a redacted media file for the specified label classes in the specified label field.
+    Requires the label field to already be present in the samples.
 
-    TODO: Add detailed docstring describing what redaction does.
+    Replaces the regions (based on the redaction_type = bounding_box/segmentation_mask)
+    with a blurred/masked image based on the redaction_method.
 
-    .. note::
-
-        Runs of this method can be referenced later via brain key
-        ``redaction_field``.
+    The redacted media is added as a new media field by default,
+    with an option to add it as a new sample.
 
     Args:
         samples: a :class:`fiftyone.core.collections.SampleCollection`

--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -972,7 +972,6 @@ def create_redaction(
     redaction_method="gaussian_blur",
     redaction_field=None,
     force_recreate=False,
-    create_as_new_sample=False,
     num_workers=None,
     progress=None,
 ):
@@ -982,8 +981,8 @@ def create_redaction(
     Replaces the regions (based on the redaction_type = bounding_box/segmentation_mask)
     with a blurred/masked image based on the redaction_method.
 
-    The redacted media is added as a new media field by default,
-    with an option to add it as a new sample.
+    The redacted media is added as a new media field specified by the redaction_field
+    and also added to the tags of the sample for easy filtering.
 
     Args:
         samples: a :class:`fiftyone.core.collections.SampleCollection`
@@ -1016,6 +1015,9 @@ def create_redaction(
         progress: whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
+    Returns:
+        a :class:`fiftyone.brain.redaction.RedactionResults`
+        This has a method generate_redacted_dataset() to generate a new dataset with the redaction.
     """
     import fiftyone.brain.internal.core.redaction as fbr
 
@@ -1027,7 +1029,6 @@ def create_redaction(
         redaction_method,
         redaction_field,
         force_recreate,
-        create_as_new_sample,
         num_workers,
         progress,
     )

--- a/fiftyone/brain/internal/core/redaction.py
+++ b/fiftyone/brain/internal/core/redaction.py
@@ -44,7 +44,6 @@ def create_redaction(
     redaction_method,
     redaction_field,
     force_recreate,
-    create_as_new_sample,
     num_workers,
     progress,
 ):
@@ -69,7 +68,6 @@ def create_redaction(
         redaction_method,
         redaction_field,
         force_recreate,
-        create_as_new_sample,
     )
     brain_key = config.redaction_field
     brain_method = config.build()
@@ -80,8 +78,6 @@ def create_redaction(
     select_fields = [
         label_field,
         brain_key,
-        "original_sample_id",
-        "redacted_sample_ids",
     ]
     select_fields = [
         ff for ff in select_fields if samples.get_field(ff) is not None
@@ -89,7 +85,13 @@ def create_redaction(
     view = samples.select_fields(select_fields)
 
     logger.info("Computing redaction...")
-    for sample in view.iter_samples(progress=progress):
+    redaction_view = view.filter_labels(
+        f"{config.label_field}.detections",
+        F("label").is_in(config.label_classes),
+        only_matches=False,
+    )
+
+    for sample in redaction_view.iter_samples(progress=progress):
         brain_method.process_sample(sample)
         sample.save()
 
@@ -118,7 +120,6 @@ class RedactionConfig(fob.BrainMethodConfig):
         redaction_method,
         redaction_field,
         force_recreate,
-        create_as_new_sample,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -128,7 +129,6 @@ class RedactionConfig(fob.BrainMethodConfig):
         self.redaction_method = redaction_method
         self.redaction_field = redaction_field
         self.force_recreate = force_recreate
-        self.create_as_new_sample = create_as_new_sample
         self.make_redaction_field()
 
     def make_redaction_field(self):
@@ -172,7 +172,6 @@ class Redaction(fob.BrainMethod):
         self.redaction_type = None
         self.redaction_method = None
         self.force_recreate = None
-        self.create_as_new_sample = None
         self.redaction_field = None
         self.processing_frames = False
 
@@ -192,7 +191,6 @@ class Redaction(fob.BrainMethod):
         self.redaction_method = self.config.redaction_method
         self.redaction_field = self.config.redaction_field
         self.force_recreate = self.config.force_recreate
-        self.create_as_new_sample = self.config.create_as_new_sample
         self.processing_frames = samples._is_frame_field(
             self.config.label_field
         )
@@ -202,34 +200,6 @@ class Redaction(fob.BrainMethod):
             sample.filepath,
             rel_output_dir=self.redaction_field,
         )
-        # if self.create_as_new_sample:
-        #     if (
-        #         ("redacted_sample_ids" in sample)
-        #         and (sample["redacted_sample_ids"] is not None)
-        #         and (self.redaction_field in sample["redacted_sample_ids"])
-        #         and (
-        #             os.path.exists(
-        #                 sample._dataset[
-        #                     sample["redacted_sample_ids"][self.redaction_field]
-        #                 ]["filepath"]
-        #             )
-        #         )
-        #     ):
-        #         logger.debug(
-        #             f"Redaction already exists for sample {sample.id} --> {sample['redacted_sample_ids'][self.redaction_field]}"
-        #         )
-        #         if self.force_recreate:
-        #             sample._dataset.delete_sample(
-        #                 sample["redacted_sample_ids"][self.redaction_field]
-        #             )
-        #             sample["redacted_sample_ids"].pop(self.redaction_field)
-        #         else:
-        #             return
-        #     if self.redaction_field in sample.tags:
-        #         logger.debug(
-        #             f"This is a redaction of sample {sample['original_sample_id']}"
-        #         )
-        #         return
 
         if (
             (f"{self.redaction_field}_filepath" in sample)
@@ -255,27 +225,6 @@ class Redaction(fob.BrainMethod):
             )
         else:
             self.redact_file_at(redacted_media_path, sample[self.label_field])
-
-        # if self.create_as_new_sample:
-        #     redacted_sample = sample.copy()
-        #     redacted_sample[self.label_field] = self.filter_detections(
-        #         sample[self.label_field], keep_matching=False
-        #     )
-        #     redacted_sample["filepath"] = redacted_media_path
-        #     if self.redaction_field not in redacted_sample.tags:
-        #         redacted_sample.tags.append(self.redaction_field)
-        #     redacted_sample["original_sample_id"] = sample.id
-        #     logger.debug(
-        #         f"Adding redacted sample at filepath: {redacted_media_path}"
-        #     )
-        #     sample._dataset.add_sample(redacted_sample)
-        #     if ("redacted_sample_ids" not in sample) or (
-        #         sample["redacted_sample_ids"] is None
-        #     ):
-        #         sample["redacted_sample_ids"] = {}
-        #     sample["redacted_sample_ids"][
-        #         self.redaction_field
-        #     ] = redacted_sample.id
 
         # add the redacted filepath to the sample
         if self.redaction_field not in sample.tags:
@@ -314,10 +263,10 @@ class Redaction(fob.BrainMethod):
                 )
             for frame, detections_object in zip(vp, detections_object_list):
                 redacted_image = self._redact_entire_image(frame)
-                redacted_image = self._apply_redaction_to_image(
+                frame = self._apply_redaction_to_image(
                     frame, redacted_image, detections_object
                 )
-                vp.write(redacted_image)
+                vp.write(frame)
         shutil.move(temp_redacted_path, redacted_path)
 
     def _redact_entire_image(self, image):
@@ -342,7 +291,7 @@ class Redaction(fob.BrainMethod):
     def _apply_redaction_to_image(
         self, image, redacted_image, detections_object
     ):
-        for detection in self.filter_detections(detections_object).detections:
+        for detection in detections_object.detections:
             x1, y1, x2, y2 = get_corners_from_bbox(
                 detection.bounding_box, image.shape
             )
@@ -361,53 +310,17 @@ class Redaction(fob.BrainMethod):
                 )
         return image
 
-    def filter_detections(
-        self, detections_object: fol.Detections, keep_matching: bool = True
-    ) -> fol.Detections:
-        """
-        Filters the detections object to keep only the detections that match the redaction labels.
-        Args:
-            detections_object: fol.Detections object
-            keep_matching: bool to keep matching detections (True) or remove matching detections (False)
-        Returns:
-            fo.Detections object
-        """
-        filtered_detections = fo.Detections()
-        if (not hasattr(detections_object, "detections")) or (
-            detections_object.detections is None
-        ):
-            return filtered_detections
-        for detection in detections_object.detections:
-            if keep_matching and (
-                detection.label
-                in self.label_classes  # pylint: disable=unsupported-membership-test
-            ):
-                filtered_detections.detections.append(detection)
-            elif not keep_matching and (
-                detection.label
-                not in self.label_classes  # pylint: disable=unsupported-membership-test
-            ):
-                filtered_detections.detections.append(detection)
-        return filtered_detections
-
     def get_fields(self, samples, brain_key):
         fields = [
             self.label_field,
             f"{brain_key}_filepath",
-            # "original_sample_id",
-            # "redacted_sample_ids",
         ]
-
-        # if samples._is_frame_field(self.label_field):
-        #     fields.append(samples._FRAMES_PREFIX + f"{brain_key}_filepath")
-
         return fields
 
     def cleanup(self, samples, brain_key):
         label_field = self.label_field
 
-        # samples._dataset.delete_sample_fields(brain_key, error_level=1)
-        samples._dataset.delete_sample_fields(
+        samples._dataset.delete_sample_field(
             f"{brain_key}_filepath", error_level=1
         )
 
@@ -454,25 +367,26 @@ class RedactionResults(fob.BrainResults):
 
         select_fields = self.backend.get_fields(self.samples, self.key)
         redacted_view = self.samples.select_fields(select_fields)
+        # exclude detetions of type label_field from the redacted dataset
+        redacted_view = redacted_view.filter_labels(
+            f"{self.backend.label_field}.detections",
+            ~F("label").is_in(self.backend.label_classes),
+            only_matches=False,
+        )
 
         for redacted_sample in redacted_view.iter_samples():
             redacted_sample["filepath"] = redacted_sample[
                 f"{self.key}_filepath"
             ]
-            redacted_sample[
-                self.backend.label_field
-            ] = self.backend.filter_detections(
-                redacted_sample[self.backend.label_field], keep_matching=False
-            )
-
             redacted_sample.tags.append(self.key)
             redacted_dataset.add_sample(redacted_sample)
 
-        redacted_dataset.delete_sample_fields(
+        # remove the redacted field from the redacted dataset
+        redacted_dataset.delete_sample_field(
             f"{self.key}_filepath", error_level=1
         )
-        logger.info(f"Redacted dataset {redacted_dataset.name} created")
 
+        logger.info(f"Redacted dataset {redacted_dataset.name} created")
         return redacted_dataset
 
 

--- a/fiftyone/brain/internal/core/redaction.py
+++ b/fiftyone/brain/internal/core/redaction.py
@@ -12,6 +12,8 @@ from typing import Tuple
 import numpy as np
 import cv2
 
+cv2.setNumThreads(1)
+
 from eta.core.video import VideoProcessor
 
 import fiftyone as fo
@@ -88,7 +90,9 @@ def create_redaction(
         only_matches=True,
     )
 
-    redaction_view.map_samples(brain_method.process_sample_fn, save=True)
+    _ = list(
+        redaction_view.map_samples(brain_method.process_sample_fn, save=True)
+    )
 
     logger.info(f"Adding redacted media field: {redacted_filepath_field}")
     if redacted_filepath_field not in samples.app_config.media_fields:
@@ -96,16 +100,20 @@ def create_redaction(
         samples.save()
 
     # upload the redacted media to the cloud
-    cloud_view = redaction_view.match(F("local_path").exists())
     remote_base_dirs = list(
-        set([os.path.dirname(f) for f in cloud_view.values("filepath")])
+        set(
+            [
+                os.path.dirname(f)
+                for f in redaction_view.values("filepath")
+                if not fos.is_local(f)
+            ]
+        )
     )
     for remote_base_dir in remote_base_dirs:
         fos.ensure_dir(remote_base_dir)
         fos.upload_media(
-            cloud_view.match(F("filepath").contains_str(remote_base_dir)),
-            remote_dir=config.redaction_field,
-            rel_dir=remote_base_dir,
+            redaction_view.match(F("filepath").contains_str(remote_base_dir)),
+            remote_dir=fos.join(remote_base_dir, config.redaction_field),
             media_field=redacted_filepath_field,
             update_filepaths=True,
             cache=False,
@@ -195,9 +203,15 @@ class Redaction(fob.BrainMethod):
         )
         fos.copy_file(local_media_path, redacted_media_path)
         if self.processing_frames:
-            self.redact_video_file_at(redacted_media_path, self.label_field)
+            self.redact_video_file_at(
+                redacted_media_path, sample[self.label_field]
+            )
         else:
-            self.redact_image_file_at(redacted_media_path, self.label_field)
+            self.redact_image_file_at(
+                redacted_media_path, sample[self.label_field]
+            )
+
+        sample[f"{self.redaction_field}_filepath"] = redacted_media_path
 
     def redact_image_file_at(self, redacted_path, detections_object):
         if not detections_object.detections:

--- a/fiftyone/brain/internal/core/redaction.py
+++ b/fiftyone/brain/internal/core/redaction.py
@@ -42,7 +42,6 @@ def create_redaction(
     redaction_type,
     redaction_method,
     redaction_field,
-    force_recreate,
     progress,
 ):
     """See ``fiftyone/brain/__init__.py``."""
@@ -65,7 +64,6 @@ def create_redaction(
         redaction_type,
         redaction_method,
         redaction_field,
-        force_recreate,
     )
     brain_key = config.redaction_field
     brain_method = config.build()
@@ -78,7 +76,6 @@ def create_redaction(
         samples._dataset.add_sample_field(
             redacted_filepath_field, fof.StringField
         )
-
     select_fields = [label_field, "filepath", redacted_filepath_field]
     view = samples.select_fields(select_fields)
 
@@ -90,14 +87,10 @@ def create_redaction(
         F("label").is_in(config.label_classes),
         only_matches=True,
     )
-    detections_object_list = redaction_view.values(config.label_field)
 
-    # TODO(neeraja): use set_values()
-    for sample, sample_detections in zip(
-        redaction_view.iter_samples(progress=progress), detections_object_list
-    ):
-        brain_method.process_sample(sample, sample_detections)
-        sample.save()
+    redaction_view.map_samples(
+        brain_method.process_sample_fn,
+    )
 
     logger.info(f"Adding redacted media field: {brain_key}_filepath")
     if f"{brain_key}_filepath" not in samples.app_config.media_fields:
@@ -119,7 +112,6 @@ class RedactionConfig(fob.BrainMethodConfig):
         redaction_type,
         redaction_method,
         redaction_field,
-        force_recreate,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -128,7 +120,6 @@ class RedactionConfig(fob.BrainMethodConfig):
         self.redaction_type = redaction_type
         self.redaction_method = redaction_method
         self.redaction_field = redaction_field
-        self.force_recreate = force_recreate
         self.validate_label_classes()
         self.make_redaction_field()
 
@@ -166,7 +157,6 @@ class Redaction(fob.BrainMethod):
         self.redaction_type = self.config.redaction_type
         self.redaction_method = self.config.redaction_method
         self.redaction_field = self.config.redaction_field
-        self.force_recreate = self.config.force_recreate
         self.processing_frames = False
 
     def ensure_requirements(self):
@@ -174,44 +164,20 @@ class Redaction(fob.BrainMethod):
 
     def register_samples(self, samples):
         _, self.processing_frames = samples._handle_frame_field(
-            self.config.label_field
+            self.label_field
         )
-        self.label_type = samples._get_label_field_type(
-            self.config.label_field
-        )
+        self.label_type = samples._get_label_field_type(self.label_field)
 
-    def process_sample(self, sample, sample_detections):
+    def process_sample_fn(self, sample):
         redacted_media_path = _get_outpath(
             sample.filepath,
             rel_output_dir=self.redaction_field,
         )
-
-        if (
-            (f"{self.redaction_field}_filepath" in sample)
-            and (sample[f"{self.redaction_field}_filepath"] is not None)
-            and (fos.exists(sample[f"{self.redaction_field}_filepath"]))
-        ):
-            logger.debug(f"Redaction already exists for sample {sample.id}")
-            if self.force_recreate:
-                sample[f"{self.redaction_field}_filepath"] = None
-                sample.tags.remove(self.redaction_field)
-            else:
-                return
-
         fos.copy_file(sample.filepath, redacted_media_path)
-
         if self.processing_frames:
-            self.redact_video_file_at(redacted_media_path, sample_detections)
+            self.redact_video_file_at(redacted_media_path, self.label_field)
         else:
-            self.redact_image_file_at(redacted_media_path, sample_detections)
-
-        # add the redacted filepath to the sample
-        if self.redaction_field not in sample.tags:
-            sample.tags.append(self.redaction_field)
-        sample[f"{self.redaction_field}_filepath"] = redacted_media_path
-
-        sample.save()
-        return
+            self.redact_image_file_at(redacted_media_path, self.label_field)
 
     def redact_image_file_at(self, redacted_path, detections_object):
         if not detections_object.detections:
@@ -302,13 +268,13 @@ class Redaction(fob.BrainMethod):
 
     def get_fields(self, brain_key):
         fields = [
-            self.config.label_field,
+            self.label_field,
             f"{brain_key}_filepath",
         ]
         return fields
 
     def cleanup(self, samples, brain_key):
-        label_field = self.config.label_field
+        label_field = self.label_field
 
         samples._dataset.delete_sample_field(
             f"{brain_key}_filepath", error_level=1

--- a/fiftyone/brain/internal/core/redaction.py
+++ b/fiftyone/brain/internal/core/redaction.py
@@ -12,20 +12,23 @@ from typing import Tuple
 import numpy as np
 import cv2
 
+# from eta.core.video import VideoProcessor
+
 import fiftyone as fo
 import fiftyone.core.storage as fos
 import fiftyone.core.brain as fob
 import fiftyone.core.labels as fol
 import fiftyone.core.validation as fov
+from fiftyone import ViewField as F
 
 
 logger = logging.getLogger(__name__)
 
 
 _ALLOWED_TYPES = (
+    fol.Detection,
     fol.Detections,
-    fol.Polylines,
-    fol.Keypoints,
+    fol.TemporalDetection,
     fol.TemporalDetections,
 )
 
@@ -39,6 +42,7 @@ def create_redaction(
     label_classes,
     redaction_type,
     redaction_method,
+    redaction_field,
     force_recreate,
     create_as_new_sample,
     num_workers,
@@ -63,6 +67,7 @@ def create_redaction(
         label_classes,
         redaction_type,
         redaction_method,
+        redaction_field,
         force_recreate,
         create_as_new_sample,
     )
@@ -84,25 +89,21 @@ def create_redaction(
     view = samples.select_fields(select_fields)
 
     logger.info("Computing redaction...")
-    view._dataset.persistent = True
     for sample in view.iter_samples(progress=progress):
         brain_method.process_sample(sample)
         sample.save()
 
-    if not create_as_new_sample:
-        logger.info(f"Adding redacted media field: {brain_key}_filepath")
-        if (
-            f"{brain_key}_filepath"
-            not in view._dataset.app_config.media_fields
-        ):
-            view._dataset.app_config.media_fields.append(
-                f"{brain_key}_filepath"
-            )
+    logger.info(f"Adding redacted media field: {brain_key}_filepath")
+    if f"{brain_key}_filepath" not in view._dataset.app_config.media_fields:
+        view._dataset.app_config.media_fields.append(f"{brain_key}_filepath")
 
     view._dataset.save()
-    brain_method.save_run_results(samples, brain_key, None)
+
+    results = RedactionResults(samples, config, brain_key, brain_method)
+    brain_method.save_run_results(samples, brain_key, results)
 
     logger.info("Redaction computation complete")
+    return results
 
 
 # @todo move to `fiftyone/brain/redaction.py`
@@ -115,6 +116,7 @@ class RedactionConfig(fob.BrainMethodConfig):
         label_classes,
         redaction_type,
         redaction_method,
+        redaction_field,
         force_recreate,
         create_as_new_sample,
         **kwargs,
@@ -124,9 +126,9 @@ class RedactionConfig(fob.BrainMethodConfig):
         self.label_classes = label_classes
         self.redaction_type = redaction_type
         self.redaction_method = redaction_method
+        self.redaction_field = redaction_field
         self.force_recreate = force_recreate
         self.create_as_new_sample = create_as_new_sample
-        self.redaction_field = None
         self.make_redaction_field()
 
     def make_redaction_field(self):
@@ -139,14 +141,18 @@ class RedactionConfig(fob.BrainMethodConfig):
             ]
         else:
             try:
-                self.label_classes = list(self.label_classes)
+                self.label_classes = list(map(str, self.label_classes))
             except:
                 raise ValueError(
                     f"Invalid label classes type: {type(self.label_classes)}"
                 )
         redaction_labels = "_".join(self.label_classes)
-        redaction_field = f"redacted_{self.label_field.replace('.', '_')}_{redaction_labels}_{self.redaction_type}_{self.redaction_method}"
-        self.redaction_field = redaction_field
+        redaction_field_string = f"redacted_{self.label_field.replace('.', '_')}_{redaction_labels}_{self.redaction_type}_{self.redaction_method}"
+        self.redaction_field = (
+            redaction_field_string
+            if self.redaction_field is None
+            else self.redaction_field
+        )
 
     @property
     def type(self):
@@ -196,50 +202,46 @@ class Redaction(fob.BrainMethod):
             sample.filepath,
             rel_output_dir=self.redaction_field,
         )
-        if self.create_as_new_sample:
-            if (
-                ("redacted_sample_ids" in sample)
-                and (sample["redacted_sample_ids"] is not None)
-                and (self.redaction_field in sample["redacted_sample_ids"])
-                and (
-                    os.path.exists(
-                        sample._dataset[
-                            sample["redacted_sample_ids"][self.redaction_field]
-                        ]["filepath"]
-                    )
-                )
-            ):
-                logger.debug(
-                    f"Redaction already exists for sample {sample.id} --> {sample['redacted_sample_ids'][self.redaction_field]}"
-                )
-                if self.force_recreate:
-                    sample._dataset.delete_sample(
-                        sample["redacted_sample_ids"][self.redaction_field]
-                    )
-                    sample["redacted_sample_ids"].pop(self.redaction_field)
-                else:
-                    return
-            if self.redaction_field in sample.tags:
-                logger.debug(
-                    f"This is a redaction of sample {sample['original_sample_id']}"
-                )
+        # if self.create_as_new_sample:
+        #     if (
+        #         ("redacted_sample_ids" in sample)
+        #         and (sample["redacted_sample_ids"] is not None)
+        #         and (self.redaction_field in sample["redacted_sample_ids"])
+        #         and (
+        #             os.path.exists(
+        #                 sample._dataset[
+        #                     sample["redacted_sample_ids"][self.redaction_field]
+        #                 ]["filepath"]
+        #             )
+        #         )
+        #     ):
+        #         logger.debug(
+        #             f"Redaction already exists for sample {sample.id} --> {sample['redacted_sample_ids'][self.redaction_field]}"
+        #         )
+        #         if self.force_recreate:
+        #             sample._dataset.delete_sample(
+        #                 sample["redacted_sample_ids"][self.redaction_field]
+        #             )
+        #             sample["redacted_sample_ids"].pop(self.redaction_field)
+        #         else:
+        #             return
+        #     if self.redaction_field in sample.tags:
+        #         logger.debug(
+        #             f"This is a redaction of sample {sample['original_sample_id']}"
+        #         )
+        #         return
+
+        if (
+            (f"{self.redaction_field}_filepath" in sample)
+            and (sample[f"{self.redaction_field}_filepath"] is not None)
+            and (os.path.exists(sample[f"{self.redaction_field}_filepath"]))
+        ):
+            logger.debug(f"Redaction already exists for sample {sample.id}")
+            if self.force_recreate:
+                sample[f"{self.redaction_field}_filepath"] = None
+                sample.tags.remove(self.redaction_field)
+            else:
                 return
-        else:
-            if (
-                (f"{self.redaction_field}_filepath" in sample)
-                and (sample[f"{self.redaction_field}_filepath"] is not None)
-                and (
-                    os.path.exists(sample[f"{self.redaction_field}_filepath"])
-                )
-            ):
-                logger.debug(
-                    f"Redaction already exists for sample {sample.id}"
-                )
-                if self.force_recreate:
-                    sample[f"{self.redaction_field}_filepath"] = None
-                    sample.tags.remove(self.redaction_field)
-                else:
-                    return
 
         shutil.copy(sample.filepath, redacted_media_path)
 
@@ -254,31 +256,31 @@ class Redaction(fob.BrainMethod):
         else:
             self.redact_file_at(redacted_media_path, sample[self.label_field])
 
-        if self.create_as_new_sample:
-            redacted_sample = sample.copy()
-            redacted_sample[self.label_field] = self.filter_detections(
-                sample[self.label_field], keep_matching=False
-            )
-            redacted_sample["filepath"] = redacted_media_path
-            if self.redaction_field not in redacted_sample.tags:
-                redacted_sample.tags.append(self.redaction_field)
-            redacted_sample["original_sample_id"] = sample.id
-            logger.debug(
-                f"Adding redacted sample at filepath: {redacted_media_path}"
-            )
-            sample._dataset.add_sample(redacted_sample)
-            if ("redacted_sample_ids" not in sample) or (
-                sample["redacted_sample_ids"] is None
-            ):
-                sample["redacted_sample_ids"] = {}
-            sample["redacted_sample_ids"][
-                self.redaction_field
-            ] = redacted_sample.id
-        else:
-            # add the redacted filepath to the sample
-            if self.redaction_field not in sample.tags:
-                sample.tags.append(self.redaction_field)
-            sample[f"{self.redaction_field}_filepath"] = redacted_media_path
+        # if self.create_as_new_sample:
+        #     redacted_sample = sample.copy()
+        #     redacted_sample[self.label_field] = self.filter_detections(
+        #         sample[self.label_field], keep_matching=False
+        #     )
+        #     redacted_sample["filepath"] = redacted_media_path
+        #     if self.redaction_field not in redacted_sample.tags:
+        #         redacted_sample.tags.append(self.redaction_field)
+        #     redacted_sample["original_sample_id"] = sample.id
+        #     logger.debug(
+        #         f"Adding redacted sample at filepath: {redacted_media_path}"
+        #     )
+        #     sample._dataset.add_sample(redacted_sample)
+        #     if ("redacted_sample_ids" not in sample) or (
+        #         sample["redacted_sample_ids"] is None
+        #     ):
+        #         sample["redacted_sample_ids"] = {}
+        #     sample["redacted_sample_ids"][
+        #         self.redaction_field
+        #     ] = redacted_sample.id
+
+        # add the redacted filepath to the sample
+        if self.redaction_field not in sample.tags:
+            sample.tags.append(self.redaction_field)
+        sample[f"{self.redaction_field}_filepath"] = redacted_media_path
 
         sample.save()
         return
@@ -385,32 +387,87 @@ class Redaction(fob.BrainMethod):
     def get_fields(self, samples, brain_key):
         fields = [
             self.label_field,
-            self.redaction_field,
-            "original_sample_id",
-            "redacted_sample_ids",
+            f"{brain_key}_filepath",
+            # "original_sample_id",
+            # "redacted_sample_ids",
         ]
 
-        if samples._is_frame_field(self.label_field):
-            fields.append(samples._FRAMES_PREFIX + self.redaction_field)
+        # if samples._is_frame_field(self.label_field):
+        #     fields.append(samples._FRAMES_PREFIX + f"{brain_key}_filepath")
 
         return fields
 
     def cleanup(self, samples, brain_key):
         label_field = self.label_field
-        redaction_field = self.redaction_field
 
-        samples._dataset.delete_sample_fields(redaction_field, error_level=1)
+        # samples._dataset.delete_sample_fields(brain_key, error_level=1)
+        samples._dataset.delete_sample_fields(
+            f"{brain_key}_filepath", error_level=1
+        )
 
         if samples._is_frame_field(label_field):
-            samples._dataset.delete_frame_fields(
-                redaction_field, error_level=1
-            )
+            samples._dataset.delete_frame_fields(brain_key, error_level=1)
 
     def _validate_run(self, samples, brain_key, existing_info):
         self._validate_fields_match(brain_key, "label_field", existing_info)
         self._validate_fields_match(
             brain_key, "redaction_field", existing_info
         )
+
+
+class RedactionResults(fob.BrainResults):
+    """Class for storing the results of :meth:`fiftyone.brain.create_redaction`.
+
+    Args:
+        samples: the :class:`fiftyone.core.collections.SampleCollection` used
+        config: the :class:`RedactionConfig` used
+        brain_key: the brain key
+        backend (None): a :class:`Redaction` backend
+    """
+
+    def __init__(self, samples, config, brain_key, backend=None):
+        super().__init__(samples, config, brain_key, backend=backend)
+
+    def generate_redacted_dataset(self, name=None, overwrite=False):
+        """
+        Generates a new dataset with the redacted media only.
+        Args:
+            name: name of the redacted dataset
+            overwrite: whether to overwrite the redacted dataset if it already exists
+        Returns:
+            fo.Dataset
+        """
+        redacted_dataset_name = (
+            name
+            if name is not None
+            else f"{self.samples._dataset.name}_{self.samples.name}_redacted"
+        )
+        redacted_dataset = fo.Dataset(
+            name=redacted_dataset_name, overwrite=overwrite
+        )
+
+        select_fields = self.backend.get_fields(self.samples, self.key)
+        redacted_view = self.samples.select_fields(select_fields)
+
+        for redacted_sample in redacted_view.iter_samples():
+            redacted_sample["filepath"] = redacted_sample[
+                f"{self.key}_filepath"
+            ]
+            redacted_sample[
+                self.backend.label_field
+            ] = self.backend.filter_detections(
+                redacted_sample[self.backend.label_field], keep_matching=False
+            )
+
+            redacted_sample.tags.append(self.key)
+            redacted_dataset.add_sample(redacted_sample)
+
+        redacted_dataset.delete_sample_fields(
+            f"{self.key}_filepath", error_level=1
+        )
+        logger.info(f"Redacted dataset {redacted_dataset.name} created")
+
+        return redacted_dataset
 
 
 def fit_mask_to_bbox(

--- a/fiftyone/brain/internal/core/redaction.py
+++ b/fiftyone/brain/internal/core/redaction.py
@@ -309,6 +309,12 @@ class Redaction(fob.BrainMethod):
     def cleanup(self, samples, brain_key):
         label_field = self.label_field
 
+        redaction_view = samples.match(
+            F(f"{brain_key}_filepath") != None
+        ).match(F(f"{brain_key}_filepath") != F("filepath"))
+        for sample in redaction_view:
+            fos.delete_file(sample[f"{brain_key}_filepath"])
+
         samples._dataset.delete_sample_field(
             f"{brain_key}_filepath", error_level=1
         )

--- a/fiftyone/brain/internal/core/redaction.py
+++ b/fiftyone/brain/internal/core/redaction.py
@@ -1,0 +1,391 @@
+"""
+Redaction methods.
+
+| Copyright 2017-2025, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+"""
+import os
+import logging
+import shutil
+from typing import Tuple
+
+import numpy as np
+import cv2
+
+import fiftyone as fo
+import fiftyone.core.storage as fos
+import fiftyone.core.brain as fob
+import fiftyone.core.labels as fol
+import fiftyone.core.validation as fov
+
+
+logger = logging.getLogger(__name__)
+
+
+_ALLOWED_TYPES = (
+    fol.Detections,
+    fol.Polylines,
+    fol.Keypoints,
+    fol.TemporalDetections,
+)
+
+_GAUSSIAN_BLUR_KERNEL_SIZE = lambda w: (w // 10) * 2 + 1  # ensure ksize is odd
+_STACK_BLUR_KERNEL_SIZE = lambda w: min(w, 50) * 2 + 1  # ensure ksize is odd
+
+
+def create_redaction(
+    samples,
+    label_field,
+    label_classes,
+    redaction_type,
+    redaction_method,
+    force_recreate,
+    create_as_new_sample,
+    num_workers,
+    progress,
+):
+    """See ``fiftyone/brain/__init__.py``."""
+
+    #
+    # Algorithm
+    #
+    # TODO(neeraja): Add algorithm description
+    #
+
+    fov.validate_collection(samples)
+    fov.validate_collection_label_fields(samples, label_field, _ALLOWED_TYPES)
+
+    config = RedactionConfig(
+        label_field,
+        label_classes,
+        redaction_type,
+        redaction_method,
+        force_recreate,
+        create_as_new_sample,
+    )
+    brain_key = config.redaction_field
+    brain_method = config.build()
+    brain_method.ensure_requirements()
+    brain_method.register_run(samples, brain_key, cleanup=False)
+    brain_method.register_samples(samples)
+
+    select_fields = [
+        label_field,
+        config.redaction_field,
+        "original_sample_id",
+        "redacted_sample_ids",
+    ]
+    select_fields = [
+        ff for ff in select_fields if samples.get_field(ff) is not None
+    ]
+    view = samples.select_fields(select_fields)
+
+    logger.info("Computing redaction...")
+    view._dataset.persistent = True
+    for sample in view.iter_samples(progress=progress):
+        brain_method.process_sample(sample)
+        sample.save()
+
+    if not create_as_new_sample:
+        logger.info(
+            f"Adding redacted media field: {config.redaction_field}_filepath"
+        )
+        if (
+            f"{config.redaction_field}_filepath"
+            not in view._dataset.app_config.media_fields
+        ):
+            view._dataset.app_config.media_fields.append(
+                f"{config.redaction_field}_filepath"
+            )
+
+    view._dataset.save()
+    brain_method.save_run_results(samples, brain_key, None)
+
+    logger.info("Redaction computation complete")
+
+
+# @todo move to `fiftyone/brain/redaction.py`
+# Don't do this hastily; `get_brain_info()` on existing datasets has this
+# class's full path in it and may need migration
+class RedactionConfig(fob.BrainMethodConfig):
+    def __init__(
+        self,
+        label_field,
+        label_classes,
+        redaction_type,
+        redaction_method,
+        force_recreate,
+        create_as_new_sample,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.label_field = label_field
+        self.label_classes = [
+            label_name.strip()
+            for label_name in label_classes.strip("[").strip("]").split(",")
+        ]
+        self.redaction_type = redaction_type
+        self.redaction_method = redaction_method
+        self.force_recreate = force_recreate
+        self.create_as_new_sample = create_as_new_sample
+        redaction_labels = "_".join(label_classes)
+        redaction_field = f"redacted_{label_field}_{redaction_labels}_{redaction_type}_{redaction_method}"
+        self.redaction_field = redaction_field
+
+    @property
+    def type(self):
+        return "redaction"
+
+    @property
+    def method(self):
+        # TODO(neeraja): is this just a unique ID?
+        return self.redaction_field
+
+
+class Redaction(fob.BrainMethod):
+    def __init__(self, config):
+        super().__init__(config)
+        self.label_field = None
+        self.label_classes = None
+        self.redaction_type = None
+        self.redaction_method = None
+        self.force_recreate = None
+        self.create_as_new_sample = None
+        self.redaction_field = None
+
+    def ensure_requirements(self):
+        pass
+
+    def register_samples(self, samples):
+        self.label_field, _ = samples._handle_frame_field(
+            self.config.label_field
+        )
+        self.label_type = samples._get_label_field_type(
+            self.config.label_field
+        )
+
+    def process_sample(self, sample):
+        redacted_media_path = _get_outpath(
+            sample.filepath,
+            rel_output_dir=self.redaction_field,
+        )
+        if self.create_as_new_sample:
+            if (
+                ("redacted_sample_ids" in sample)
+                and (self.redaction_field in sample["redacted_sample_ids"])
+                and (
+                    os.path.exists(
+                        sample._dataset[
+                            sample["redacted_sample_ids"][self.redaction_field]
+                        ]["filepath"]
+                    )
+                )
+            ):
+                logger.debug(
+                    f"Redaction already exists for sample {sample.id} --> {sample['redacted_sample_ids'][self.redaction_field]}"
+                )
+                if self.force_recreate:
+                    sample._dataset.delete_sample(
+                        sample["redacted_sample_ids"][self.redaction_field]
+                    )
+                    sample["redacted_sample_ids"].pop(self.redaction_field)
+                else:
+                    return
+            if self.redaction_field in sample.tags:
+                logger.debug(
+                    f"This is a redaction of sample {sample['original_sample_id']}"
+                )
+                return
+        else:
+            if (f"{self.redaction_field}_filepath" in sample) and (
+                os.path.exists(sample[f"{self.redaction_field}_filepath"])
+            ):
+                logger.debug(
+                    f"Redaction already exists for sample {sample.id}"
+                )
+                if self.force_recreate:
+                    sample[f"{self.redaction_field}_filepath"] = None
+                    sample.tags.remove(self.redaction_field)
+                else:
+                    return
+
+        shutil.copy(sample.filepath, redacted_media_path)
+
+        processing_frames = sample._is_frame_field(self.label_field)
+        if processing_frames:
+            # TODO(neeraja): handle this for frame fields
+            # images = sample.frames.values()
+            raise NotImplementedError("Frame fields are not supported yet")
+        else:
+            self.redact_file_at(redacted_media_path, sample[self.label_field])
+
+        if self.create_as_new_sample:
+            redacted_sample = sample.copy()
+            redacted_sample[self.label_field] = self.filter_detections(
+                sample[self.label_field], keep_matching=False
+            )
+            redacted_sample["filepath"] = redacted_media_path
+            redacted_sample.tags.append(self.redaction_field)
+            redacted_sample["original_sample_id"] = sample.id
+            if "redacted_sample_ids" not in sample:
+                sample["redacted_sample_ids"] = {}
+            sample["redacted_sample_ids"][
+                self.redaction_field
+            ] = redacted_sample.id
+            logger.info(
+                f"Adding redacted sample at filepath: {redacted_media_path}"
+            )
+            sample._dataset.add_sample(redacted_sample)
+        else:
+            # add the redacted filepath to the sample
+            sample.tags.append(self.redaction_field)
+            sample[f"{self.redaction_field}_filepath"] = redacted_media_path
+
+        sample.save()
+        return
+
+    def redact_file_at(self, redacted_path, detections_object):
+        image = cv2.imread(redacted_path)
+        if self.redaction_method == "gaussian_blur":
+            ksize = int(
+                _GAUSSIAN_BLUR_KERNEL_SIZE(min(image.shape[0], image.shape[1]))
+            )
+            redacted_image = cv2.GaussianBlur(image, (ksize, ksize), 0)
+        elif self.redaction_method == "stack_blur":
+            ksize = int(
+                _STACK_BLUR_KERNEL_SIZE(min(image.shape[0], image.shape[1]))
+            )
+            redacted_image = cv2.stackBlur(image, (ksize, ksize))
+        elif self.redaction_method == "mask":
+            redacted_image = np.zeros_like(image)
+        else:
+            raise ValueError(
+                f"Unimplemented redaction method: {self.redaction_method}"
+            )
+
+        for detection in self.filter_detections(detections_object).detections:
+            x1, y1, x2, y2 = get_corners_from_bbox(
+                detection.bounding_box, image.shape
+            )
+            mask = detection.get_mask()
+            if self.redaction_type == "segmentation_mask" and mask is not None:
+                mask = fit_mask_to_bbox(mask, (y2 - y1, x2 - x1))
+                image[y1:y2, x1:x2][mask] = redacted_image[y1:y2, x1:x2][mask]
+            elif self.redaction_type == "bounding_box":
+                image[y1:y2, x1:x2] = redacted_image[y1:y2, x1:x2]
+            elif self.redaction_type == "segmentation_mask" and mask is None:
+                logger.warning(f"No mask found for detection: {detection}")
+                continue
+            else:
+                raise ValueError(
+                    f"Unknown redaction type: {self.redaction_type}"
+                )
+
+        cv2.imwrite(redacted_path, image)
+
+    def filter_detections(
+        self, detections_object: fol.Detections, keep_matching: bool = True
+    ) -> fol.Detections:
+        """
+        Filters the detections object to keep only the detections that match the redaction labels.
+        Args:
+            detections_object: fol.Detections object
+            keep_matching: bool to keep matching detections (True) or remove matching detections (False)
+        Returns:
+            fo.Detections object
+        """
+        filtered_detections = fo.Detections()
+        if (not hasattr(detections_object, "detections")) or (
+            detections_object.detections is None
+        ):
+            return filtered_detections
+        for detection in detections_object.detections:
+            if keep_matching and (
+                detection.label
+                in self.label_classes  # pylint: disable=unsupported-membership-test
+            ):
+                filtered_detections.detections.append(detection)
+            elif not keep_matching and (
+                detection.label
+                not in self.label_classes  # pylint: disable=unsupported-membership-test
+            ):
+                filtered_detections.detections.append(detection)
+        return filtered_detections
+
+    def get_fields(self, samples, brain_key):
+        fields = [
+            self.config.label_field,
+            self.config.redaction_field,
+            "original_sample_id",
+            "redacted_sample_ids",
+        ]
+
+        if samples._is_frame_field(self.config.label_field):
+            fields.append(samples._FRAMES_PREFIX + self.config.redaction_field)
+
+        return fields
+
+    def cleanup(self, samples, brain_key):
+        label_field = self.config.label_field
+        redaction_field = self.config.redaction_field
+
+        samples._dataset.delete_sample_fields(redaction_field, error_level=1)
+
+        if samples._is_frame_field(label_field):
+            samples._dataset.delete_frame_fields(
+                redaction_field, error_level=1
+            )
+
+    def _validate_run(self, samples, brain_key, existing_info):
+        self._validate_fields_match(brain_key, "label_field", existing_info)
+        self._validate_fields_match(
+            brain_key, "redaction_field", existing_info
+        )
+
+
+def fit_mask_to_bbox(
+    mask: np.ndarray, bbox_size: Tuple[int, int]
+) -> np.ndarray:
+    """
+    Pads or crops the mask to the bounding box size.
+    Args:
+        mask: np.ndarray of shape (mask_height, mask_width)
+        bbox_size: Tuple[int, int] of the bounding box size (height, width)
+    Returns:
+        np.ndarray of shape (height, width)
+    """
+    return np.pad(
+        mask,
+        [
+            (0, max(0, bbox_size[0] - mask.shape[0])),
+            (0, max(0, bbox_size[1] - mask.shape[1])),
+        ],
+    )[: bbox_size[0], : bbox_size[1]]
+
+
+def get_corners_from_bbox(
+    bbox: Tuple[float, float, float, float], image_shape: Tuple[int, int]
+) -> Tuple[int, int, int, int]:
+    """
+    Returns the corners of the bounding box in image coordinates.
+
+    Args:
+        bbox: Tuple[float, float, float, float] of the bounding box (top-left-x, top-left-y, width, height)
+        image_shape: Tuple[int, int] of the image shape (height, width)
+
+    Returns:
+        Tuple[int, int, int, int] of the corners of the bounding box
+        in image coordinates (left, top, right, bottom) i.e. (x1, y1, x2, y2)
+    """
+    x1 = int(bbox[0] * image_shape[1])
+    y1 = int(bbox[1] * image_shape[0])
+    x2 = int((bbox[0] + bbox[2]) * image_shape[1])
+    y2 = int((bbox[1] + bbox[3]) * image_shape[0])
+    return (x1, y1, x2, y2)
+
+
+def _get_outpath(inpath, rel_output_dir):
+    dir_path = os.path.dirname(inpath)
+    dir_path = fos.normalize_path(dir_path)
+    filename = os.path.basename(inpath)
+    return os.path.join(dir_path, rel_output_dir, filename)

--- a/fiftyone/brain/internal/core/redaction.py
+++ b/fiftyone/brain/internal/core/redaction.py
@@ -44,6 +44,7 @@ def create_redaction(
     redaction_type,
     redaction_method,
     redaction_field,
+    remote_redacted_media_dir,
     progress,
 ):
     """See ``fiftyone/brain/__init__.py``."""
@@ -81,7 +82,7 @@ def create_redaction(
     select_fields = [label_field, "filepath", redacted_filepath_field]
     view = samples.select_fields(select_fields)
 
-    logger.info("Computing redaction...")
+    logger.info("Computing redaction ...")
 
     view.set_values(redacted_filepath_field, view.values("filepath"))
     redaction_view = view.filter_labels(
@@ -100,25 +101,23 @@ def create_redaction(
         samples.save()
 
     # upload the redacted media to the cloud
-    remote_base_dirs = list(
-        set(
-            [
-                os.path.dirname(f)
-                for f in redaction_view.values("filepath")
-                if not fos.is_local(f)
-            ]
-        )
-    )
-    for remote_base_dir in remote_base_dirs:
-        fos.ensure_dir(remote_base_dir)
-        fos.upload_media(
-            redaction_view.match(F("filepath").contains_str(remote_base_dir)),
-            remote_dir=fos.join(remote_base_dir, config.redaction_field),
-            media_field=redacted_filepath_field,
-            update_filepaths=True,
-            cache=False,
-            overwrite=True,
-        )
+    if hasattr(fos, "upload_media"):
+        if remote_redacted_media_dir is not None:
+            logger.info(
+                f"Uploading redacted media to {remote_redacted_media_dir} ..."
+            )
+            fos.upload_media(
+                redaction_view,
+                remote_dir=remote_redacted_media_dir,
+                media_field=redacted_filepath_field,
+                update_filepaths=True,
+                cache=False,
+                overwrite=True,
+            )
+        else:
+            logger.info(
+                "No `remote_redacted_media_dir` provided, not uploading redacted media to the cloud"
+            )
 
     results = RedactionResults(samples, config, brain_key, brain_method)
     brain_method.save_run_results(samples, brain_key, results)

--- a/fiftyone/brain/internal/core/redaction.py
+++ b/fiftyone/brain/internal/core/redaction.py
@@ -82,19 +82,18 @@ def create_redaction(
     view = samples.select_fields(select_fields)
 
     logger.info("Computing redaction...")
+
+    for sample in view.iter_samples():
+        sample[f"{config.redaction_field}_filepath"] = sample.filepath
+        sample.save()
+
     redaction_view = view.filter_labels(
         f"{config.label_field}.detections",
         F("label").is_in(config.label_classes),
-        only_matches=False,
+        only_matches=True,
     )
+    detections_object_list = redaction_view.values(config.label_field)
 
-    if brain_method.processing_frames:
-        detections_object_list = samples.values(config.label_field)
-    else:
-        detections_object_list = [
-            sample[config.label_field]
-            for sample in redaction_view.iter_samples()
-        ]
     for sample, sample_detections in zip(
         redaction_view.iter_samples(progress=progress), detections_object_list
     ):
@@ -135,20 +134,12 @@ class RedactionConfig(fob.BrainMethodConfig):
         self.make_redaction_field()
 
     def validate_label_classes(self):
-        if isinstance(self.label_classes, str):
-            self.label_classes = [
-                label_name.strip()
-                for label_name in self.label_classes.strip("[")
-                .strip("]")
-                .split(",")
-            ]
-        else:
-            try:
-                self.label_classes = list(map(str, self.label_classes))
-            except:
-                raise ValueError(
-                    f"Invalid label classes type: {type(self.label_classes)}"
-                )
+        try:
+            self.label_classes = list(map(str.strip, self.label_classes))
+        except:
+            raise ValueError(
+                f"Invalid label classes type: {type(self.label_classes)}"
+            )
 
     def make_redaction_field(self):
         redaction_field_string = f"redacted_{self.label_field.replace('.', '_')}_{self.redaction_type}_{self.redaction_method}"
@@ -170,8 +161,8 @@ class RedactionConfig(fob.BrainMethodConfig):
 class Redaction(fob.BrainMethod):
     def __init__(self, config):
         super().__init__(config)
-        self.label_field = None
         self.label_type = None
+        self.label_field = self.config.label_field
         self.label_classes = self.config.label_classes
         self.redaction_type = self.config.redaction_type
         self.redaction_method = self.config.redaction_method
@@ -183,7 +174,7 @@ class Redaction(fob.BrainMethod):
         pass
 
     def register_samples(self, samples):
-        self.label_field, self.processing_frames = samples._handle_frame_field(
+        _, self.processing_frames = samples._handle_frame_field(
             self.config.label_field
         )
         self.label_type = samples._get_label_field_type(
@@ -191,40 +182,29 @@ class Redaction(fob.BrainMethod):
         )
 
     def process_sample(self, sample, sample_detections):
-        if len(sample_detections) == 0:
-            redacted_media_path = sample.filepath
-        else:
-            redacted_media_path = _get_outpath(
-                sample.filepath,
-                rel_output_dir=self.redaction_field,
-            )
+        redacted_media_path = _get_outpath(
+            sample.filepath,
+            rel_output_dir=self.redaction_field,
+        )
 
-            if (
-                (f"{self.redaction_field}_filepath" in sample)
-                and (sample[f"{self.redaction_field}_filepath"] is not None)
-                and (
-                    os.path.exists(sample[f"{self.redaction_field}_filepath"])
-                )
-            ):
-                logger.debug(
-                    f"Redaction already exists for sample {sample.id}"
-                )
-                if self.force_recreate:
-                    sample[f"{self.redaction_field}_filepath"] = None
-                    sample.tags.remove(self.redaction_field)
-                else:
-                    return
-
-            shutil.copy(sample.filepath, redacted_media_path)
-
-            if self.processing_frames:
-                self.redact_video_file_at(
-                    redacted_media_path, sample_detections
-                )
+        if (
+            (f"{self.redaction_field}_filepath" in sample)
+            and (sample[f"{self.redaction_field}_filepath"] is not None)
+            and (os.path.exists(sample[f"{self.redaction_field}_filepath"]))
+        ):
+            logger.debug(f"Redaction already exists for sample {sample.id}")
+            if self.force_recreate:
+                sample[f"{self.redaction_field}_filepath"] = None
+                sample.tags.remove(self.redaction_field)
             else:
-                self.redact_image_file_at(
-                    redacted_media_path, sample_detections
-                )
+                return
+
+        shutil.copy(sample.filepath, redacted_media_path)
+
+        if self.processing_frames:
+            self.redact_video_file_at(redacted_media_path, sample_detections)
+        else:
+            self.redact_image_file_at(redacted_media_path, sample_detections)
 
         # add the redacted filepath to the sample
         if self.redaction_field not in sample.tags:
@@ -235,6 +215,9 @@ class Redaction(fob.BrainMethod):
         return
 
     def redact_image_file_at(self, redacted_path, detections_object):
+        if len(detections_object.detections) == 0:
+            return
+
         image = cv2.imread(redacted_path)
         redacted_image = self._redact_entire_image(image)
         image = self._apply_redaction_to_image(
@@ -243,6 +226,14 @@ class Redaction(fob.BrainMethod):
         cv2.imwrite(redacted_path, image)
 
     def redact_video_file_at(self, redacted_path, detections_object_list):
+        if all(
+            [
+                len(detections_object.detections) == 0
+                for detections_object in detections_object_list
+            ]
+        ):
+            return
+
         suffix = redacted_path.split(".")[-1]
         temp_redacted_path = redacted_path.replace(
             f".{suffix}", f"_temp.{suffix}"
@@ -312,13 +303,13 @@ class Redaction(fob.BrainMethod):
 
     def get_fields(self, brain_key):
         fields = [
-            self.label_field,
+            self.config.label_field,
             f"{brain_key}_filepath",
         ]
         return fields
 
     def cleanup(self, samples, brain_key):
-        label_field = self.label_field
+        label_field = self.config.label_field
 
         samples._dataset.delete_sample_field(
             f"{brain_key}_filepath", error_level=1
@@ -369,7 +360,7 @@ class RedactionResults(fob.BrainResults):
         redacted_view = self.samples.select_fields(select_fields)
         # exclude detections of type label_field from the redacted dataset
         redacted_view = redacted_view.filter_labels(
-            f"{self.backend.label_field}.detections",
+            f"{self.backend.config.label_field}.detections",
             ~F("label").is_in(self.backend.label_classes),
             only_matches=False,
         )
@@ -433,7 +424,6 @@ def get_corners_from_bbox(
 
 def _get_outpath(inpath, rel_output_dir):
     dir_path = os.path.dirname(inpath)
-    # dir_path = fos.normalize_path(dir_path)
     filename = os.path.basename(inpath)
     dir_path = os.path.join(dir_path, rel_output_dir)
     os.makedirs(dir_path, exist_ok=True)

--- a/fiftyone/brain/internal/core/redaction.py
+++ b/fiftyone/brain/internal/core/redaction.py
@@ -49,7 +49,10 @@ def create_redaction(
     #
     # Algorithm
     #
-    # TODO(neeraja): Add algorithm description
+    # Generates a blurred/masked image based on the redaction_method.
+    # Identifies areas of the image (based on the redaction_type = bounding_box/segmentation_mask)
+    # corresponding to the label_classes from the label_field
+    # and replaces the regions with the redaction_method image
     #
 
     fov.validate_collection(samples)
@@ -71,7 +74,7 @@ def create_redaction(
 
     select_fields = [
         label_field,
-        config.redaction_field,
+        brain_key,
         "original_sample_id",
         "redacted_sample_ids",
     ]
@@ -87,15 +90,13 @@ def create_redaction(
         sample.save()
 
     if not create_as_new_sample:
-        logger.info(
-            f"Adding redacted media field: {config.redaction_field}_filepath"
-        )
+        logger.info(f"Adding redacted media field: {brain_key}_filepath")
         if (
-            f"{config.redaction_field}_filepath"
+            f"{brain_key}_filepath"
             not in view._dataset.app_config.media_fields
         ):
             view._dataset.app_config.media_fields.append(
-                f"{config.redaction_field}_filepath"
+                f"{brain_key}_filepath"
             )
 
     view._dataset.save()
@@ -120,16 +121,31 @@ class RedactionConfig(fob.BrainMethodConfig):
     ):
         super().__init__(**kwargs)
         self.label_field = label_field
-        self.label_classes = [
-            label_name.strip()
-            for label_name in label_classes.strip("[").strip("]").split(",")
-        ]
+        self.label_classes = label_classes
         self.redaction_type = redaction_type
         self.redaction_method = redaction_method
         self.force_recreate = force_recreate
         self.create_as_new_sample = create_as_new_sample
-        redaction_labels = "_".join(label_classes)
-        redaction_field = f"redacted_{label_field}_{redaction_labels}_{redaction_type}_{redaction_method}"
+        self.redaction_field = None
+        self.make_redaction_field()
+
+    def make_redaction_field(self):
+        if isinstance(self.label_classes, str):
+            self.label_classes = [
+                label_name.strip()
+                for label_name in self.label_classes.strip("[")
+                .strip("]")
+                .split(",")
+            ]
+        else:
+            try:
+                self.label_classes = list(self.label_classes)
+            except:
+                raise ValueError(
+                    f"Invalid label classes type: {type(self.label_classes)}"
+                )
+        redaction_labels = "_".join(self.label_classes)
+        redaction_field = f"redacted_{self.label_field}_{redaction_labels}_{self.redaction_type}_{self.redaction_method}"
         self.redaction_field = redaction_field
 
     @property
@@ -138,7 +154,6 @@ class RedactionConfig(fob.BrainMethodConfig):
 
     @property
     def method(self):
-        # TODO(neeraja): is this just a unique ID?
         return self.redaction_field
 
 
@@ -146,12 +161,14 @@ class Redaction(fob.BrainMethod):
     def __init__(self, config):
         super().__init__(config)
         self.label_field = None
+        self.label_type = None
         self.label_classes = None
         self.redaction_type = None
         self.redaction_method = None
         self.force_recreate = None
         self.create_as_new_sample = None
         self.redaction_field = None
+        self.processing_frames = False
 
     def ensure_requirements(self):
         pass
@@ -163,6 +180,16 @@ class Redaction(fob.BrainMethod):
         self.label_type = samples._get_label_field_type(
             self.config.label_field
         )
+        self.label_classes = self.config.label_classes
+
+        self.redaction_type = self.config.redaction_type
+        self.redaction_method = self.config.redaction_method
+        self.redaction_field = self.config.redaction_field
+        self.force_recreate = self.config.force_recreate
+        self.create_as_new_sample = self.config.create_as_new_sample
+        self.processing_frames = samples._is_frame_field(
+            self.config.label_field
+        )
 
     def process_sample(self, sample):
         redacted_media_path = _get_outpath(
@@ -172,6 +199,7 @@ class Redaction(fob.BrainMethod):
         if self.create_as_new_sample:
             if (
                 ("redacted_sample_ids" in sample)
+                and (sample["redacted_sample_ids"] is not None)
                 and (self.redaction_field in sample["redacted_sample_ids"])
                 and (
                     os.path.exists(
@@ -197,8 +225,12 @@ class Redaction(fob.BrainMethod):
                 )
                 return
         else:
-            if (f"{self.redaction_field}_filepath" in sample) and (
-                os.path.exists(sample[f"{self.redaction_field}_filepath"])
+            if (
+                (f"{self.redaction_field}_filepath" in sample)
+                and (sample[f"{self.redaction_field}_filepath"] is not None)
+                and (
+                    os.path.exists(sample[f"{self.redaction_field}_filepath"])
+                )
             ):
                 logger.debug(
                     f"Redaction already exists for sample {sample.id}"
@@ -211,8 +243,7 @@ class Redaction(fob.BrainMethod):
 
         shutil.copy(sample.filepath, redacted_media_path)
 
-        processing_frames = sample._is_frame_field(self.label_field)
-        if processing_frames:
+        if self.processing_frames:
             # TODO(neeraja): handle this for frame fields
             # images = sample.frames.values()
             raise NotImplementedError("Frame fields are not supported yet")
@@ -225,20 +256,24 @@ class Redaction(fob.BrainMethod):
                 sample[self.label_field], keep_matching=False
             )
             redacted_sample["filepath"] = redacted_media_path
-            redacted_sample.tags.append(self.redaction_field)
+            if self.redaction_field not in redacted_sample.tags:
+                redacted_sample.tags.append(self.redaction_field)
             redacted_sample["original_sample_id"] = sample.id
-            if "redacted_sample_ids" not in sample:
-                sample["redacted_sample_ids"] = {}
-            sample["redacted_sample_ids"][
-                self.redaction_field
-            ] = redacted_sample.id
             logger.info(
                 f"Adding redacted sample at filepath: {redacted_media_path}"
             )
             sample._dataset.add_sample(redacted_sample)
+            if ("redacted_sample_ids" not in sample) or (
+                sample["redacted_sample_ids"] is None
+            ):
+                sample["redacted_sample_ids"] = {}
+            sample["redacted_sample_ids"][
+                self.redaction_field
+            ] = redacted_sample.id
         else:
             # add the redacted filepath to the sample
-            sample.tags.append(self.redaction_field)
+            if self.redaction_field not in sample.tags:
+                sample.tags.append(self.redaction_field)
             sample[f"{self.redaction_field}_filepath"] = redacted_media_path
 
         sample.save()
@@ -314,20 +349,20 @@ class Redaction(fob.BrainMethod):
 
     def get_fields(self, samples, brain_key):
         fields = [
-            self.config.label_field,
-            self.config.redaction_field,
+            self.label_field,
+            self.redaction_field,
             "original_sample_id",
             "redacted_sample_ids",
         ]
 
-        if samples._is_frame_field(self.config.label_field):
-            fields.append(samples._FRAMES_PREFIX + self.config.redaction_field)
+        if samples._is_frame_field(self.label_field):
+            fields.append(samples._FRAMES_PREFIX + self.redaction_field)
 
         return fields
 
     def cleanup(self, samples, brain_key):
-        label_field = self.config.label_field
-        redaction_field = self.config.redaction_field
+        label_field = self.label_field
+        redaction_field = self.redaction_field
 
         samples._dataset.delete_sample_fields(redaction_field, error_level=1)
 
@@ -386,6 +421,8 @@ def get_corners_from_bbox(
 
 def _get_outpath(inpath, rel_output_dir):
     dir_path = os.path.dirname(inpath)
-    dir_path = fos.normalize_path(dir_path)
+    # dir_path = fos.normalize_path(dir_path)
     filename = os.path.basename(inpath)
-    return os.path.join(dir_path, rel_output_dir, filename)
+    dir_path = os.path.join(dir_path, rel_output_dir)
+    os.makedirs(dir_path, exist_ok=True)
+    return os.path.join(dir_path, filename)

--- a/fiftyone/brain/internal/core/redaction.py
+++ b/fiftyone/brain/internal/core/redaction.py
@@ -28,8 +28,6 @@ logger = logging.getLogger(__name__)
 _ALLOWED_TYPES = (
     fol.Detection,
     fol.Detections,
-    fol.TemporalDetection,
-    fol.TemporalDetections,
 )
 
 _GAUSSIAN_BLUR_KERNEL_SIZE = lambda w: (w // 10) * 2 + 1  # ensure ksize is odd
@@ -44,7 +42,6 @@ def create_redaction(
     redaction_method,
     redaction_field,
     force_recreate,
-    num_workers,
     progress,
 ):
     """See ``fiftyone/brain/__init__.py``."""
@@ -96,10 +93,9 @@ def create_redaction(
         sample.save()
 
     logger.info(f"Adding redacted media field: {brain_key}_filepath")
-    if f"{brain_key}_filepath" not in view._dataset.app_config.media_fields:
-        view._dataset.app_config.media_fields.append(f"{brain_key}_filepath")
-
-    view._dataset.save()
+    if f"{brain_key}_filepath" not in samples.app_config.media_fields:
+        samples.app_config.media_fields.append(f"{brain_key}_filepath")
+        samples.save()
 
     results = RedactionResults(samples, config, brain_key, brain_method)
     brain_method.save_run_results(samples, brain_key, results)
@@ -108,9 +104,6 @@ def create_redaction(
     return results
 
 
-# @todo move to `fiftyone/brain/redaction.py`
-# Don't do this hastily; `get_brain_info()` on existing datasets has this
-# class's full path in it and may need migration
 class RedactionConfig(fob.BrainMethodConfig):
     def __init__(
         self,
@@ -129,9 +122,10 @@ class RedactionConfig(fob.BrainMethodConfig):
         self.redaction_method = redaction_method
         self.redaction_field = redaction_field
         self.force_recreate = force_recreate
+        self.validate_label_classes()
         self.make_redaction_field()
 
-    def make_redaction_field(self):
+    def validate_label_classes(self):
         if isinstance(self.label_classes, str):
             self.label_classes = [
                 label_name.strip()
@@ -146,8 +140,9 @@ class RedactionConfig(fob.BrainMethodConfig):
                 raise ValueError(
                     f"Invalid label classes type: {type(self.label_classes)}"
                 )
-        redaction_labels = "_".join(self.label_classes)
-        redaction_field_string = f"redacted_{self.label_field.replace('.', '_')}_{redaction_labels}_{self.redaction_type}_{self.redaction_method}"
+
+    def make_redaction_field(self):
+        redaction_field_string = f"redacted_{self.label_field.replace('.', '_')}_{self.redaction_type}_{self.redaction_method}"
         self.redaction_field = (
             redaction_field_string
             if self.redaction_field is None
@@ -160,7 +155,7 @@ class RedactionConfig(fob.BrainMethodConfig):
 
     @property
     def method(self):
-        return self.redaction_field
+        return self.redaction_method
 
 
 class Redaction(fob.BrainMethod):
@@ -168,30 +163,21 @@ class Redaction(fob.BrainMethod):
         super().__init__(config)
         self.label_field = None
         self.label_type = None
-        self.label_classes = None
-        self.redaction_type = None
-        self.redaction_method = None
-        self.force_recreate = None
-        self.redaction_field = None
+        self.label_classes = self.config.label_classes
+        self.redaction_type = self.config.redaction_type
+        self.redaction_method = self.config.redaction_method
+        self.redaction_field = self.config.redaction_field
+        self.force_recreate = self.config.force_recreate
         self.processing_frames = False
 
     def ensure_requirements(self):
         pass
 
     def register_samples(self, samples):
-        self.label_field, _ = samples._handle_frame_field(
+        self.label_field, self.processing_frames = samples._handle_frame_field(
             self.config.label_field
         )
         self.label_type = samples._get_label_field_type(
-            self.config.label_field
-        )
-        self.label_classes = self.config.label_classes
-
-        self.redaction_type = self.config.redaction_type
-        self.redaction_method = self.config.redaction_method
-        self.redaction_field = self.config.redaction_field
-        self.force_recreate = self.config.force_recreate
-        self.processing_frames = samples._is_frame_field(
             self.config.label_field
         )
 
@@ -296,21 +282,21 @@ class Redaction(fob.BrainMethod):
                 detection.bounding_box, image.shape
             )
             mask = detection.get_mask()
-            if self.redaction_type == "segmentation_mask" and mask is not None:
+            if self.redaction_type == "segmentation_mask":
+                if mask is None:
+                    logger.warning(f"No mask found for detection: {detection}")
+                    continue
                 mask = fit_mask_to_bbox(mask, (y2 - y1, x2 - x1))
                 image[y1:y2, x1:x2][mask] = redacted_image[y1:y2, x1:x2][mask]
             elif self.redaction_type == "bounding_box":
                 image[y1:y2, x1:x2] = redacted_image[y1:y2, x1:x2]
-            elif self.redaction_type == "segmentation_mask" and mask is None:
-                logger.warning(f"No mask found for detection: {detection}")
-                continue
             else:
                 raise ValueError(
                     f"Unknown redaction type: {self.redaction_type}"
                 )
         return image
 
-    def get_fields(self, samples, brain_key):
+    def get_fields(self, brain_key):
         fields = [
             self.label_field,
             f"{brain_key}_filepath",
@@ -365,9 +351,9 @@ class RedactionResults(fob.BrainResults):
             name=redacted_dataset_name, overwrite=overwrite
         )
 
-        select_fields = self.backend.get_fields(self.samples, self.key)
+        select_fields = self.backend.get_fields(self.key)
         redacted_view = self.samples.select_fields(select_fields)
-        # exclude detetions of type label_field from the redacted dataset
+        # exclude detections of type label_field from the redacted dataset
         redacted_view = redacted_view.filter_labels(
             f"{self.backend.label_field}.detections",
             ~F("label").is_in(self.backend.label_classes),

--- a/fiftyone/brain/internal/core/redaction.py
+++ b/fiftyone/brain/internal/core/redaction.py
@@ -12,7 +12,7 @@ from typing import Tuple
 import numpy as np
 import cv2
 
-# from eta.core.video import VideoProcessor
+from eta.core.video import VideoProcessor
 
 import fiftyone as fo
 import fiftyone.core.storage as fos
@@ -294,25 +294,31 @@ class Redaction(fob.BrainMethod):
         cv2.imwrite(redacted_path, image)
 
     def redact_video_file_at(self, redacted_path, detections_object_list):
-        video_frames, fps, (width, height) = read_video_frames(redacted_path)
-        if len(video_frames) != len(detections_object_list):
-            raise ValueError(
-                f"Number of video frames ({len(video_frames)}) does not match the number of detections ({len(detections_object_list)})"
-            )
-
-        redacted_video_frames = []
-        for video_frame, detections_object in zip(
-            video_frames, detections_object_list
-        ):
-            redacted_image = self._redact_entire_image(video_frame)
-            redacted_image = self._apply_redaction_to_image(
-                video_frame, redacted_image, detections_object
-            )
-            redacted_video_frames.append(redacted_image)
-
-        write_video_frames(
-            redacted_path, redacted_video_frames, fps, (width, height)
+        suffix = redacted_path.split(".")[-1]
+        temp_redacted_path = redacted_path.replace(
+            f".{suffix}", f"_temp.{suffix}"
         )
+        with VideoProcessor(
+            redacted_path,
+            out_video_path=temp_redacted_path,
+            out_opts=[
+                "-pix_fmt",
+                "yuv420p",
+                "-c:v",
+                "libopenh264",  # this increases the video quality
+            ],
+        ) as vp:
+            if vp.total_frame_count != len(detections_object_list):
+                raise ValueError(
+                    f"Number of video frames ({vp.total_frame_count}) does not match the number of detections ({len(detections_object_list)})"
+                )
+            for frame, detections_object in zip(vp, detections_object_list):
+                redacted_image = self._redact_entire_image(frame)
+                redacted_image = self._apply_redaction_to_image(
+                    frame, redacted_image, detections_object
+                )
+                vp.write(redacted_image)
+        shutil.move(temp_redacted_path, redacted_path)
 
     def _redact_entire_image(self, image):
         if self.redaction_method == "gaussian_blur":
@@ -518,32 +524,3 @@ def _get_outpath(inpath, rel_output_dir):
     dir_path = os.path.join(dir_path, rel_output_dir)
     os.makedirs(dir_path, exist_ok=True)
     return os.path.join(dir_path, filename)
-
-
-def read_video_frames(filepath):
-    cap = cv2.VideoCapture(filepath)
-
-    fps = cap.get(cv2.CAP_PROP_FPS)
-    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-
-    frames = []
-    while True:
-        ret, frame = cap.read()
-        if not ret:
-            break
-        frames.append(frame)
-    cap.release()
-    return frames, fps, (width, height)
-
-
-def write_video_frames(
-    filepath, frames, fps: int, frame_width_height: Tuple[int, int]
-):
-    video_file = cv2.VideoWriter(
-        filepath, cv2.VideoWriter_fourcc(*"mp4v"), fps, frame_width_height
-    )
-    for frame in frames:
-        video_file.write(frame)
-    video_file.release()
-    return

--- a/fiftyone/brain/internal/core/redaction.py
+++ b/fiftyone/brain/internal/core/redaction.py
@@ -12,7 +12,6 @@ from typing import Tuple
 import numpy as np
 import cv2
 
-cv2.setNumThreads(1)
 
 from eta.core.video import VideoProcessor
 
@@ -45,6 +44,8 @@ def create_redaction(
     redaction_method,
     redaction_field,
     remote_redacted_media_dir,
+    num_workers,
+    skip_failures,
     progress,
 ):
     """See ``fiftyone/brain/__init__.py``."""
@@ -91,8 +92,16 @@ def create_redaction(
         only_matches=True,
     )
 
+    map_kwargs = {
+        "save": True,
+        "progress": progress,
+        "num_workers": num_workers,
+        "skip_failures": skip_failures,
+    }
     _ = list(
-        redaction_view.map_samples(brain_method.process_sample_fn, save=True)
+        redaction_view.map_samples(
+            brain_method.process_sample_fn, **map_kwargs
+        )
     )
 
     logger.info(f"Adding redacted media field: {redacted_filepath_field}")
@@ -146,12 +155,11 @@ class RedactionConfig(fob.BrainMethodConfig):
         self.make_redaction_field()
 
     def validate_label_classes(self):
-        try:
-            self.label_classes = list(map(str.strip, self.label_classes))
-        except:
-            raise ValueError(
+        if not isinstance(self.label_classes, (list, tuple)):
+            raise TypeError(
                 f"Invalid label classes type: {type(self.label_classes)}"
             )
+        self.label_classes = list(map(str.strip, self.label_classes))
 
     def make_redaction_field(self):
         redaction_field_string = f"redacted_{self.label_field.replace('.', '_')}_{self.redaction_type}_{self.redaction_method}"
@@ -180,14 +188,16 @@ class Redaction(fob.BrainMethod):
         self.redaction_method = self.config.redaction_method
         self.redaction_field = self.config.redaction_field
         self.processing_frames = False
+        self.frame_label_field = None
 
     def ensure_requirements(self):
         pass
 
     def register_samples(self, samples):
-        _, self.processing_frames = samples._handle_frame_field(
-            self.label_field
-        )
+        (
+            self.frame_label_field,
+            self.processing_frames,
+        ) = samples._handle_frame_field(self.label_field)
         self.label_type = samples._get_label_field_type(self.label_field)
 
     def process_sample_fn(self, sample):
@@ -203,7 +213,13 @@ class Redaction(fob.BrainMethod):
         fos.copy_file(local_media_path, redacted_media_path)
         if self.processing_frames:
             self.redact_video_file_at(
-                redacted_media_path, sample[self.label_field]
+                redacted_media_path,
+                list(
+                    map(
+                        lambda frame: frame[self.frame_label_field],
+                        sample.frames.values(),
+                    )
+                ),
             )
         else:
             self.redact_image_file_at(
@@ -251,14 +267,16 @@ class Redaction(fob.BrainMethod):
                     f"Number of video frames ({vp.total_frame_count}) does not match the number of detections ({len(detections_object_list)})"
                 )
             for frame, detections_object in zip(vp, detections_object_list):
-                redacted_image = self._redact_entire_image(frame)
-                frame = self._apply_redaction_to_image(
-                    frame, redacted_image, detections_object
-                )
+                if detections_object:
+                    redacted_image = self._redact_entire_image(frame)
+                    frame = self._apply_redaction_to_image(
+                        frame, redacted_image, detections_object
+                    )
                 vp.write(frame)
         fos.move_file(temp_redacted_path, redacted_path)
 
     def _redact_entire_image(self, image):
+        cv2.setNumThreads(1)
         if self.redaction_method == "gaussian_blur":
             ksize = int(
                 _GAUSSIAN_BLUR_KERNEL_SIZE(min(image.shape[0], image.shape[1]))

--- a/fiftyone/brain/internal/core/redaction.py
+++ b/fiftyone/brain/internal/core/redaction.py
@@ -263,7 +263,7 @@ class Redaction(fob.BrainMethod):
             if self.redaction_field not in redacted_sample.tags:
                 redacted_sample.tags.append(self.redaction_field)
             redacted_sample["original_sample_id"] = sample.id
-            logger.info(
+            logger.debug(
                 f"Adding redacted sample at filepath: {redacted_media_path}"
             )
             sample._dataset.add_sample(redacted_sample)

--- a/fiftyone/brain/internal/core/redaction.py
+++ b/fiftyone/brain/internal/core/redaction.py
@@ -17,6 +17,7 @@ from eta.core.video import VideoProcessor
 import fiftyone as fo
 import fiftyone.core.storage as fos
 import fiftyone.core.brain as fob
+import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
 import fiftyone.core.validation as fov
 from fiftyone import ViewField as F
@@ -72,21 +73,18 @@ def create_redaction(
     brain_method.register_run(samples, brain_key, cleanup=False)
     brain_method.register_samples(samples)
 
-    select_fields = [
-        label_field,
-        brain_key,
-    ]
-    select_fields = [
-        ff for ff in select_fields if samples.get_field(ff) is not None
-    ]
+    redacted_filepath_field = f"{config.redaction_field}_filepath"
+    if samples.get_field(redacted_filepath_field) is None:
+        samples._dataset.add_sample_field(
+            redacted_filepath_field, fof.StringField
+        )
+
+    select_fields = [label_field, "filepath", redacted_filepath_field]
     view = samples.select_fields(select_fields)
 
     logger.info("Computing redaction...")
 
-    for sample in view.iter_samples():
-        sample[f"{config.redaction_field}_filepath"] = sample.filepath
-        sample.save()
-
+    view.set_values(redacted_filepath_field, view.values("filepath"))
     redaction_view = view.filter_labels(
         f"{config.label_field}.detections",
         F("label").is_in(config.label_classes),
@@ -94,6 +92,7 @@ def create_redaction(
     )
     detections_object_list = redaction_view.values(config.label_field)
 
+    # TODO(neeraja): use set_values()
     for sample, sample_detections in zip(
         redaction_view.iter_samples(progress=progress), detections_object_list
     ):
@@ -190,7 +189,7 @@ class Redaction(fob.BrainMethod):
         if (
             (f"{self.redaction_field}_filepath" in sample)
             and (sample[f"{self.redaction_field}_filepath"] is not None)
-            and (os.path.exists(sample[f"{self.redaction_field}_filepath"]))
+            and (fos.exists(sample[f"{self.redaction_field}_filepath"]))
         ):
             logger.debug(f"Redaction already exists for sample {sample.id}")
             if self.force_recreate:
@@ -199,7 +198,7 @@ class Redaction(fob.BrainMethod):
             else:
                 return
 
-        shutil.copy(sample.filepath, redacted_media_path)
+        fos.copy_file(sample.filepath, redacted_media_path)
 
         if self.processing_frames:
             self.redact_video_file_at(redacted_media_path, sample_detections)
@@ -215,7 +214,7 @@ class Redaction(fob.BrainMethod):
         return
 
     def redact_image_file_at(self, redacted_path, detections_object):
-        if len(detections_object.detections) == 0:
+        if not detections_object.detections:
             return
 
         image = cv2.imread(redacted_path)
@@ -228,7 +227,7 @@ class Redaction(fob.BrainMethod):
     def redact_video_file_at(self, redacted_path, detections_object_list):
         if all(
             [
-                len(detections_object.detections) == 0
+                not detections_object.detections
                 for detections_object in detections_object_list
             ]
         ):
@@ -258,7 +257,7 @@ class Redaction(fob.BrainMethod):
                     frame, redacted_image, detections_object
                 )
                 vp.write(frame)
-        shutil.move(temp_redacted_path, redacted_path)
+        fos.move_file(temp_redacted_path, redacted_path)
 
     def _redact_entire_image(self, image):
         if self.redaction_method == "gaussian_blur":
@@ -352,9 +351,6 @@ class RedactionResults(fob.BrainResults):
             if name is not None
             else f"{self.samples._dataset.name}_{self.samples.name}_redacted"
         )
-        redacted_dataset = fo.Dataset(
-            name=redacted_dataset_name, overwrite=overwrite
-        )
 
         select_fields = self.backend.get_fields(self.key)
         redacted_view = self.samples.select_fields(select_fields)
@@ -365,12 +361,12 @@ class RedactionResults(fob.BrainResults):
             only_matches=False,
         )
 
-        for redacted_sample in redacted_view.iter_samples():
-            redacted_sample["filepath"] = redacted_sample[
-                f"{self.key}_filepath"
-            ]
-            redacted_sample.tags.append(self.key)
-            redacted_dataset.add_sample(redacted_sample)
+        if overwrite and redacted_dataset_name in fo.list_datasets():
+            fo.delete_dataset(redacted_dataset_name)
+        redacted_dataset = redacted_view.clone(name=redacted_dataset_name)
+        redacted_dataset.set_values(
+            "filepath", redacted_view.values(f"{self.key}_filepath")
+        )
 
         # remove the redacted field from the redacted dataset
         redacted_dataset.delete_sample_field(

--- a/fiftyone/brain/internal/core/redaction.py
+++ b/fiftyone/brain/internal/core/redaction.py
@@ -88,8 +88,17 @@ def create_redaction(
         only_matches=False,
     )
 
-    for sample in redaction_view.iter_samples(progress=progress):
-        brain_method.process_sample(sample)
+    if brain_method.processing_frames:
+        detections_object_list = samples.values(config.label_field)
+    else:
+        detections_object_list = [
+            sample[config.label_field]
+            for sample in redaction_view.iter_samples()
+        ]
+    for sample, sample_detections in zip(
+        redaction_view.iter_samples(progress=progress), detections_object_list
+    ):
+        brain_method.process_sample(sample, sample_detections)
         sample.save()
 
     logger.info(f"Adding redacted media field: {brain_key}_filepath")
@@ -181,36 +190,41 @@ class Redaction(fob.BrainMethod):
             self.config.label_field
         )
 
-    def process_sample(self, sample):
-        redacted_media_path = _get_outpath(
-            sample.filepath,
-            rel_output_dir=self.redaction_field,
-        )
-
-        if (
-            (f"{self.redaction_field}_filepath" in sample)
-            and (sample[f"{self.redaction_field}_filepath"] is not None)
-            and (os.path.exists(sample[f"{self.redaction_field}_filepath"]))
-        ):
-            logger.debug(f"Redaction already exists for sample {sample.id}")
-            if self.force_recreate:
-                sample[f"{self.redaction_field}_filepath"] = None
-                sample.tags.remove(self.redaction_field)
-            else:
-                return
-
-        shutil.copy(sample.filepath, redacted_media_path)
-
-        if self.processing_frames:
-            detections_object_list = [
-                frame[self.label_field.replace("frames.", "")]
-                for frame in sample.frames.values()
-            ]
-            self.redact_video_file_at(
-                redacted_media_path, detections_object_list
-            )
+    def process_sample(self, sample, sample_detections):
+        if len(sample_detections) == 0:
+            redacted_media_path = sample.filepath
         else:
-            self.redact_file_at(redacted_media_path, sample[self.label_field])
+            redacted_media_path = _get_outpath(
+                sample.filepath,
+                rel_output_dir=self.redaction_field,
+            )
+
+            if (
+                (f"{self.redaction_field}_filepath" in sample)
+                and (sample[f"{self.redaction_field}_filepath"] is not None)
+                and (
+                    os.path.exists(sample[f"{self.redaction_field}_filepath"])
+                )
+            ):
+                logger.debug(
+                    f"Redaction already exists for sample {sample.id}"
+                )
+                if self.force_recreate:
+                    sample[f"{self.redaction_field}_filepath"] = None
+                    sample.tags.remove(self.redaction_field)
+                else:
+                    return
+
+            shutil.copy(sample.filepath, redacted_media_path)
+
+            if self.processing_frames:
+                self.redact_video_file_at(
+                    redacted_media_path, sample_detections
+                )
+            else:
+                self.redact_image_file_at(
+                    redacted_media_path, sample_detections
+                )
 
         # add the redacted filepath to the sample
         if self.redaction_field not in sample.tags:
@@ -220,7 +234,7 @@ class Redaction(fob.BrainMethod):
         sample.save()
         return
 
-    def redact_file_at(self, redacted_path, detections_object):
+    def redact_image_file_at(self, redacted_path, detections_object):
         image = cv2.imread(redacted_path)
         redacted_image = self._redact_entire_image(image)
         image = self._apply_redaction_to_image(

--- a/fiftyone/brain/internal/core/redaction.py
+++ b/fiftyone/brain/internal/core/redaction.py
@@ -88,14 +88,29 @@ def create_redaction(
         only_matches=True,
     )
 
-    redaction_view.map_samples(
-        brain_method.process_sample_fn,
-    )
+    redaction_view.map_samples(brain_method.process_sample_fn, save=True)
 
-    logger.info(f"Adding redacted media field: {brain_key}_filepath")
-    if f"{brain_key}_filepath" not in samples.app_config.media_fields:
-        samples.app_config.media_fields.append(f"{brain_key}_filepath")
+    logger.info(f"Adding redacted media field: {redacted_filepath_field}")
+    if redacted_filepath_field not in samples.app_config.media_fields:
+        samples.app_config.media_fields.append(redacted_filepath_field)
         samples.save()
+
+    # upload the redacted media to the cloud
+    cloud_view = redaction_view.match(F("local_path").exists())
+    remote_base_dirs = list(
+        set([os.path.dirname(f) for f in cloud_view.values("filepath")])
+    )
+    for remote_base_dir in remote_base_dirs:
+        fos.ensure_dir(remote_base_dir)
+        fos.upload_media(
+            cloud_view.match(F("filepath").contains_str(remote_base_dir)),
+            remote_dir=config.redaction_field,
+            rel_dir=remote_base_dir,
+            media_field=redacted_filepath_field,
+            update_filepaths=True,
+            cache=False,
+            overwrite=True,
+        )
 
     results = RedactionResults(samples, config, brain_key, brain_method)
     brain_method.save_run_results(samples, brain_key, results)
@@ -169,11 +184,16 @@ class Redaction(fob.BrainMethod):
         self.label_type = samples._get_label_field_type(self.label_field)
 
     def process_sample_fn(self, sample):
-        redacted_media_path = _get_outpath(
-            sample.filepath,
+        local_media_path = (
+            sample.filepath
+            if fos.is_local(sample.filepath)
+            else sample.local_path
+        )
+        redacted_media_path = _get_outpath_local(
+            local_media_path,
             rel_output_dir=self.redaction_field,
         )
-        fos.copy_file(sample.filepath, redacted_media_path)
+        fos.copy_file(local_media_path, redacted_media_path)
         if self.processing_frames:
             self.redact_video_file_at(redacted_media_path, self.label_field)
         else:
@@ -285,6 +305,7 @@ class Redaction(fob.BrainMethod):
 
     def _validate_run(self, samples, brain_key, existing_info):
         self._validate_fields_match(brain_key, "label_field", existing_info)
+        self._validate_fields_match(brain_key, "label_classes", existing_info)
         self._validate_fields_match(
             brain_key, "redaction_field", existing_info
         )
@@ -384,9 +405,9 @@ def get_corners_from_bbox(
     return (x1, y1, x2, y2)
 
 
-def _get_outpath(inpath, rel_output_dir):
-    dir_path = os.path.dirname(inpath)
+def _get_outpath_local(inpath, rel_output_dir):
     filename = os.path.basename(inpath)
-    dir_path = os.path.join(dir_path, rel_output_dir)
-    os.makedirs(dir_path, exist_ok=True)
-    return os.path.join(dir_path, filename)
+    dir_path = os.path.dirname(inpath)
+    out_dir_path = fos.join(dir_path, rel_output_dir)
+    fos.ensure_dir(out_dir_path)
+    return fos.join(out_dir_path, filename)

--- a/fiftyone/brain/internal/core/redaction.py
+++ b/fiftyone/brain/internal/core/redaction.py
@@ -145,7 +145,7 @@ class RedactionConfig(fob.BrainMethodConfig):
                     f"Invalid label classes type: {type(self.label_classes)}"
                 )
         redaction_labels = "_".join(self.label_classes)
-        redaction_field = f"redacted_{self.label_field}_{redaction_labels}_{self.redaction_type}_{self.redaction_method}"
+        redaction_field = f"redacted_{self.label_field.replace('.', '_')}_{redaction_labels}_{self.redaction_type}_{self.redaction_method}"
         self.redaction_field = redaction_field
 
     @property
@@ -244,9 +244,13 @@ class Redaction(fob.BrainMethod):
         shutil.copy(sample.filepath, redacted_media_path)
 
         if self.processing_frames:
-            # TODO(neeraja): handle this for frame fields
-            # images = sample.frames.values()
-            raise NotImplementedError("Frame fields are not supported yet")
+            detections_object_list = [
+                frame[self.label_field.replace("frames.", "")]
+                for frame in sample.frames.values()
+            ]
+            self.redact_video_file_at(
+                redacted_media_path, detections_object_list
+            )
         else:
             self.redact_file_at(redacted_media_path, sample[self.label_field])
 
@@ -281,6 +285,34 @@ class Redaction(fob.BrainMethod):
 
     def redact_file_at(self, redacted_path, detections_object):
         image = cv2.imread(redacted_path)
+        redacted_image = self._redact_entire_image(image)
+        image = self._apply_redaction_to_image(
+            image, redacted_image, detections_object
+        )
+        cv2.imwrite(redacted_path, image)
+
+    def redact_video_file_at(self, redacted_path, detections_object_list):
+        video_frames, fps, (width, height) = read_video_frames(redacted_path)
+        if len(video_frames) != len(detections_object_list):
+            raise ValueError(
+                f"Number of video frames ({len(video_frames)}) does not match the number of detections ({len(detections_object_list)})"
+            )
+
+        redacted_video_frames = []
+        for video_frame, detections_object in zip(
+            video_frames, detections_object_list
+        ):
+            redacted_image = self._redact_entire_image(video_frame)
+            redacted_image = self._apply_redaction_to_image(
+                video_frame, redacted_image, detections_object
+            )
+            redacted_video_frames.append(redacted_image)
+
+        write_video_frames(
+            redacted_path, redacted_video_frames, fps, (width, height)
+        )
+
+    def _redact_entire_image(self, image):
         if self.redaction_method == "gaussian_blur":
             ksize = int(
                 _GAUSSIAN_BLUR_KERNEL_SIZE(min(image.shape[0], image.shape[1]))
@@ -297,7 +329,11 @@ class Redaction(fob.BrainMethod):
             raise ValueError(
                 f"Unimplemented redaction method: {self.redaction_method}"
             )
+        return redacted_image
 
+    def _apply_redaction_to_image(
+        self, image, redacted_image, detections_object
+    ):
         for detection in self.filter_detections(detections_object).detections:
             x1, y1, x2, y2 = get_corners_from_bbox(
                 detection.bounding_box, image.shape
@@ -315,8 +351,7 @@ class Redaction(fob.BrainMethod):
                 raise ValueError(
                     f"Unknown redaction type: {self.redaction_type}"
                 )
-
-        cv2.imwrite(redacted_path, image)
+        return image
 
     def filter_detections(
         self, detections_object: fol.Detections, keep_matching: bool = True
@@ -426,3 +461,32 @@ def _get_outpath(inpath, rel_output_dir):
     dir_path = os.path.join(dir_path, rel_output_dir)
     os.makedirs(dir_path, exist_ok=True)
     return os.path.join(dir_path, filename)
+
+
+def read_video_frames(filepath):
+    cap = cv2.VideoCapture(filepath)
+
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+
+    frames = []
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        frames.append(frame)
+    cap.release()
+    return frames, fps, (width, height)
+
+
+def write_video_frames(
+    filepath, frames, fps: int, frame_width_height: Tuple[int, int]
+):
+    video_file = cv2.VideoWriter(
+        filepath, cv2.VideoWriter_fourcc(*"mp4v"), fps, frame_width_height
+    )
+    for frame in frames:
+        video_file.write(frame)
+    video_file.release()
+    return

--- a/tests/intensive/test_interface.py
+++ b/tests/intensive/test_interface.py
@@ -118,21 +118,37 @@ def test_redaction():
     dataset = foz.load_zoo_dataset("quickstart").clone()
     test_view = dataset.take(10, seed=42)
 
-    fob.create_redaction(
+    _ = fob.create_redaction(
         test_view,
         label_field="ground_truth",
         label_classes="person,car",
         redaction_type="bounding_box",
         redaction_method="stack_blur",
+        redaction_field="test_interface",
     )
     print(dataset.list_brain_runs())
-    print(
-        dataset.get_brain_info(
-            "redacted_ground_truth_person_car_bounding_box_stack_blur"
-        )
-    )
+    print(dataset.get_brain_info("test_interface"))
 
-    dataset.delete_brain_runs()
+    dataset.delete_brain_run("test_interface")
+    print(dataset)
+
+
+def test_redaction_video():
+    dataset = foz.load_zoo_dataset("quickstart-video").clone()
+    test_view = dataset.take(1, seed=42)
+
+    _ = fob.create_redaction(
+        test_view,
+        label_field="frames.detections",
+        label_classes="person,car",
+        redaction_type="bounding_box",
+        redaction_method="stack_blur",
+        redaction_field="test_interface_video",
+    )
+    print(dataset.list_brain_runs())
+    print(dataset.get_brain_info("test_interface_video"))
+
+    dataset.delete_brain_run("test_interface_video")
     print(dataset)
 
 

--- a/tests/intensive/test_interface.py
+++ b/tests/intensive/test_interface.py
@@ -121,7 +121,7 @@ def test_redaction():
     _ = fob.create_redaction(
         test_view,
         label_field="ground_truth",
-        label_classes="person,car",
+        label_classes=["person", "car"],
         redaction_type="bounding_box",
         redaction_method="stack_blur",
         redaction_field="test_interface",
@@ -140,7 +140,7 @@ def test_redaction_video():
     _ = fob.create_redaction(
         test_view,
         label_field="frames.detections",
-        label_classes="person,car",
+        label_classes=["person", "car"],
         redaction_type="bounding_box",
         redaction_method="stack_blur",
         redaction_field="test_interface_video",

--- a/tests/intensive/test_interface.py
+++ b/tests/intensive/test_interface.py
@@ -131,8 +131,6 @@ def test_redaction():
             "redacted_ground_truth_person_car_bounding_box_stack_blur"
         )
     )
-    # redacted_image_path = test_view.first()["redacted_ground_truth_person_car_bounding_box_stack_blur_filepath"]
-    # assert os.path.exists(redacted_image_path)
 
     dataset.delete_brain_runs()
     print(dataset)

--- a/tests/intensive/test_interface.py
+++ b/tests/intensive/test_interface.py
@@ -135,7 +135,7 @@ def test_redaction():
 
 def test_redaction_video():
     dataset = foz.load_zoo_dataset("quickstart-video").clone()
-    test_view = dataset.take(1, seed=42)
+    test_view = dataset.limit(1)
 
     _ = fob.create_redaction(
         test_view,
@@ -144,6 +144,7 @@ def test_redaction_video():
         redaction_type="bounding_box",
         redaction_method="stack_blur",
         redaction_field="test_interface_video",
+        num_workers=2,
     )
     print(dataset.list_brain_runs())
     print(dataset.get_brain_info("test_interface_video"))

--- a/tests/intensive/test_interface.py
+++ b/tests/intensive/test_interface.py
@@ -114,6 +114,30 @@ def test_hardness():
     print(dataset)
 
 
+def test_redaction():
+    dataset = foz.load_zoo_dataset("quickstart").clone()
+    test_view = dataset.take(10, seed=42)
+
+    fob.create_redaction(
+        test_view,
+        label_field="ground_truth",
+        label_classes="person,car",
+        redaction_type="bounding_box",
+        redaction_method="stack_blur",
+    )
+    print(dataset.list_brain_runs())
+    print(
+        dataset.get_brain_info(
+            "redacted_ground_truth_person_car_bounding_box_stack_blur"
+        )
+    )
+    # redacted_image_path = test_view.first()["redacted_ground_truth_person_car_bounding_box_stack_blur_filepath"]
+    # assert os.path.exists(redacted_image_path)
+
+    dataset.delete_brain_runs()
+    print(dataset)
+
+
 if __name__ == "__main__":
     fo.config.show_progress_bars = True
     unittest.main(verbosity=2)

--- a/tests/intensive/test_redaction.py
+++ b/tests/intensive/test_redaction.py
@@ -46,9 +46,7 @@ def test_recreate_redaction_fields():
         redaction_type="bounding_box",
         redaction_method="stack_blur",
     )
-    expected_brain_key = (
-        "redacted_ground_truth_person_car_bounding_box_stack_blur"
-    )
+    expected_brain_key = "redacted_ground_truth_bounding_box_stack_blur"
 
     for sample in test_view.iter_samples():
         redacted_image_path = sample[expected_brain_key + "_filepath"]

--- a/tests/intensive/test_redaction.py
+++ b/tests/intensive/test_redaction.py
@@ -35,58 +35,58 @@ def test_create_redaction_fields():
     dataset.delete_brain_run(brain_key)
 
 
-def test_recreate_redaction_fields():
-    dataset = foz.load_zoo_dataset("quickstart").clone()
-    test_view = dataset.take(5, seed=42)
+# def test_recreate_redaction_fields():
+#     dataset = foz.load_zoo_dataset("quickstart").clone()
+#     test_view = dataset.take(5, seed=42)
 
-    _ = fob.create_redaction(
-        test_view,
-        label_field="ground_truth",
-        label_classes=["person", "car"],
-        redaction_type="bounding_box",
-        redaction_method="stack_blur",
-    )
-    expected_brain_key = "redacted_ground_truth_bounding_box_stack_blur"
+#     _ = fob.create_redaction(
+#         test_view,
+#         label_field="ground_truth",
+#         label_classes=["person", "car"],
+#         redaction_type="bounding_box",
+#         redaction_method="stack_blur",
+#     )
+#     expected_brain_key = "redacted_ground_truth_bounding_box_stack_blur"
 
-    for sample in test_view.iter_samples():
-        redacted_image_path = sample[expected_brain_key + "_filepath"]
-        original_image_path = sample["filepath"]
-        if (original_image_path != redacted_image_path) and os.path.exists(
-            redacted_image_path
-        ):
-            os.remove(redacted_image_path)
+#     for sample in test_view.iter_samples():
+#         redacted_image_path = sample[expected_brain_key + "_filepath"]
+#         original_image_path = sample["filepath"]
+#         if (original_image_path != redacted_image_path) and os.path.exists(
+#             redacted_image_path
+#         ):
+#             os.remove(redacted_image_path)
 
-    _ = fob.create_redaction(
-        test_view,
-        label_field="ground_truth",
-        label_classes=["person", "car"],
-        redaction_type="bounding_box",
-        redaction_method="stack_blur",
-        force_recreate=False,
-        # still recreates since the files are missing
-    )
-    for sample in test_view.iter_samples():
-        redacted_image_path = sample[expected_brain_key + "_filepath"]
-        assert redacted_image_path is not None
-        assert os.path.exists(redacted_image_path)
-    modification_time = os.path.getmtime(
-        test_view.first()[expected_brain_key + "_filepath"]
-    )
+#     _ = fob.create_redaction(
+#         test_view,
+#         label_field="ground_truth",
+#         label_classes=["person", "car"],
+#         redaction_type="bounding_box",
+#         redaction_method="stack_blur",
+#         force_recreate=False,
+#         # still recreates since the files are missing
+#     )
+#     for sample in test_view.iter_samples():
+#         redacted_image_path = sample[expected_brain_key + "_filepath"]
+#         assert redacted_image_path is not None
+#         assert os.path.exists(redacted_image_path)
+#     modification_time = os.path.getmtime(
+#         test_view.first()[expected_brain_key + "_filepath"]
+#     )
 
-    _ = fob.create_redaction(
-        test_view,
-        label_field="ground_truth",
-        label_classes=["person", "car"],
-        redaction_type="bounding_box",
-        redaction_method="stack_blur",
-        force_recreate=True,
-    )
-    new_modification_time = os.path.getmtime(
-        test_view.first()[expected_brain_key + "_filepath"]
-    )
-    assert new_modification_time > modification_time
+#     _ = fob.create_redaction(
+#         test_view,
+#         label_field="ground_truth",
+#         label_classes=["person", "car"],
+#         redaction_type="bounding_box",
+#         redaction_method="stack_blur",
+#         force_recreate=True,
+#     )
+#     new_modification_time = os.path.getmtime(
+#         test_view.first()[expected_brain_key + "_filepath"]
+#     )
+#     assert new_modification_time > modification_time
 
-    dataset.delete_brain_run(expected_brain_key)
+#     dataset.delete_brain_run(expected_brain_key)
 
 
 def test_create_redaction_samples_video():
@@ -106,7 +106,8 @@ def test_create_redaction_samples_video():
         name="test_1_redacted_dataset", overwrite=True
     )
     for redacted_sample in redacted_dataset.iter_samples():
-        assert brain_key in redacted_sample.tags
+        # TODO(neeraja): revisit the tags functionality
+        # assert brain_key in redacted_sample.tags
         assert redacted_sample["filepath"] is not None
         assert os.path.exists(redacted_sample["filepath"])
 
@@ -141,7 +142,8 @@ def test_create_redaction_samples():
         name="test_10_redacted_dataset", overwrite=True
     )
     for redacted_sample in redacted_dataset.iter_samples():
-        assert brain_key in redacted_sample.tags
+        # TODO(neeraja): revisit the tags functionality
+        # assert brain_key in redacted_sample.tags
         assert redacted_sample["filepath"] is not None
         assert os.path.exists(redacted_sample["filepath"])
 

--- a/tests/intensive/test_redaction.py
+++ b/tests/intensive/test_redaction.py
@@ -1,0 +1,121 @@
+"""
+Redaction tests.
+
+| Copyright 2017-2025, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import unittest
+import os
+
+import fiftyone as fo
+import fiftyone.brain as fob
+import fiftyone.zoo as foz
+
+
+def test_create_redaction_fields():
+    dataset = foz.load_zoo_dataset("quickstart").clone()
+    test_view = dataset.take(10, seed=42)
+
+    fob.create_redaction(
+        test_view,
+        label_field="ground_truth",
+        label_classes="person,car",
+        redaction_type="bounding_box",
+        redaction_method="stack_blur",
+    )
+    expected_brain_key = (
+        "redacted_ground_truth_person_car_bounding_box_stack_blur"
+    )
+    assert expected_brain_key in dataset.list_brain_runs()
+    redacted_image_path = test_view.first()[expected_brain_key + "_filepath"]
+    assert redacted_image_path is not None
+    assert os.path.exists(redacted_image_path)
+
+    dataset.delete_brain_runs()
+
+
+def test_recreate_redaction_fields():
+    dataset = foz.load_zoo_dataset("quickstart").clone()
+    test_view = dataset.take(5, seed=42)
+
+    fob.create_redaction(
+        test_view,
+        label_field="ground_truth",
+        label_classes="person,car",
+        redaction_type="bounding_box",
+        redaction_method="stack_blur",
+    )
+    expected_brain_key = (
+        "redacted_ground_truth_person_car_bounding_box_stack_blur"
+    )
+
+    for sample in test_view.iter_samples():
+        redacted_image_path = sample[expected_brain_key + "_filepath"]
+        if os.path.exists(redacted_image_path):
+            os.remove(redacted_image_path)
+
+    fob.create_redaction(
+        test_view,
+        label_field="ground_truth",
+        label_classes="person,car",
+        redaction_type="bounding_box",
+        redaction_method="stack_blur",
+        force_recreate=False,
+        # still recreates since the files are missing
+    )
+    for sample in test_view.iter_samples():
+        redacted_image_path = sample[expected_brain_key + "_filepath"]
+        assert redacted_image_path is not None
+        assert os.path.exists(redacted_image_path)
+    modification_time = os.path.getmtime(
+        test_view.first()[expected_brain_key + "_filepath"]
+    )
+
+    fob.create_redaction(
+        test_view,
+        label_field="ground_truth",
+        label_classes="person,car",
+        redaction_type="bounding_box",
+        redaction_method="stack_blur",
+        force_recreate=True,
+    )
+    new_modification_time = os.path.getmtime(
+        test_view.first()[expected_brain_key + "_filepath"]
+    )
+    assert new_modification_time > modification_time
+
+    dataset.delete_brain_runs()
+
+
+def test_create_redaction_samples():
+    dataset = foz.load_zoo_dataset("quickstart").clone()
+    test_view = dataset.take(10, seed=42)
+
+    fob.create_redaction(
+        test_view,
+        label_field="ground_truth",
+        label_classes="person,car",
+        redaction_type="bounding_box",
+        redaction_method="mask",
+        create_as_new_sample=True,
+    )
+    expected_brain_key = "redacted_ground_truth_person_car_bounding_box_mask"
+    for sample in test_view.iter_samples():
+        if expected_brain_key in sample.tags:
+            continue
+        redacted_sample_id = sample["redacted_sample_ids"][expected_brain_key]
+        assert redacted_sample_id is not None
+        assert redacted_sample_id in dataset.values("id")
+        redacted_sample = dataset[redacted_sample_id]
+        assert redacted_sample["filepath"] is not None
+        assert os.path.exists(redacted_sample["filepath"])
+        assert redacted_sample["original_sample_id"] is not None
+        assert redacted_sample["original_sample_id"] == sample.id
+
+    dataset.delete_brain_runs()
+
+
+if __name__ == "__main__":
+    fo.config.show_progress_bars = True
+    unittest.main(verbosity=2)

--- a/tests/intensive/test_redaction.py
+++ b/tests/intensive/test_redaction.py
@@ -40,8 +40,12 @@ def test_create_redaction_fields():
             nontrivial_samples.first()[brain_key + "_filepath"]
             != nontrivial_samples.first()["filepath"]
         )
+        redacted_image_path = nontrivial_samples.first()[
+            brain_key + "_filepath"
+        ]
 
     dataset.delete_brain_run(brain_key)
+    assert not fos.exists(redacted_image_path)
 
 
 def test_create_redaction_samples_video():

--- a/tests/intensive/test_redaction.py
+++ b/tests/intensive/test_redaction.py
@@ -35,60 +35,6 @@ def test_create_redaction_fields():
     dataset.delete_brain_run(brain_key)
 
 
-# def test_recreate_redaction_fields():
-#     dataset = foz.load_zoo_dataset("quickstart").clone()
-#     test_view = dataset.take(5, seed=42)
-
-#     _ = fob.create_redaction(
-#         test_view,
-#         label_field="ground_truth",
-#         label_classes=["person", "car"],
-#         redaction_type="bounding_box",
-#         redaction_method="stack_blur",
-#     )
-#     expected_brain_key = "redacted_ground_truth_bounding_box_stack_blur"
-
-#     for sample in test_view.iter_samples():
-#         redacted_image_path = sample[expected_brain_key + "_filepath"]
-#         original_image_path = sample["filepath"]
-#         if (original_image_path != redacted_image_path) and os.path.exists(
-#             redacted_image_path
-#         ):
-#             os.remove(redacted_image_path)
-
-#     _ = fob.create_redaction(
-#         test_view,
-#         label_field="ground_truth",
-#         label_classes=["person", "car"],
-#         redaction_type="bounding_box",
-#         redaction_method="stack_blur",
-#         force_recreate=False,
-#         # still recreates since the files are missing
-#     )
-#     for sample in test_view.iter_samples():
-#         redacted_image_path = sample[expected_brain_key + "_filepath"]
-#         assert redacted_image_path is not None
-#         assert os.path.exists(redacted_image_path)
-#     modification_time = os.path.getmtime(
-#         test_view.first()[expected_brain_key + "_filepath"]
-#     )
-
-#     _ = fob.create_redaction(
-#         test_view,
-#         label_field="ground_truth",
-#         label_classes=["person", "car"],
-#         redaction_type="bounding_box",
-#         redaction_method="stack_blur",
-#         force_recreate=True,
-#     )
-#     new_modification_time = os.path.getmtime(
-#         test_view.first()[expected_brain_key + "_filepath"]
-#     )
-#     assert new_modification_time > modification_time
-
-#     dataset.delete_brain_run(expected_brain_key)
-
-
 def test_create_redaction_samples_video():
     dataset = foz.load_zoo_dataset("quickstart-video").clone()
     test_view = dataset.take(1, seed=42)
@@ -106,8 +52,6 @@ def test_create_redaction_samples_video():
         name="test_1_redacted_dataset", overwrite=True
     )
     for redacted_sample in redacted_dataset.iter_samples():
-        # TODO(neeraja): revisit the tags functionality
-        # assert brain_key in redacted_sample.tags
         assert redacted_sample["filepath"] is not None
         assert os.path.exists(redacted_sample["filepath"])
 
@@ -142,8 +86,6 @@ def test_create_redaction_samples():
         name="test_10_redacted_dataset", overwrite=True
     )
     for redacted_sample in redacted_dataset.iter_samples():
-        # TODO(neeraja): revisit the tags functionality
-        # assert brain_key in redacted_sample.tags
         assert redacted_sample["filepath"] is not None
         assert os.path.exists(redacted_sample["filepath"])
 

--- a/tests/intensive/test_redaction.py
+++ b/tests/intensive/test_redaction.py
@@ -22,7 +22,7 @@ def test_create_redaction_fields():
     results = fob.create_redaction(
         test_view,
         label_field="ground_truth",
-        label_classes="person,car",
+        label_classes=["person", "car"],
         redaction_type="bounding_box",
         redaction_method="stack_blur",
         redaction_field=brain_key,
@@ -42,7 +42,7 @@ def test_recreate_redaction_fields():
     _ = fob.create_redaction(
         test_view,
         label_field="ground_truth",
-        label_classes="person,car",
+        label_classes=["person", "car"],
         redaction_type="bounding_box",
         redaction_method="stack_blur",
     )
@@ -50,13 +50,16 @@ def test_recreate_redaction_fields():
 
     for sample in test_view.iter_samples():
         redacted_image_path = sample[expected_brain_key + "_filepath"]
-        if os.path.exists(redacted_image_path):
+        original_image_path = sample["filepath"]
+        if (original_image_path != redacted_image_path) and os.path.exists(
+            redacted_image_path
+        ):
             os.remove(redacted_image_path)
 
     _ = fob.create_redaction(
         test_view,
         label_field="ground_truth",
-        label_classes="person,car",
+        label_classes=["person", "car"],
         redaction_type="bounding_box",
         redaction_method="stack_blur",
         force_recreate=False,
@@ -73,7 +76,7 @@ def test_recreate_redaction_fields():
     _ = fob.create_redaction(
         test_view,
         label_field="ground_truth",
-        label_classes="person,car",
+        label_classes=["person", "car"],
         redaction_type="bounding_box",
         redaction_method="stack_blur",
         force_recreate=True,
@@ -86,6 +89,41 @@ def test_recreate_redaction_fields():
     dataset.delete_brain_run(expected_brain_key)
 
 
+def test_create_redaction_samples_video():
+    dataset = foz.load_zoo_dataset("quickstart-video").clone()
+    test_view = dataset.take(1, seed=42)
+
+    brain_key = "test_create_redaction_samples_video"
+    results = fob.create_redaction(
+        test_view,
+        label_field="frames.detections",
+        label_classes=["person", "car"],
+        redaction_type="bounding_box",
+        redaction_method="mask",
+        redaction_field=brain_key,
+    )
+    redacted_dataset = results.generate_redacted_dataset(
+        name="test_1_redacted_dataset", overwrite=True
+    )
+    for redacted_sample in redacted_dataset.iter_samples():
+        assert brain_key in redacted_sample.tags
+        assert redacted_sample["filepath"] is not None
+        assert os.path.exists(redacted_sample["filepath"])
+
+    assert (
+        len(
+            redacted_dataset.match(
+                F("frames.detections.detections.label").contains(
+                    ["person", "car"]
+                )
+            )
+        )
+        == 0
+    )
+
+    dataset.delete_brain_run(brain_key)
+
+
 def test_create_redaction_samples():
     dataset = foz.load_zoo_dataset("quickstart").clone()
     test_view = dataset.take(10, seed=42)
@@ -94,7 +132,7 @@ def test_create_redaction_samples():
     results = fob.create_redaction(
         test_view,
         label_field="ground_truth",
-        label_classes="person,car",
+        label_classes=["person", "car"],
         redaction_type="bounding_box",
         redaction_method="mask",
         redaction_field=brain_key,

--- a/tests/intensive/test_redaction.py
+++ b/tests/intensive/test_redaction.py
@@ -15,103 +15,106 @@ import fiftyone.core.storage as fos
 from fiftyone import ViewField as F
 
 
-def test_create_redaction_fields():
-    dataset = foz.load_zoo_dataset("quickstart").clone()
-    test_view = dataset.take(10, seed=42)
+class TestRedaction(unittest.TestCase):
+    def test_create_redaction_fields(self):
+        dataset = foz.load_zoo_dataset("quickstart").clone()
+        test_view = dataset.take(10, seed=42)
 
-    brain_key = "test_create_redaction_fields"
-    results = fob.create_redaction(
-        test_view,
-        label_field="ground_truth",
-        label_classes=["person", "car"],
-        redaction_type="bounding_box",
-        redaction_method="stack_blur",
-        redaction_field=brain_key,
-    )
-    assert brain_key in dataset.list_brain_runs()
-    redacted_image_path = test_view.first()[brain_key + "_filepath"]
-    assert redacted_image_path is not None
-    assert fos.exists(redacted_image_path)
-    nontrivial_samples = test_view.match(
-        F("ground_truth.detections.label").contains(["person", "car"])
-    )
-    if len(nontrivial_samples) > 0:
-        assert (
-            nontrivial_samples.first()[brain_key + "_filepath"]
-            != nontrivial_samples.first()["filepath"]
+        brain_key = "test_create_redaction_fields"
+        results = fob.create_redaction(
+            test_view,
+            label_field="ground_truth",
+            label_classes=["person", "car"],
+            redaction_type="bounding_box",
+            redaction_method="stack_blur",
+            redaction_field=brain_key,
         )
-        redacted_image_path = nontrivial_samples.first()[
-            brain_key + "_filepath"
-        ]
+        assert brain_key in dataset.list_brain_runs()
+        redacted_image_path = test_view.first()[brain_key + "_filepath"]
+        assert redacted_image_path is not None
+        assert fos.exists(redacted_image_path)
+        nontrivial_samples = test_view.match(
+            F("ground_truth.detections.label").contains(["person", "car"])
+        )
+        if len(nontrivial_samples) > 0:
+            assert (
+                nontrivial_samples.first()[brain_key + "_filepath"]
+                != nontrivial_samples.first()["filepath"]
+            )
+            redacted_image_path = nontrivial_samples.first()[
+                brain_key + "_filepath"
+            ]
 
-    dataset.delete_brain_run(brain_key)
-    assert not fos.exists(redacted_image_path)
+        dataset.delete_brain_run(brain_key)
+        assert not fos.exists(redacted_image_path)
 
+    def test_create_redaction_samples_video(self):
+        dataset = foz.load_zoo_dataset("quickstart-video").clone()
+        test_view = dataset.limit(1)
 
-def test_create_redaction_samples_video():
-    dataset = foz.load_zoo_dataset("quickstart-video").clone()
-    test_view = dataset.take(1, seed=42)
+        brain_key = "test_create_redaction_samples_video"
+        results = fob.create_redaction(
+            test_view,
+            label_field="frames.detections",
+            label_classes=["person", "car"],
+            redaction_type="bounding_box",
+            redaction_method="mask",
+            redaction_field=brain_key,
+        )
+        redacted_dataset = results.generate_redacted_dataset(
+            name="test_1_redacted_dataset", overwrite=True
+        )
+        for redacted_sample in redacted_dataset.iter_samples():
+            assert redacted_sample["filepath"] is not None
+            assert fos.exists(redacted_sample["filepath"])
 
-    brain_key = "test_create_redaction_samples_video"
-    results = fob.create_redaction(
-        test_view,
-        label_field="frames.detections",
-        label_classes=["person", "car"],
-        redaction_type="bounding_box",
-        redaction_method="mask",
-        redaction_field=brain_key,
-    )
-    redacted_dataset = results.generate_redacted_dataset(
-        name="test_1_redacted_dataset", overwrite=True
-    )
-    for redacted_sample in redacted_dataset.iter_samples():
-        assert redacted_sample["filepath"] is not None
-        assert fos.exists(redacted_sample["filepath"])
-
-    assert (
-        len(
-            redacted_dataset.match(
-                F("frames.detections.detections.label").contains(
-                    ["person", "car"]
+        assert (
+            len(
+                redacted_dataset.match(
+                    F("frames.detections.detections.label").contains(
+                        ["person", "car"]
+                    )
                 )
             )
+            == 0
         )
-        == 0
-    )
 
-    dataset.delete_brain_run(brain_key)
+        dataset.delete_brain_run(brain_key)
+        redacted_dataset.delete()
 
+    def test_create_redaction_samples(self):
+        dataset = foz.load_zoo_dataset("quickstart").clone()
+        test_view = dataset.take(10, seed=42)
 
-def test_create_redaction_samples():
-    dataset = foz.load_zoo_dataset("quickstart").clone()
-    test_view = dataset.take(10, seed=42)
+        brain_key = "test_create_redaction_samples"
+        results = fob.create_redaction(
+            test_view,
+            label_field="ground_truth",
+            label_classes=["person", "car"],
+            redaction_type="bounding_box",
+            redaction_method="mask",
+            redaction_field=brain_key,
+        )
+        redacted_dataset = results.generate_redacted_dataset(
+            name="test_10_redacted_dataset", overwrite=True
+        )
+        for redacted_sample in redacted_dataset.iter_samples():
+            assert redacted_sample["filepath"] is not None
+            assert fos.exists(redacted_sample["filepath"])
 
-    brain_key = "test_create_redaction_samples"
-    results = fob.create_redaction(
-        test_view,
-        label_field="ground_truth",
-        label_classes=["person", "car"],
-        redaction_type="bounding_box",
-        redaction_method="mask",
-        redaction_field=brain_key,
-    )
-    redacted_dataset = results.generate_redacted_dataset(
-        name="test_10_redacted_dataset", overwrite=True
-    )
-    for redacted_sample in redacted_dataset.iter_samples():
-        assert redacted_sample["filepath"] is not None
-        assert fos.exists(redacted_sample["filepath"])
-
-    assert (
-        len(
-            redacted_dataset.match(
-                F("ground_truth.detections.label").contains(["person", "car"])
+        assert (
+            len(
+                redacted_dataset.match(
+                    F("ground_truth.detections.label").contains(
+                        ["person", "car"]
+                    )
+                )
             )
+            == 0
         )
-        == 0
-    )
 
-    dataset.delete_brain_run(brain_key)
+        dataset.delete_brain_run(brain_key)
+        redacted_dataset.delete()
 
 
 if __name__ == "__main__":

--- a/tests/intensive/test_redaction.py
+++ b/tests/intensive/test_redaction.py
@@ -32,10 +32,14 @@ def test_create_redaction_fields():
     redacted_image_path = test_view.first()[brain_key + "_filepath"]
     assert redacted_image_path is not None
     assert fos.exists(redacted_image_path)
-    assert (
-        test_view.first()[brain_key + "_filepath"]
-        != test_view.first()["filepath"]
-    )  # only since the first sample has >0 detections of label classes
+    nontrivial_samples = test_view.match(
+        F("ground_truth.detections.label").contains(["person", "car"])
+    )
+    if len(nontrivial_samples) > 0:
+        assert (
+            nontrivial_samples.first()[brain_key + "_filepath"]
+            != nontrivial_samples.first()["filepath"]
+        )
 
     dataset.delete_brain_run(brain_key)
 

--- a/tests/intensive/test_redaction.py
+++ b/tests/intensive/test_redaction.py
@@ -17,29 +17,28 @@ def test_create_redaction_fields():
     dataset = foz.load_zoo_dataset("quickstart").clone()
     test_view = dataset.take(10, seed=42)
 
-    fob.create_redaction(
+    brain_key = "test_create_redaction_fields"
+    results = fob.create_redaction(
         test_view,
         label_field="ground_truth",
         label_classes="person,car",
         redaction_type="bounding_box",
         redaction_method="stack_blur",
+        redaction_field=brain_key,
     )
-    expected_brain_key = (
-        "redacted_ground_truth_person_car_bounding_box_stack_blur"
-    )
-    assert expected_brain_key in dataset.list_brain_runs()
-    redacted_image_path = test_view.first()[expected_brain_key + "_filepath"]
+    assert brain_key in dataset.list_brain_runs()
+    redacted_image_path = test_view.first()[brain_key + "_filepath"]
     assert redacted_image_path is not None
     assert os.path.exists(redacted_image_path)
 
-    dataset.delete_brain_runs()
+    dataset.delete_brain_run(brain_key)
 
 
 def test_recreate_redaction_fields():
     dataset = foz.load_zoo_dataset("quickstart").clone()
     test_view = dataset.take(5, seed=42)
 
-    fob.create_redaction(
+    _ = fob.create_redaction(
         test_view,
         label_field="ground_truth",
         label_classes="person,car",
@@ -55,7 +54,7 @@ def test_recreate_redaction_fields():
         if os.path.exists(redacted_image_path):
             os.remove(redacted_image_path)
 
-    fob.create_redaction(
+    _ = fob.create_redaction(
         test_view,
         label_field="ground_truth",
         label_classes="person,car",
@@ -72,7 +71,7 @@ def test_recreate_redaction_fields():
         test_view.first()[expected_brain_key + "_filepath"]
     )
 
-    fob.create_redaction(
+    _ = fob.create_redaction(
         test_view,
         label_field="ground_truth",
         label_classes="person,car",
@@ -85,35 +84,32 @@ def test_recreate_redaction_fields():
     )
     assert new_modification_time > modification_time
 
-    dataset.delete_brain_runs()
+    dataset.delete_brain_run(expected_brain_key)
 
 
 def test_create_redaction_samples():
     dataset = foz.load_zoo_dataset("quickstart").clone()
     test_view = dataset.take(10, seed=42)
 
-    fob.create_redaction(
+    brain_key = "test_create_redaction_samples"
+    results = fob.create_redaction(
         test_view,
         label_field="ground_truth",
         label_classes="person,car",
         redaction_type="bounding_box",
         redaction_method="mask",
-        create_as_new_sample=True,
+        redaction_field=brain_key,
+        create_as_new_sample=False,
     )
-    expected_brain_key = "redacted_ground_truth_person_car_bounding_box_mask"
-    for sample in test_view.iter_samples():
-        if expected_brain_key in sample.tags:
-            continue
-        redacted_sample_id = sample["redacted_sample_ids"][expected_brain_key]
-        assert redacted_sample_id is not None
-        assert redacted_sample_id in dataset.values("id")
-        redacted_sample = dataset[redacted_sample_id]
+    redacted_dataset = results.generate_redacted_dataset(
+        name="test_10_redacted_dataset", overwrite=True
+    )
+    for redacted_sample in redacted_dataset.iter_samples():
+        assert brain_key in redacted_sample.tags
         assert redacted_sample["filepath"] is not None
         assert os.path.exists(redacted_sample["filepath"])
-        assert redacted_sample["original_sample_id"] is not None
-        assert redacted_sample["original_sample_id"] == sample.id
 
-    dataset.delete_brain_runs()
+    dataset.delete_brain_run(brain_key)
 
 
 if __name__ == "__main__":

--- a/tests/intensive/test_redaction.py
+++ b/tests/intensive/test_redaction.py
@@ -11,6 +11,7 @@ import os
 import fiftyone as fo
 import fiftyone.brain as fob
 import fiftyone.zoo as foz
+from fiftyone import ViewField as F
 
 
 def test_create_redaction_fields():
@@ -99,7 +100,6 @@ def test_create_redaction_samples():
         redaction_type="bounding_box",
         redaction_method="mask",
         redaction_field=brain_key,
-        create_as_new_sample=False,
     )
     redacted_dataset = results.generate_redacted_dataset(
         name="test_10_redacted_dataset", overwrite=True
@@ -108,6 +108,15 @@ def test_create_redaction_samples():
         assert brain_key in redacted_sample.tags
         assert redacted_sample["filepath"] is not None
         assert os.path.exists(redacted_sample["filepath"])
+
+    assert (
+        len(
+            redacted_dataset.match(
+                F("ground_truth.detections.label").contains(["person", "car"])
+            )
+        )
+        == 0
+    )
 
     dataset.delete_brain_run(brain_key)
 

--- a/tests/intensive/test_redaction.py
+++ b/tests/intensive/test_redaction.py
@@ -11,6 +11,7 @@ import os
 import fiftyone as fo
 import fiftyone.brain as fob
 import fiftyone.zoo as foz
+import fiftyone.core.storage as fos
 from fiftyone import ViewField as F
 
 
@@ -30,7 +31,11 @@ def test_create_redaction_fields():
     assert brain_key in dataset.list_brain_runs()
     redacted_image_path = test_view.first()[brain_key + "_filepath"]
     assert redacted_image_path is not None
-    assert os.path.exists(redacted_image_path)
+    assert fos.exists(redacted_image_path)
+    assert (
+        test_view.first()[brain_key + "_filepath"]
+        != test_view.first()["filepath"]
+    )  # only since the first sample has >0 detections of label classes
 
     dataset.delete_brain_run(brain_key)
 
@@ -53,7 +58,7 @@ def test_create_redaction_samples_video():
     )
     for redacted_sample in redacted_dataset.iter_samples():
         assert redacted_sample["filepath"] is not None
-        assert os.path.exists(redacted_sample["filepath"])
+        assert fos.exists(redacted_sample["filepath"])
 
     assert (
         len(
@@ -87,7 +92,7 @@ def test_create_redaction_samples():
     )
     for redacted_sample in redacted_dataset.iter_samples():
         assert redacted_sample["filepath"] is not None
-        assert os.path.exists(redacted_sample["filepath"])
+        assert fos.exists(redacted_sample["filepath"])
 
     assert (
         len(


### PR DESCRIPTION
# Rationale

This feature gives users the ability to mask or blur sensitive information from their datasets, thereby enabling them to share their data wider.
Users can specify the detection field and label classes of their choice, as well as the redaction region (bounding_box/segementation_mask) and method.

_This method assumes that the label field & classes to be redacted already exist. For functionality that includes model application, we may maintain a plugin in FO Labs._

## Changes

Added a new brain method `create_redaction`, that operates on a collection of samples and accepts various arguments relating to the redaction method.

## Testing

- `test_interface.py::test_redaction` for checking a basic operation
- `test_redaction.py` for checking edge cases

## Notes

- If the provided `label_field` is not present in the sample collection, raises an error
- If the provided `label_classes` are not present in the sample/collection, nothing is redacted in the new media

## Related

Earlier version at https://github.com/neerajaabhyankar/redaction-plugin.
This will still be maintained, since it includes a single-operation `apply_model` + `create_redaction` capability. (ToDo: update the plugin to use this brain method.)

Presently, there does not exist a very high-quality face detection model that is worth recommending (the closest is https://huggingface.co/EsraaFouad/detr_fine_tune_face_detection_final but it also detects animal faces). Application via huggingface is easy; open to opinions on having it in the plugin v/s the brain method v/s entirely up to the user to bring their own model for flexibility in what they want to redact.

## JIRA

https://voxel51.atlassian.net/browse/ML-279

<!-- Optional Sections:
## Screenshots
## Related
-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->