### PR TITLE
Remove stale gate blocking image models from video embeddings

### DIFF
--- a/fiftyone/brain/internal/core/utils.py
+++ b/fiftyone/brain/internal/core/utils.py
@@ -783,16 +783,6 @@ def get_embeddings(
                 progress=progress,
             )
         else:
-            if (
-                samples.media_type == fomm.VIDEO
-                and model.media_type == fomm.IMAGE
-            ):
-                raise ValueError(
-                    "This method cannot use image models to compute video "
-                    "embeddings. Try providing precomputed video embeddings "
-                    "or converting to a frames view via `to_frames()` first"
-                )
-
             logger.info("Computing embeddings...")
             embeddings = samples.compute_embeddings(
                 model,
@@ -813,6 +803,17 @@ def get_embeddings(
             embeddings = [
                 embeddings.get(_id, None) for _id in samples.values("id")
             ]
+
+        # Per-frame embeddings from video datasets need aggregation to
+        # per-sample embeddings for visualization/similarity
+        if isinstance(embeddings, list) and embeddings:
+            _agg = []
+            for e in embeddings:
+                if isinstance(e, np.ndarray) and e.ndim == 2:
+                    _agg.append(e.mean(axis=0))
+                else:
+                    _agg.append(e)
+            embeddings = _agg
 
         embeddings, ref_sample_ids = _handle_missing_embeddings(
             embeddings, samples


### PR DESCRIPTION
## Summary

- Remove the `ValueError` gate in `get_embeddings` that rejects image models on video datasets
- Add mean-pool aggregation for per-frame embeddings returned by the video-to-frames routing

## Context

The gate at `utils.py:786-794` was added in May 2023 when `compute_embeddings` had no way to handle image models on video datasets. In May 2025, `compute_embeddings` gained `process_video_frames` routing (voxel51/fiftyone#5711) which decomposes videos to frames and embeds each frame individually. The gate was never removed, so it now blocks a valid code path.

This was reported by users trying to run `compute_visualization` and `compute_similarity` with Qwen3-VL embedding models on video datasets (voxel51/fiftyone#6778).

## Changes

1. **Removed the gate** that raised `ValueError: This method cannot use image models to compute video embeddings`
2. **Added per-frame to per-sample aggregation**: when `compute_embeddings` returns a dict of per-frame embedding arrays (variable frame counts per video), mean-pool each sample's frames down to a single vector before passing to `np.stack`

## Test plan

- [x] `compute_similarity` on `quickstart-video` with `qwen3-vl-embedding-2b-torch` — passes
- [x] `compute_visualization` on `quickstart-video` — passes the brain gate (UMAP step fails on unrelated NumPy/Numba version conflict)
- [x] `compute_similarity` on `quickstart` (image dataset) — no regression
- [x] Existing `test_qwen3_vl.py` unit tests — 28/28 pass
- [x] Brain `test_similarity.py` suite — same 5 pass / 7 fail as before change (pre-existing failures from missing qdrant, version mismatch, embedding dimension mismatch)