### PR TITLE
fix out of disk space

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,11 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
+      - name: Free Disk Space (Ubuntu) # standard runner's 14 GB available disk size isn't enough. Need at least 22 GB free.
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          large-packages: false # e2e test failed when `true`
+          docker-images: false
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,9 +73,6 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Free Disk Space (Ubuntu) # standard runner's 14 GB available disk size isn't enough. Need at least 22 GB free.
         uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          large-packages: false # e2e test failed when `true`
-          docker-images: false
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
# Rationale

Free up disk space to avoid out of space errors when running tests

## Changes

- copied https://github.com/voxel51/fiftyone-teams/blob/f381c19be98fa95c08d8c8edf9e0b44b3aecef46/.github/workflows/test.yml#L85

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->