### PR TITLE
chore(actions): AS-1199 update brain secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
           repository: voxel51/fiftyone
       - name: Clone voxel51-eta
         uses: actions/checkout@v6
+        if: ${{ !startsWith(github.ref, 'refs/heads/rel') && !startsWith(github.ref, 'refs/tags/') }}
         with:
           fetch-depth: 1
           path: eta
@@ -121,6 +122,7 @@ jobs:
         # Install from PyPI
         if: ${{ !startsWith(github.ref, 'refs/heads/rel') && !startsWith(github.ref, 'refs/tags/') }}
         run: |
+          echo "Installing ETA from source because github.ref = ${{ github.ref }} (not a release)"
           python setup.py bdist_wheel
           pip install ./dist/*.whl --force-reinstall
       - name: Reinstall fiftyone-brain

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
           repository: voxel51/eta
       # ETA tests will create a storage client which, 
       # in it's __init__, tries to log in to GCP.
+      # See tests/tests_uniqueness.py
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,9 @@ jobs:
           pip install ./dist/*.whl
       - name: Install ETA from source
         working-directory: eta
+        # Don't install from source if this is a release.
+        # Install from PyPI
+        if: ${{ !startsWith(github.ref, 'refs/heads/rel') && !startsWith(github.ref, 'refs/tags/') }}
         run: |
           python setup.py bdist_wheel
           pip install ./dist/*.whl --force-reinstall

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,17 +71,27 @@ jobs:
       - name: Clone fiftyone
         uses: actions/checkout@v6
         with:
+          fetch-depth: 1
           path: fiftyone-src
-          depth: 1
           ref: develop
           repository: voxel51/fiftyone
       - name: Clone voxel51-eta
         uses: actions/checkout@v6
         with:
+          fetch-depth: 1
           path: eta
-          depth: 1
           ref: develop
           repository: voxel51/eta
+      # ETA tests will create a storage client which, 
+      # in it's __init__, tries to log in to GCP.
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: ${{ secrets.REPO_GCP_PROJECT }}
+          service_account: ${{ secrets.REPO_GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.REPO_GOOGLE_WORKLOAD_IDP }}
+      - name: Set Up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v6
         with:
@@ -103,20 +113,11 @@ jobs:
       - name: Install ETA from source
         working-directory: eta
         run: |
-          echo "Installing ETA from source because github.ref = ${{ github.ref }} (not a release)"
           python setup.py bdist_wheel
           pip install ./dist/*.whl --force-reinstall
       - name: Reinstall fiftyone-brain
         run: |
           pip install --force-reinstall --no-deps dist/*.whl
-      # - name: Set up ETA credentials
-      #   env:
-      #     FIFTYONE_GOOGLE_CREDENTIALS: ${{ secrets.FIFTYONE_GOOGLE_CREDENTIALS }}
-      #   run: |
-      #     mkdir -p "${HOME}/.eta"
-      #     echo "$FIFTYONE_GOOGLE_CREDENTIALS" > "${HOME}/.eta/google-credentials.json"
-      #     wc "${HOME}/.eta/google-credentials.json"
-      #     md5sum "${HOME}/.eta/google-credentials.json"
       - name: Install test dependencies
         run: |
           pip install imageio pytest torch torchvision

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - develop
-      - afoley/as-1199-remove-brain-secrets
     tags:
       - v*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - develop
+      - afoley/as-1199-remove-brain-secrets
     tags:
       - v*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,20 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: true
+      - name: Clone fiftyone
+        uses: actions/checkout@v6
+        with:
+          path: fiftyone-src
+          depth: 1
+          ref: develop
+          repository: voxel51/fiftyone
+      - name: Clone voxel51-eta
+        uses: actions/checkout@v6
+        with:
+          path: eta
+          depth: 1
+          ref: develop
+          repository: voxel51/eta
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v6
         with:
@@ -80,31 +94,28 @@ jobs:
           name: dist
           path: dist/
       - name: Install fiftyone
+        working-directory: fiftyone-src
         run: |
-          git clone https://${{ secrets.FIFTYONE_GITHUB_TOKEN }}@github.com/voxel51/fiftyone fiftyone-src --depth 1 --branch develop
-          cd fiftyone-src
           python setup.py bdist_wheel
           pip install voxel51-eta[storage] fiftyone-db
           pip install ./dist/*.whl
       - name: Install ETA from source
-        if: ${{ !startsWith(github.ref, 'refs/heads/rel') && !startsWith(github.ref, 'refs/tags/') }}
+        working-directory: eta
         run: |
           echo "Installing ETA from source because github.ref = ${{ github.ref }} (not a release)"
-          git clone https://github.com/voxel51/eta eta --depth 1 --branch develop
-          cd eta
           python setup.py bdist_wheel
           pip install ./dist/*.whl --force-reinstall
       - name: Reinstall fiftyone-brain
         run: |
           pip install --force-reinstall --no-deps dist/*.whl
-      - name: Set up ETA credentials
-        env:
-          FIFTYONE_GOOGLE_CREDENTIALS: ${{ secrets.FIFTYONE_GOOGLE_CREDENTIALS }}
-        run: |
-          mkdir -p "${HOME}/.eta"
-          echo "$FIFTYONE_GOOGLE_CREDENTIALS" > "${HOME}/.eta/google-credentials.json"
-          wc "${HOME}/.eta/google-credentials.json"
-          md5sum "${HOME}/.eta/google-credentials.json"
+      # - name: Set up ETA credentials
+      #   env:
+      #     FIFTYONE_GOOGLE_CREDENTIALS: ${{ secrets.FIFTYONE_GOOGLE_CREDENTIALS }}
+      #   run: |
+      #     mkdir -p "${HOME}/.eta"
+      #     echo "$FIFTYONE_GOOGLE_CREDENTIALS" > "${HOME}/.eta/google-credentials.json"
+      #     wc "${HOME}/.eta/google-credentials.json"
+      #     md5sum "${HOME}/.eta/google-credentials.json"
       - name: Install test dependencies
         run: |
           pip install imageio pytest torch torchvision

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,9 @@ jobs:
       FIFTYONE_DATASET_ZOO_DIR: ${{ github.workspace }}/.fiftyone
       FIFTYONE_DO_NOT_TRACK: true
       FIFTYONE_MODEL_ZOO_DIR: ${{ github.workspace }}/.fiftyone
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:

--- a/tests/intensive/test_visualization.py
+++ b/tests/intensive/test_visualization.py
@@ -13,7 +13,6 @@ import unittest
 
 import cv2
 import numpy as np
-import random as rand
 
 import fiftyone as fo
 import fiftyone.brain as fob

--- a/tests/models/test_simple_resnet.py
+++ b/tests/models/test_simple_resnet.py
@@ -7,9 +7,7 @@ Tests for :mod:`fiftyone.brain.internal.models.simple_resnet`.
 """
 import imageio
 from PIL import Image
-import pytest
 import torch
-import torchvision
 
 import eta.core.image as etai
 


### PR DESCRIPTION
# Rationale

Dependabot has been running against this repo but didn't have access to the secrets. Therefore, all of the tests it ran failed. This made triaging the PRs difficult.

While inspecting this action, I noticed that we were using:

1. a long lived `git` token, which isn't required
2. a long lived service account key

We can remove (1) and use short-lived tokens for (2) via WIF

## Changes

1. Use the `google-github-actions/auth@v3` action to authenticate to GCP and add comments as to why that's needed
2. Replace the `git clone` bash steps with `actions/checkout@v6`
3. Adds the required WIF secrets
4. Removes unused imports in the tests

## Testing

I tested with `push.branches=[afoley/as-1199-remove-brain-secrets]`

Result: https://github.com/voxel51/fiftyone-brain/actions/runs/21075220495/job/60615314133

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->