### PR TITLE
Release/v0.21.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,4 +162,4 @@ jobs:
       # See
       # [fiftyone-brain](https://pypi.org/manage/project/fiftyone-brain/settings/publishing/)
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.14.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
         run: |
           pip install --upgrade pip setuptools wheel
       - name: Download fiftyone-brain wheel
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -152,7 +152,7 @@ jobs:
       id-token: write
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
       - name: Upload wheel
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/

--- a/README.md
+++ b/README.md
@@ -16,10 +16,14 @@
 [![PyPI version](https://badge.fury.io/py/fiftyone-brain.svg)](https://pypi.org/project/fiftyone-brain)
 [![Downloads](https://static.pepy.tech/badge/fiftyone-brain)](https://pepy.tech/project/fiftyone-brain)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Slack](https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=white)](https://slack.voxel51.com)
+
+[![Discord](https://img.shields.io/badge/Discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/fiftyone-community)
+[![Hugging Face](https://img.shields.io/badge/Hugging_Face-purple?style=flat&logo=huggingface)](https://huggingface.co/Voxel51)
+[![Voxel51 Blog](https://img.shields.io/badge/Voxel51_Blog-ff6d04?style=flat)](https://voxel51.com/blog)
+[![Newsletter](https://img.shields.io/badge/Newsletter-BE5B25?logo=mail.ru&logoColor=white)](https://share.hsforms.com/1zpJ60ggaQtOoVeBqIZdaaA2ykyk)
+[![LinkedIn](https://img.shields.io/badge/In-white?style=flat&label=Linked&labelColor=blue)](https://www.linkedin.com/company/voxel51)
+[![Twitter](https://img.shields.io/badge/Twitter-000000?logo=x&logoColor=white)](https://x.com/voxel51)
 [![Medium](https://img.shields.io/badge/Medium-12100E?logo=medium&logoColor=white)](https://medium.com/voxel51)
-[![Mailing list](http://bit.ly/2Md9rxM)](https://share.hsforms.com/1zpJ60ggaQtOoVeBqIZdaaA2ykyk)
-[![Twitter](https://img.shields.io/twitter/follow/Voxel51?style=social)](https://twitter.com/voxel51)
 
 </p>
 </div>

--- a/fiftyone/brain/internal/core/utils.py
+++ b/fiftyone/brain/internal/core/utils.py
@@ -787,11 +787,17 @@ def get_embeddings(
                 samples.media_type == fomm.VIDEO
                 and model.media_type == fomm.IMAGE
             ):
-                raise ValueError(
-                    "This method cannot use image models to compute video "
-                    "embeddings. Try providing precomputed video embeddings "
-                    "or converting to a frames view via `to_frames()` first"
-                )
+                if hasattr(model, "mode"):
+                    try:
+                        model.mode = "video"
+                    except Exception:
+                        pass
+                if model.media_type == fomm.IMAGE:
+                    raise ValueError(
+                        "This method cannot use image models to compute video "
+                        "embeddings. Try providing precomputed video embeddings "
+                        "or converting to a frames view via `to_frames()` first"
+                    )
 
             logger.info("Computing embeddings...")
             embeddings = samples.compute_embeddings(

--- a/fiftyone/brain/internal/core/utils.py
+++ b/fiftyone/brain/internal/core/utils.py
@@ -783,22 +783,6 @@ def get_embeddings(
                 progress=progress,
             )
         else:
-            if (
-                samples.media_type == fomm.VIDEO
-                and model.media_type == fomm.IMAGE
-            ):
-                if hasattr(model, "mode"):
-                    try:
-                        model.mode = "video"
-                    except Exception:
-                        pass
-                if model.media_type == fomm.IMAGE:
-                    raise ValueError(
-                        "This method cannot use image models to compute video "
-                        "embeddings. Try providing precomputed video embeddings "
-                        "or converting to a frames view via `to_frames()` first"
-                    )
-
             logger.info("Computing embeddings...")
             embeddings = samples.compute_embeddings(
                 model,

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import os
 from setuptools import setup
 
 
-VERSION = "0.21.4"
+VERSION = "0.21.6"
 
 
 def get_version():


### PR DESCRIPTION
## Release notes

- Removes duplicative model-related error handling from `fiftyone.brain`, instead deferring this to `fiftyone`s `compute_embeddings()` method [(#287)](https://github.com/voxel51/fiftyone-brain/pull/287)
