### PR TITLE
Ensure ids exist in lancedb index when querying

### DIFF
--- a/fiftyone/brain/internal/core/elasticsearch.py
+++ b/fiftyone/brain/internal/core/elasticsearch.py
@@ -781,9 +781,10 @@ class ElasticsearchSimilarityIndex(SimilarityIndex):
         query = np.array(
             [r["_source"]["vector"] for r in response["docs"] if r["found"]]
         )
+
         if query.size == 0:
             raise ValueError(
-                "Query ids %s were not found in the index" % query_ids
+                "Query IDs %s were not found in the index" % query_ids
             )
 
         if single_query:

--- a/fiftyone/brain/internal/core/elasticsearch.py
+++ b/fiftyone/brain/internal/core/elasticsearch.py
@@ -781,6 +781,10 @@ class ElasticsearchSimilarityIndex(SimilarityIndex):
         query = np.array(
             [r["_source"]["vector"] for r in response["docs"] if r["found"]]
         )
+        if query.size == 0:
+            raise ValueError(
+                "Query ids %s were not found in the index" % query_ids
+            )
 
         if single_query:
             query = query[0, :]

--- a/fiftyone/brain/internal/core/lancedb.py
+++ b/fiftyone/brain/internal/core/lancedb.py
@@ -485,10 +485,12 @@ class LanceDBSimilarityIndex(SimilarityIndex):
         df = self._table.to_pandas()
         df = df[df["id"].isin(query_ids)]
         query = np.array([v for v in df["vector"]])
+
         if query.size == 0:
             raise ValueError(
-                "Query ids %s were not found in the LanceDB index" % query_ids
+                "Query IDs %s were not found in the index" % query_ids
             )
+
         if single_query:
             query = query[0, :]
 

--- a/fiftyone/brain/internal/core/lancedb.py
+++ b/fiftyone/brain/internal/core/lancedb.py
@@ -433,8 +433,7 @@ class LanceDBSimilarityIndex(SimilarityIndex):
                 index_ids = list(self.current_sample_ids)
 
             df = table.to_pandas()
-            df.set_index("id", drop=False, inplace=True)
-            df = df.loc[df.index.isin(set(index_ids))]
+            df = df[df["id"].isin(index_ids)]
             table = self._db.create_table(
                 self.config.table_name + "_filter", df, mode="overwrite"
             )
@@ -484,8 +483,7 @@ class LanceDBSimilarityIndex(SimilarityIndex):
 
         # Query by ID(s)
         df = self._table.to_pandas()
