### PR TITLE
Standardizing on `sh` in install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ and run the install script:
 
 ```shell
 # Mac or Linux
-bash install.bash
+bash install.sh
 
 # Windows
 .\install.bat
@@ -75,7 +75,7 @@ developer installation using the `-d` flag of the install script:
 
 ```shell
 # Mac or Linux
-bash install.bash -d
+bash install.sh -d
 
 # Windows
 .\install.bat -d

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 # Installs the `fiftyone-brain` package and its dependencies.
 #
 # Usage:
-#   bash install.bash
+#   sh install.sh
 #
 # Copyright 2017-2025, Voxel51, Inc.
 # voxel51.com
@@ -11,7 +11,7 @@
 # Show usage information
 set -e
 usage() {
-    echo "Usage:  bash $0 [-h] [-d]
+    echo "Usage:  sh $0 [-h] [-d]
 
 Getting help:
 -h      Display this help message.


### PR DESCRIPTION
https://github.com/voxel51/fiftyone/pull/6348 converted FO's install scripts from `bash` to `sh`, including [this change](https://github.com/voxel51/fiftyone/blob/84d631652dd17132d9c864c2a11e1a4383684198/install.sh#L175), which assumed that FOB's install script would also be converted. However, this was not done... until now!