### PR TITLE
FOEPD-2833: Updated copyright notices to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@ file or class name and description of purpose be included on the
 same "printed page" as the copyright notice for easier
 identification within third-party archives.
 
-Copyright 2017-2022, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/fiftyone/brain/__init__.py
+++ b/fiftyone/brain/__init__.py
@@ -4,7 +4,7 @@ and visualization.
 
 See https://github.com/voxel51/fiftyone for more information.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/config.py
+++ b/fiftyone/brain/config.py
@@ -1,7 +1,7 @@
 """
 Brain config.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/__init__.py
+++ b/fiftyone/brain/internal/__init__.py
@@ -3,7 +3,7 @@ Internal FiftyOne Brain package.
 
 Contains all non-public code powering the ``fiftyone.brain`` public namespace.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/__init__.py
+++ b/fiftyone/brain/internal/core/__init__.py
@@ -1,5 +1,5 @@
 """
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/duplicates.py
+++ b/fiftyone/brain/internal/core/duplicates.py
@@ -1,7 +1,7 @@
 """
 Duplicates methods.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/elasticsearch.py
+++ b/fiftyone/brain/internal/core/elasticsearch.py
@@ -1,7 +1,7 @@
 """
 Elastisearch similarity backend.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/hardness.py
+++ b/fiftyone/brain/internal/core/hardness.py
@@ -1,7 +1,7 @@
 """
 Hardness methods.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/lancedb.py
+++ b/fiftyone/brain/internal/core/lancedb.py
@@ -1,7 +1,7 @@
 """
 LanceDB similarity backend.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/leaky_splits.py
+++ b/fiftyone/brain/internal/core/leaky_splits.py
@@ -1,7 +1,7 @@
 """
 Finds leaks between splits.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/milvus.py
+++ b/fiftyone/brain/internal/core/milvus.py
@@ -1,7 +1,7 @@
 """
 Milvus similarity backend.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/mistakenness.py
+++ b/fiftyone/brain/internal/core/mistakenness.py
@@ -1,7 +1,7 @@
 """
 Mistakenness methods.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/mongodb.py
+++ b/fiftyone/brain/internal/core/mongodb.py
@@ -1,7 +1,7 @@
 """
 MongoDB similarity backend.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/mosaic.py
+++ b/fiftyone/brain/internal/core/mosaic.py
@@ -1,7 +1,7 @@
 """
 Mosaic similarity backend.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/pgvector.py
+++ b/fiftyone/brain/internal/core/pgvector.py
@@ -1,7 +1,7 @@
 """
 PGVector similarity backend.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/pinecone.py
+++ b/fiftyone/brain/internal/core/pinecone.py
@@ -1,7 +1,7 @@
 """
 Piencone similarity backend.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/qdrant.py
+++ b/fiftyone/brain/internal/core/qdrant.py
@@ -1,7 +1,7 @@
 """
 Qdrant similarity backend.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/redis.py
+++ b/fiftyone/brain/internal/core/redis.py
@@ -1,7 +1,7 @@
 """
 Redis similarity backend.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/representativeness.py
+++ b/fiftyone/brain/internal/core/representativeness.py
@@ -1,7 +1,7 @@
 """
 Representativeness methods.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/sklearn.py
+++ b/fiftyone/brain/internal/core/sklearn.py
@@ -1,7 +1,7 @@
 """
 Sklearn similarity backend.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/uniqueness.py
+++ b/fiftyone/brain/internal/core/uniqueness.py
@@ -1,7 +1,7 @@
 """
 Uniqueness methods.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/utils.py
+++ b/fiftyone/brain/internal/core/utils.py
@@ -1,7 +1,7 @@
 """
 Utilities.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/core/visualization.py
+++ b/fiftyone/brain/internal/core/visualization.py
@@ -1,7 +1,7 @@
 """
 Visualization methods.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/models/__init__.py
+++ b/fiftyone/brain/internal/models/__init__.py
@@ -1,7 +1,7 @@
 """
 Brain models.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/models/simple_resnet.py
+++ b/fiftyone/brain/internal/models/simple_resnet.py
@@ -4,7 +4,7 @@ Implementation of a simple ResNet that is suitable only for smallish data.
 The original implementation of this is from David Page's work on fast model
 training with resnets at https://github.com/davidcpage/cifar10-fast.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/internal/models/torch.py
+++ b/fiftyone/brain/internal/models/torch.py
@@ -1,7 +1,7 @@
 """
 PyTorch utilities.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/similarity.py
+++ b/fiftyone/brain/similarity.py
@@ -1,7 +1,7 @@
 """
 Similarity interface.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -1,7 +1,7 @@
 """
 Visualization interface.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/install.bat
+++ b/install.bat
@@ -4,7 +4,7 @@
 :: Usage:
 :: .\install.bat
 ::
-:: Copyright 2017-2025, Voxel51, Inc.
+:: Copyright 2017-2026, Voxel51, Inc.
 :: voxel51.com
 ::
 :: Commands:

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 # Usage:
 #   sh install.sh
 #
-# Copyright 2017-2025, Voxel51, Inc.
+# Copyright 2017-2026, Voxel51, Inc.
 # voxel51.com
 #
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 """
 Installs `fiftyone-brain`.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/README.md
+++ b/tests/README.md
@@ -34,4 +34,4 @@ pytest <file>.py -s -k <test_function_name>
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/tests/intensive/test_interface.py
+++ b/tests/intensive/test_interface.py
@@ -1,7 +1,7 @@
 """
 Brain interface tests.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/test_similarity.py
+++ b/tests/intensive/test_similarity.py
@@ -116,7 +116,7 @@ Brain config setup at `~/.fiftyone/brain_config.json`::
         }
     }
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/test_uniqueness.py
+++ b/tests/intensive/test_uniqueness.py
@@ -1,7 +1,7 @@
 """
 Uniqueness tests.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/test_visualization.py
+++ b/tests/intensive/test_visualization.py
@@ -5,7 +5,7 @@ All of these tests are designed to be run manually via::
 
     pytest tests/intensive/test_visualization.py -s -k test_<name>
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/models/test_simple_resnet.py
+++ b/tests/models/test_simple_resnet.py
@@ -1,7 +1,7 @@
 """
 Tests for :mod:`fiftyone.brain.internal.models.simple_resnet`.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/test_uniqueness.py
+++ b/tests/test_uniqueness.py
@@ -1,7 +1,7 @@
 """
 Uniqueness tests.
 
-| Copyright 2017-2025, Voxel51, Inc.
+| Copyright 2017-2026, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """


### PR DESCRIPTION
# Rationale

n/a

## Changes

Updated copyright year to 2026. Does not add copyright notices to files without them.

## Testing

n/a