-        df.set_index("id", drop=False, inplace=True)
-        df = df.loc[df.index.isin(set(query_ids))]
+        df = df[df["id"].isin(query_ids)]
         query = np.array([v for v in df["vector"]])
         if query.size == 0:
             raise ValueError(

--- a/fiftyone/brain/internal/core/lancedb.py
+++ b/fiftyone/brain/internal/core/lancedb.py
@@ -434,7 +434,7 @@ class LanceDBSimilarityIndex(SimilarityIndex):
 
             df = table.to_pandas()
             df.set_index("id", drop=False, inplace=True)
-            df = df.loc[index_ids]
+            df = df.loc[df.index.isin(set(index_ids))]
             table = self._db.create_table(
                 self.config.table_name + "_filter", df, mode="overwrite"
             )
@@ -485,8 +485,12 @@ class LanceDBSimilarityIndex(SimilarityIndex):
         # Query by ID(s)
         df = self._table.to_pandas()
         df.set_index("id", drop=False, inplace=True)
-        df = df.loc[query_ids]
+        df = df.loc[df.index.isin(set(query_ids))]
         query = np.array([v for v in df["vector"]])
+        if query.size == 0:
+            raise ValueError(
+                "Sample ids %s were not found in the LanceDB index" % query_ids
+            )
         if single_query:
             query = query[0, :]
 

--- a/fiftyone/brain/internal/core/lancedb.py
+++ b/fiftyone/brain/internal/core/lancedb.py
@@ -487,7 +487,7 @@ class LanceDBSimilarityIndex(SimilarityIndex):
         query = np.array([v for v in df["vector"]])
         if query.size == 0:
             raise ValueError(
-                "Sample ids %s were not found in the LanceDB index" % query_ids
+                "Query ids %s were not found in the LanceDB index" % query_ids
             )
         if single_query:
             query = query[0, :]

--- a/fiftyone/brain/internal/core/milvus.py
+++ b/fiftyone/brain/internal/core/milvus.py
@@ -755,9 +755,10 @@ class MilvusSimilarityIndex(SimilarityIndex):
         # Query by ID(s)
         response = self._get_embeddings(query_ids)
         query = np.array([x["vector"] for x in response])
+
         if query.size == 0:
             raise ValueError(
-                "Query ids %s were not found in the index" % query_ids
+                "Query IDs %s were not found in the index" % query_ids
             )
 
         if single_query:

--- a/fiftyone/brain/internal/core/milvus.py
+++ b/fiftyone/brain/internal/core/milvus.py
@@ -755,6 +755,10 @@ class MilvusSimilarityIndex(SimilarityIndex):
         # Query by ID(s)
         response = self._get_embeddings(query_ids)
         query = np.array([x["vector"] for x in response])
+        if query.size == 0:
+            raise ValueError(
+                "Query ids %s were not found in the index" % query_ids
+            )
 
         if single_query:
             query = query[0, :]

--- a/fiftyone/brain/internal/core/pinecone.py
+++ b/fiftyone/brain/internal/core/pinecone.py
@@ -620,9 +620,10 @@ class PineconeSimilarityIndex(SimilarityIndex):
         # Query by ID(s)
         response = self._index.fetch(query_ids)["vectors"]
         query = np.array([response[_id]["values"] for _id in query_ids])
+
         if query.size == 0:
             raise ValueError(
-                "Query ids %s were not found in the index" % query_ids
+                "Query IDs %s were not found in the index" % query_ids
             )
 
         if single_query:

--- a/fiftyone/brain/internal/core/pinecone.py
+++ b/fiftyone/brain/internal/core/pinecone.py
@@ -620,6 +620,10 @@ class PineconeSimilarityIndex(SimilarityIndex):
         # Query by ID(s)
         response = self._index.fetch(query_ids)["vectors"]
         query = np.array([response[_id]["values"] for _id in query_ids])
+        if query.size == 0:
+            raise ValueError(
+                "Query ids %s were not found in the index" % query_ids
+            )
 
         if single_query:
             query = query[0, :]

--- a/fiftyone/brain/internal/core/qdrant.py
+++ b/fiftyone/brain/internal/core/qdrant.py
@@ -653,9 +653,10 @@ class QdrantSimilarityIndex(SimilarityIndex):
         qids = self._to_qdrant_ids(query_ids)
         response = self._retrieve_points(qids, with_vectors=True)
         query = np.array([r.vector for r in response])
+
         if query.size == 0:
             raise ValueError(
-                "Query ids %s were not found in the index" % query_ids
+                "Query IDs %s were not found in the index" % query_ids
             )
 
         if single_query:

--- a/fiftyone/brain/internal/core/qdrant.py
+++ b/fiftyone/brain/internal/core/qdrant.py
@@ -653,6 +653,10 @@ class QdrantSimilarityIndex(SimilarityIndex):
         qids = self._to_qdrant_ids(query_ids)
         response = self._retrieve_points(qids, with_vectors=True)
         query = np.array([r.vector for r in response])
+        if query.size == 0:
+            raise ValueError(
+                "Query ids %s were not found in the index" % query_ids
+            )
 
         if single_query:
             query = query[0, :]


### PR DESCRIPTION
# Rationale

There exist a few bugs in the lancedb integration when attempting to perform similarity search queries if:

- You query on a view that includes samples not in the lancedb table (for example, when querying on a slice of a grouped dataset)
```python
import fiftyone.brain as fob
import fiftyone.zoo as foz
import fiftyone as fo
import numpy as np

dataset = foz.load_zoo_dataset("quickstart-groups")
embeddings = np.random.random((100, 512))
dataset[:100].set_values("embeddings", embeddings)
index = fob.compute_similarity(
    dataset.exists("embeddings"),
    embeddings="embeddings",
    brain_key="group_sim",
    backend="lancedb",
)

session = fo.launch_app(dataset)
# SelectGroupSlices for the `left` slice
# Perform a image similarity search and hit an error
```

- You select a sample that doesn't exist in the similarity index to search on (this may still raise an error if there are no valid samples selected, but that error is now also more informative)

## Changes

When subselecting samples from the lancedb table, ensure the samples being selected exist in the table.

## Testing

The above code works now

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->