### PR TITLE
Route models to video mode when applied to video collections

### DIFF
--- a/fiftyone/brain/internal/core/utils.py
+++ b/fiftyone/brain/internal/core/utils.py
@@ -787,11 +787,17 @@ def get_embeddings(
                 samples.media_type == fomm.VIDEO
                 and model.media_type == fomm.IMAGE
             ):
-                raise ValueError(
-                    "This method cannot use image models to compute video "
-                    "embeddings. Try providing precomputed video embeddings "
-                    "or converting to a frames view via `to_frames()` first"
-                )
+                if hasattr(model, "mode"):
+                    try:
+                        model.mode = "video"
+                    except Exception:
+                        pass
+                if model.media_type == fomm.IMAGE:
+                    raise ValueError(
+                        "This method cannot use image models to compute video "
+                        "embeddings. Try providing precomputed video embeddings "
+                        "or converting to a frames view via `to_frames()` first"
+                    )
 
             logger.info("Computing embeddings...")
             embeddings = samples.compute_embeddings(

--- a/fiftyone/brain/internal/core/utils.py
+++ b/fiftyone/brain/internal/core/utils.py
@@ -783,22 +783,6 @@ def get_embeddings(
                 progress=progress,
             )
         else:
-            if (
-                samples.media_type == fomm.VIDEO
-                and model.media_type == fomm.IMAGE
-            ):
-                if hasattr(model, "mode"):
-                    try:
-                        model.mode = "video"
-                    except Exception:
-                        pass
-                if model.media_type == fomm.IMAGE:
-                    raise ValueError(
-                        "This method cannot use image models to compute video "
-                        "embeddings. Try providing precomputed video embeddings "
-                        "or converting to a frames view via `to_frames()` first"
-                    )
-
             logger.info("Computing embeddings...")
             embeddings = samples.compute_embeddings(
                 model,


### PR DESCRIPTION
## Release Notes

- Removes duplicative model-related error handling from `fiftyone.brain`, instead deferring this to `fiftyone`'s `compute_embeddings()` method

This change allows models that support the `mode` property to be passed to methods like `compute_similarity()` and `compute_visualization()`. Currently these methods fail, even though directly passing the model to `compute_embeddings()` does work.