### PR TITLE
Incremental embeddings visualization capabilities

### DIFF
--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -38,7 +38,6 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "mobilenet-v2-imagenet-torch"
 _DEFAULT_BATCH_SIZE = None
-_REDUCER_BLOB_WARN_BYTES = 12_000_000
 
 
 def compute_visualization(
@@ -410,15 +409,7 @@ class VisualizationResults(fob.BrainResults):
     @property
     def reducer_blob(self):
         if self._reducer_blob is None and self._reducer is not None:
-            blob = _pickle_reducer(self._reducer)
-            if blob is not None and len(blob) > _REDUCER_BLOB_WARN_BYTES:
-                logger.warning(
-                    "Serialized visualization reducer is %d bytes, which is "
-                    "approaching MongoDB's 16 MB document limit. Persistence "
-                    "may fail.",
-                    len(blob),
-                )
-            self._reducer_blob = blob
+            self._reducer_blob = _pickle_reducer(self._reducer)
 
         return self._reducer_blob
 
@@ -1773,6 +1764,12 @@ def _expected_input_dim(reducer):
 def _strip_umap_training_data(reducer):
     reducer._raw_data = None
     if getattr(reducer, "_knn_search_index", None) is not None:
+        idx = reducer._knn_search_index
+        reducer._knn_index_params = {
+            "n_trees": idx.n_trees,
+            "n_iters": idx.n_iters,
+            "max_candidates": idx.max_candidates,
+        }
         reducer._knn_search_index = None
 
 
@@ -1789,9 +1786,7 @@ def _hydrate_umap_reducer(reducer, embeddings):
     from pynndescent import NNDescent
     from sklearn.utils import check_random_state
 
-    n = embeddings.shape[0]
-    n_trees = min(64, 5 + int(round(n**0.5 / 20.0)))
-    n_iters = max(5, int(round(np.log2(n))))
+    params = reducer._knn_index_params
 
     reducer._knn_search_index = NNDescent(
         embeddings,
@@ -1799,9 +1794,9 @@ def _hydrate_umap_reducer(reducer, embeddings):
         metric=reducer.metric,
         metric_kwds=reducer._metric_kwds,
         random_state=check_random_state(reducer.random_state),
-        n_trees=n_trees,
-        n_iters=n_iters,
-        max_candidates=60,
+        n_trees=params["n_trees"],
+        n_iters=params["n_iters"],
+        max_candidates=params["max_candidates"],
         low_memory=reducer.low_memory,
         n_jobs=reducer.n_jobs,
         verbose=reducer.verbose,

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -1175,28 +1175,18 @@ class VisualizationResults(fob.BrainResults):
     def _filter_known(self, samples, embeddings):
         patches_field = self.config.patches_field
 
-        if patches_field is not None and self.label_ids is not None:
-            _, label_ids_path = samples._get_label_field_path(
-                patches_field, "id"
-            )
-            all_label_ids = samples.values(label_ids_path, unwind=True)
-            known_label_ids = set(self.label_ids.tolist())
-            new_label_ids = [
-                _id for _id in all_label_ids if _id not in known_label_ids
-            ]
+        new_ids, num_total = self._diff_ids(samples)
 
-            if len(new_label_ids) < len(all_label_ids):
-                if new_label_ids:
+        if patches_field is not None and self.label_ids is not None:
+            if len(new_ids) < num_total:
+                if new_ids:
                     samples = samples.select_labels(
-                        ids=new_label_ids, fields=patches_field
+                        ids=new_ids, fields=patches_field
                     )
                 else:
                     samples = samples.limit(0)
         else:
-            known_samples = set(self.sample_ids.tolist())
-            all_ids = samples.values("id")
-            new_ids = [_id for _id in all_ids if _id not in known_samples]
-            if len(new_ids) != len(all_ids):
+            if len(new_ids) != num_total:
                 samples = samples.select(new_ids)
 
         if isinstance(embeddings, dict):
@@ -1211,6 +1201,98 @@ class VisualizationResults(fob.BrainResults):
             }
 
         return samples, embeddings
+
+    def _diff_ids(self, samples):
+        patches_field = self.config.patches_field
+
+        if patches_field is not None and self.label_ids is not None:
+            _, label_ids_path = samples._get_label_field_path(
+                patches_field, "id"
+            )
+            all_ids = samples.values(label_ids_path, unwind=True)
+            known = set(self.label_ids.tolist())
+        else:
+            all_ids = samples.values("id")
+            known = set(self.sample_ids.tolist())
+
+        new_ids = [_id for _id in all_ids if _id not in known]
+        return new_ids, len(all_ids)
+
+    def get_new_ids(self, samples=None):
+        """Returns the IDs of the samples/patches in the given collection
+        that are not present in this visualization, along with the number of
+        embeddings that were used to fit this visualization's reducer.
+
+        For sample-level visualizations, sample IDs are returned; for
+        patch-level visualizations, label IDs are returned.
+
+        The training size can be used to decide whether an incremental
+        update via :meth:`add_samples` is appropriate; when the number of
+        new IDs is large relative to the training size (e.g. > 20%),
+        recomputing the visualization will produce a more faithful embedding.
+
+        Args:
+            samples (None): a
+                :class:`fiftyone.core.collections.SampleCollection` to check.
+                By default, the full collection on which this run was
+                performed is used
+
+        Returns:
+            a tuple of
+
+            -   a list of new IDs
+            -   the number of embeddings used to fit the reducer, or ``None``
+                if no reducer is available for this run
+        """
+        if samples is None:
+            samples = self._samples
+
+        new_ids, _ = self._diff_ids(samples)
+        return new_ids, self._training_size()
+
+    def needs_update(self, samples=None):
+        """Determines whether the given collection contains samples/patches
+        that are not present in this visualization.
+
+        Use :meth:`add_samples` to add the new samples to the visualization.
+
+        Args:
+            samples (None): a
+                :class:`fiftyone.core.collections.SampleCollection` to check.
+                By default, the full collection on which this run was
+                performed is used
+
+        Returns:
+            True/False
+        """
+        if samples is None:
+            samples = self._samples
+
+        new_ids, _ = self._diff_ids(samples)
+        return len(new_ids) > 0
+
+    def _training_size(self):
+        if self._reducer is None and self._reducer_blob is not None:
+            try:
+                self._reducer = _unpickle_reducer(self._reducer_blob)
+            except RuntimeError:
+                return None
+
+        reducer = self._reducer
+        if reducer is None:
+            return None
+
+        # UMAP
+        embedding = getattr(reducer, "embedding_", None)
+        if embedding is not None:
+            return embedding.shape[0]
+
+        # PCA
+        n_samples = getattr(reducer, "n_samples_", None)
+        if n_samples is not None:
+            return int(n_samples)
+
+        return None
 
     def _write_points_field(self, new_points, sample_ids, label_ids):
         config = self.config

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -1302,6 +1302,20 @@ class Visualization(fob.BrainMethod):
     supports_add_embeddings = False
 
     def fit_reducer(self, embeddings):
+        if type(self).fit is not Visualization.fit:
+            import warnings
+
+            warnings.warn(
+                "Overriding `Visualization.fit()` is deprecated; subclasses "
+                "should implement `fit_reducer(embeddings) -> (points, "
+                "reducer)` instead. The legacy `fit()` hook will continue "
+                "to work but cannot participate in incremental "
+                "visualization updates.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return self.fit(embeddings), None
+
         raise NotImplementedError("subclass must implement fit_reducer()")
 
     def fit(self, embeddings):

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -158,10 +158,10 @@ def compute_visualization(
         points, reducer = brain_method.fit_reducer(embeddings)
 
         if config.method == "umap" and embeddings_field is None:
-            logger.warning(
-                "Computed UMAP visualization without an `embeddings_field`; "
-                "incremental updates via `add_samples` won't be available. "
-                "Pass `embeddings=<field_name>` to enable them."
+            logger.info(
+                "Computed UMAP visualization without an embeddings field; "
+                "incremental updates via add_samples() won't be available. "
+                "Pass `embeddings=<field name>` next time to enable them"
             )
             reducer = None
     else:
@@ -370,7 +370,7 @@ class VisualizationResults(fob.BrainResults):
         label_ids (None): a ``num_points`` array of label IDs, if applicable
         reducer (None): the fitted dimensionality reduction model used to
             generate ``points``, retained to support incremental updates via
-            :meth:`add_embeddings`. Not applicable to all methods
+            :meth:`add_samples`. Not applicable to all methods
         reducer_blob (None): a base64-encoded pickled form of ``reducer``,
             used when reconstructing the results from a persisted run
         backend (None): a :class:`Visualization` backend
@@ -807,6 +807,37 @@ class VisualizationResults(fob.BrainResults):
             self.config.points_field = None
             self.save_config()
 
+    @property
+    def supports_auto_updates(self):
+        """Whether this index can be incrementally updated by calling
+        :meth:`add_samples` without manually providing `embeddings` or a
+        `model`.
+        """
+
+        # Some visualization methods do not support incremental updates
+        if not getattr(self.config.build(), "SUPPORTS_UPDATES", False):
+            return False
+
+        # The string name of a zoo model is required in order to call
+        # `add_samples()` without manually providing `embeddings` or a `model`
+        if self.config.model is None:
+            return False
+
+        # UMAP requires the embeddings to be stored on a field of the dataset
+        # in order to rehydrate its reducer
+        if (
+            self.config.method == "umap"
+            and self.config.embeddings_field is None
+        ):
+            return False
+
+        # If no reducer/blob is stored, this is an older visualization that
+        # cannot be incrementally updated
+        if self._reducer is None and self._reducer_blob is None:
+            return False
+
+        return True
+
     def add_samples(
         self,
         samples,
@@ -820,7 +851,6 @@ class VisualizationResults(fob.BrainResults):
         skip_failures=True,
         progress=None,
         skip_existing=True,
-        overwrite=True,
         allow_existing=True,
         warn_existing=False,
         reload=True,
@@ -847,14 +877,14 @@ class VisualizationResults(fob.BrainResults):
         1. ``embeddings`` if provided (array, dict, or field name)
         2. ``model`` if provided
         3. ``config.embeddings_field`` if populated on the new samples
-        4. ``config.model`` (the zoo model name recorded on the original run),
-           if any
+        4. ``config.model`` if the zoo model name recorded on the original run
         5. otherwise, an error is raised
 
-        Note: if the original :func:`compute_visualization` call was made with
-        a :class:`fiftyone.core.models.Model` instance (rather than a zoo
-        model name), ``config.model`` is ``None`` and you must pass ``model``
-        or ``embeddings`` explicitly here.
+        Note that if the original :func:`compute_visualization` call was made
+        with a :class:`fiftyone.core.models.Model` instance rather than the
+        string name of a zoo model, ``config.model`` is ``None`` and you must
+        pass ``model`` or ``embeddings`` explicitly here to extend the
+        visualization.
 
         Args:
             samples: a :class:`fiftyone.core.collections.SampleCollection`
@@ -867,7 +897,7 @@ class VisualizationResults(fob.BrainResults):
                 written through to ``config.embeddings_field`` so that future
                 UMAP reloads can rehydrate consistently
             model (None): a model to use to compute embeddings. If not
-                provided, ``config.model`` is used
+                provided, ``config.model`` is used if available
             model_kwargs (None): a dictionary of optional keyword arguments to
                 pass to the model's ``Config`` when a model name is provided
             force_square (False): see :func:`compute_visualization`
@@ -880,24 +910,19 @@ class VisualizationResults(fob.BrainResults):
                 visualization are silently dropped from ``samples`` before
                 computing embeddings, so only new samples are projected
                 through the reducer
-            overwrite (True): whether to replace (True) or ignore (False)
-                existing points with the same sample/label IDs
-            allow_existing (True): whether to ignore (True) or raise an error
-                (False) when ``overwrite`` is False and a provided ID already
-                exists in the index
+            allow_existing (True): if False, raise an error when
+                ``skip_existing`` is False and and a provided sample contains
+                an ID that already exists in the index
             warn_existing (False): whether to log a warning if a point is not
                 added because its ID already exists in the index
             reload (True): whether to refresh the current view after the
                 update
-
-        Returns:
-            self
         """
         fov.validate_collection(samples)
         if samples._root_dataset is not self._samples._root_dataset:
             raise ValueError(
-                "add_samples() requires samples from the same dataset as "
-                "the existing visualization"
+                "You can only add samples from the same dataset to an "
+                "existing visualization"
             )
 
         self._prepare_reducer(samples)
@@ -921,12 +946,11 @@ class VisualizationResults(fob.BrainResults):
         if skip_existing:
             samples, embeddings = self._filter_known(samples, embeddings)
             if len(samples) == 0:
-                logger.info(
-                    "No new samples to add to visualization '%s'", self.key
-                )
+                logger.info("No new samples to add")
                 if reload:
                     self.use_view(self._curr_view or self._samples)
-                return self
+
+                return
 
         effective_model = model
         effective_model_kwargs = model_kwargs
@@ -948,8 +972,8 @@ class VisualizationResults(fob.BrainResults):
                     effective_model_kwargs = config.model_kwargs
             else:
                 raise ValueError(
-                    "No embeddings, model, or populated embeddings_field are "
-                    "available for the new samples. Pass `model=` or "
+                    "No embeddings, model, or embeddings field are available "
+                    "for the new samples. You must pass `model=` or "
                     "`embeddings=` explicitly to add_samples()"
                 )
 
@@ -988,7 +1012,7 @@ class VisualizationResults(fob.BrainResults):
             self.sample_ids,
             self.label_ids,
             patches_field=patches_field,
-            overwrite=overwrite,
+            overwrite=skip_existing,
             allow_existing=allow_existing,
             warn_existing=warn_existing,
         )
@@ -996,7 +1020,8 @@ class VisualizationResults(fob.BrainResults):
         if ii.size == 0:
             if reload:
                 self.use_view(self._curr_view or self._samples)
-            return self
+
+            return
 
         if self.config.method == "umap":
             n_new = int(ii.size)
@@ -1008,20 +1033,24 @@ class VisualizationResults(fob.BrainResults):
                     "was trained on %d samples (%.0f%%). This is an "
                     "approximate transform — the manifold is not refit. "
                     "For batches this large, consider recomputing the "
-                    "visualization via fob.compute_visualization for a more "
-                    "faithful embedding.",
+                    "visualization via compute_visualization() for a more "
+                    "faithful embedding",
                     n_new,
                     n_train,
                     100 * ratio,
                 )
             else:
                 logger.warning(
-                    "Projecting %d new samples through fitted UMAP; this is "
-                    "an approximate transform and not equivalent to a full "
+                    "Projecting %d new samples through a fitted UMAP that "
+                    "was trained on %d samples (%.0f%%). This is an "
+                    "approximate transform and not equivalent to a full "
                     "refit. Quality depends on the new samples being "
-                    "in-distribution with the training set.",
+                    "in-distribution with the training set",
                     n_new,
+                    n_train,
+                    100 * ratio,
                 )
+
         new_points = np.asarray(self._reducer.transform(new_emb[ii, :]))
 
         n = len(self.points)
@@ -1068,6 +1097,7 @@ class VisualizationResults(fob.BrainResults):
                         source_descriptor,
                         canonical_field,
                     )
+
                 fbu.add_embeddings(
                     self._samples,
                     new_emb[ii],
@@ -1090,36 +1120,37 @@ class VisualizationResults(fob.BrainResults):
         if reload:
             self.use_view(self._curr_view or self._samples)
 
-        return self
-
     def _prepare_reducer(self, samples):
-        brain_method = self.config.build()
-        if not getattr(brain_method, "supports_add_embeddings", False):
+        if not getattr(self.config.build(), "SUPPORTS_UPDATES", False):
             raise ValueError(
                 "method '%s' does not support incremental updates; please "
-                "recompute via fob.compute_visualization" % self.config.method
+                "recompute via compute_visualization()" % self.config.method
+            )
+
+        if (
+            self.config.method == "umap"
+            and self.config.embeddings_field is None
+        ):
+            raise ValueError(
+                "UMAP incremental updates require an embeddings field. "
+                "Please recompute via "
+                "compute_visualization(..., embeddings=<field name>) to "
+                "enable incremental updates"
             )
 
         if self._reducer is None:
             if self._reducer_blob is None:
                 raise ValueError(
-                    "This visualization has no stored reducer; it was "
-                    "computed before incremental updates were supported. "
-                    "Please recompute via fob.compute_visualization to "
-                    "enable add_samples"
+                    "This visualization has no stored reducer. It may have "
+                    "been computed before incremental updates were supported. "
+                    "Please recompute via compute_visualization() to enable "
+                    "incremental updates"
                 )
 
             self._reducer = _unpickle_reducer(self._reducer_blob)
 
         if self.config.method == "umap":
             if getattr(self._reducer, "_raw_data", None) is None:
-                if self.config.embeddings_field is None:
-                    raise ValueError(
-                        "UMAP incremental updates require an "
-                        "embeddings_field. Recompute compute_visualization "
-                        "with embeddings=<field_name> set"
-                    )
-
                 training_embeddings = self._load_training_embeddings()
                 _hydrate_umap_reducer(self._reducer, training_embeddings)
 
@@ -1160,7 +1191,7 @@ class VisualizationResults(fob.BrainResults):
                 "Cannot rehydrate UMAP reducer: %d training %s are missing "
                 "from embeddings_field=%r (e.g. %s). The original training "
                 "embeddings are not recoverable; please recompute the "
-                "embeddings visualization."
+                "visualization"
                 % (
                     len(missing),
                     "labels" if patches_field is not None else "samples",
@@ -1381,28 +1412,10 @@ class VisualizationConfig(fob.BrainMethodConfig):
 
 
 class Visualization(fob.BrainMethod):
-    supports_add_embeddings = False
+    SUPPORTS_UPDATES = False
 
     def fit_reducer(self, embeddings):
-        if type(self).fit is not Visualization.fit:
-            import warnings
-
-            warnings.warn(
-                "Overriding `Visualization.fit()` is deprecated; subclasses "
-                "should implement `fit_reducer(embeddings) -> (points, "
-                "reducer)` instead. The legacy `fit()` hook will continue "
-                "to work but cannot participate in incremental "
-                "visualization updates.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            return self.fit(embeddings), None
-
         raise NotImplementedError("subclass must implement fit_reducer()")
-
-    def fit(self, embeddings):
-        points, _ = self.fit_reducer(embeddings)
-        return points
 
     def get_fields(self, samples, brain_key):
         fields = []
@@ -1523,7 +1536,7 @@ class UMAPVisualizationConfig(VisualizationConfig):
 
 
 class UMAPVisualization(Visualization):
-    supports_add_embeddings = True
+    SUPPORTS_UPDATES = True
 
     def ensure_requirements(self):
         fou.ensure_package(
@@ -1673,6 +1686,7 @@ class TSNEVisualization(Visualization):
             **{iter_param: self.config.max_iters},
         )
         points = _tsne.fit_transform(embeddings)
+
         return points, None
 
 
@@ -1734,7 +1748,7 @@ class PCAVisualizationConfig(VisualizationConfig):
 
 
 class PCAVisualization(Visualization):
-    supports_add_embeddings = True
+    SUPPORTS_UPDATES = True
 
     def fit_reducer(self, embeddings):
         _pca = skd.PCA(
@@ -1792,8 +1806,10 @@ def _parse_serialized_array(value):
 def _field_has_populated_values(samples, embeddings_field, patches_field=None):
     if embeddings_field is None:
         return False
+
     if not fbu._has_embeddings_field(samples, embeddings_field, patches_field):
         return False
+
     try:
         if patches_field is not None:
             filtered = samples.filter_labels(
@@ -1801,6 +1817,7 @@ def _field_has_populated_values(samples, embeddings_field, patches_field=None):
             )
             _, ids_path = samples._get_label_field_path(patches_field, "id")
             return len(filtered.values(ids_path, unwind=True)) > 0
+
         return len(samples.exists(embeddings_field)) > 0
     except Exception:
         return False
@@ -1809,10 +1826,13 @@ def _field_has_populated_values(samples, embeddings_field, patches_field=None):
 def _describe_embeddings_source(embeddings):
     if isinstance(embeddings, str):
         return embeddings
+
     if isinstance(embeddings, dict):
         return "<dict>"
+
     if isinstance(embeddings, np.ndarray):
         return "<ndarray>"
+
     return None
 
 
@@ -1912,5 +1932,5 @@ def _unpickle_reducer(blob):
     except Exception as e:
         raise RuntimeError(
             "Failed to deserialize fitted reducer (likely a UMAP/sklearn "
-            "version mismatch); please recompute with `compute_visualization`"
+            "version mismatch); please recompute with compute_visualization()"
         ) from e

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -1111,7 +1111,7 @@ class VisualizationResults(fob.BrainResults):
 
             self._reducer = _unpickle_reducer(self._reducer_blob)
 
-        if isinstance(self._reducer, umap.UMAP):
+        if self.config.method == "umap":
             if getattr(self._reducer, "_raw_data", None) is None:
                 if self.config.embeddings_field is None:
                     raise ValueError(

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -998,7 +998,7 @@ class VisualizationResults(fob.BrainResults):
                 self.use_view(self._curr_view or self._samples)
             return self
 
-        if isinstance(self._reducer, umap.UMAP):
+        if self.config.method == "umap":
             n_new = int(ii.size)
             n_train = self._reducer.embedding_.shape[0]
             ratio = n_new / n_train
@@ -1022,7 +1022,6 @@ class VisualizationResults(fob.BrainResults):
                     "in-distribution with the training set.",
                     n_new,
                 )
-
         new_points = np.asarray(self._reducer.transform(new_emb[ii, :]))
 
         n = len(self.points)

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -893,12 +893,18 @@ class VisualizationResults(fob.BrainResults):
         Returns:
             self
         """
+        fov.validate_collection(samples)
+        if samples._root_dataset is not self._samples._root_dataset:
+            raise ValueError(
+                "add_samples() requires samples from the same dataset as "
+                "the existing visualization"
+            )
+
         self._prepare_reducer(samples)
 
         config = self.config
         patches_field = config.patches_field
         canonical_field = config.embeddings_field
-
         source_descriptor = _describe_embeddings_source(embeddings)
 
         override_field = None

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -1147,8 +1147,30 @@ class VisualizationResults(fob.BrainResults):
         )
 
         ids_returned = label_ids if patches_field is not None else sample_ids
+
+        returned_set = set(
+            ids_returned.tolist()
+            if hasattr(ids_returned, "tolist")
+            else ids_returned
+        )
+        expected_set = set(training_ids.tolist())
+        if expected_set != returned_set:
+            missing = sorted(expected_set - returned_set)
+            raise ValueError(
+                "Cannot rehydrate UMAP reducer: %d training %s are missing "
+                "from embeddings_field=%r (e.g. %s). The original training "
+                "embeddings are not recoverable; please recompute the "
+                "embeddings visualization."
+                % (
+                    len(missing),
+                    "labels" if patches_field is not None else "samples",
+                    self.config.embeddings_field,
+                    missing[:5],
+                )
+            )
+
         order = {_id: i for i, _id in enumerate(ids_returned)}
-        idx = np.array([order[_id] for _id in training_ids if _id in order])
+        idx = np.array([order[_id] for _id in training_ids])
         return embeddings[idx]
 
     def _filter_known(self, samples, embeddings):

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -6,9 +6,11 @@ Visualization interface.
 |
 """
 
+import base64
 from copy import deepcopy
 import inspect
 import logging
+import pickle
 from packaging import version
 
 import numpy as np
@@ -36,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "mobilenet-v2-imagenet-torch"
 _DEFAULT_BATCH_SIZE = None
+_REDUCER_BLOB_WARN_BYTES = 12_000_000
 
 
 def compute_visualization(
@@ -133,6 +136,7 @@ def compute_visualization(
     if brain_key is not None:
         brain_method.register_run(samples, brain_key)
 
+    reducer = None
     if points is None:
         embeddings, sample_ids, label_ids = fbu.get_embeddings(
             samples,
@@ -151,7 +155,7 @@ def compute_visualization(
         )
 
         logger.info("Generating visualization...")
-        points = brain_method.fit(embeddings)
+        points, reducer = brain_method.fit_reducer(embeddings)
     else:
         points, sample_ids, label_ids = fbu.parse_data(
             samples,
@@ -179,6 +183,7 @@ def compute_visualization(
         points,
         sample_ids=sample_ids,
         label_ids=label_ids,
+        reducer=reducer,
     )
 
     brain_method.save_run_results(samples, brain_key, results)
@@ -355,6 +360,11 @@ class VisualizationResults(fob.BrainResults):
         points: a ``num_points x num_dims`` array of visualization points
         sample_ids (None): a ``num_points`` array of sample IDs
         label_ids (None): a ``num_points`` array of label IDs, if applicable
+        reducer (None): the fitted dimensionality reduction model used to
+            generate ``points``, retained to support incremental updates via
+            :meth:`add_embeddings`. Not applicable to all methods
+        reducer_blob (None): a base64-encoded pickled form of ``reducer``,
+            used when reconstructing the results from a persisted run
         backend (None): a :class:`Visualization` backend
     """
 
@@ -366,6 +376,8 @@ class VisualizationResults(fob.BrainResults):
         points,
         sample_ids=None,
         label_ids=None,
+        reducer=None,
+        reducer_blob=None,
         backend=None,
     ):
         super().__init__(samples, config, brain_key, backend=backend)
@@ -382,6 +394,9 @@ class VisualizationResults(fob.BrainResults):
         self.sample_ids = sample_ids
         self.label_ids = label_ids
 
+        self._reducer = reducer
+        self._reducer_blob = reducer_blob
+
         self._last_view = None
         self._curr_view = None
         self._curr_points = None
@@ -391,6 +406,21 @@ class VisualizationResults(fob.BrainResults):
         self._curr_good_inds = None
 
         self.use_view(samples)
+
+    @property
+    def reducer_blob(self):
+        if self._reducer_blob is None and self._reducer is not None:
+            blob = _pickle_reducer(self._reducer)
+            if blob is not None and len(blob) > _REDUCER_BLOB_WARN_BYTES:
+                logger.warning(
+                    "Serialized visualization reducer is %d bytes, which is "
+                    "approaching MongoDB's 16 MB document limit. Persistence "
+                    "may fail.",
+                    len(blob),
+                )
+            self._reducer_blob = blob
+
+        return self._reducer_blob
 
     def __enter__(self):
         self._last_view = self.view
@@ -405,7 +435,11 @@ class VisualizationResults(fob.BrainResults):
     _ARRAY_FIELDS = ("points", "sample_ids", "label_ids")
 
     def attributes(self):
-        return [a for a in super().attributes() if a not in self._ARRAY_FIELDS]
+        attrs = [
+            a for a in super().attributes() if a not in self._ARRAY_FIELDS
+        ]
+        attrs.append("reducer_blob")
+        return attrs
 
     def serialize(self, reflective=False):
         """Serializes the results into a dictionary.
@@ -773,11 +807,408 @@ class VisualizationResults(fob.BrainResults):
             self.config.points_field = None
             self.save_config()
 
+    def add_samples(
+        self,
+        samples,
+        embeddings=None,
+        model=None,
+        model_kwargs=None,
+        force_square=False,
+        alpha=None,
+        batch_size=None,
+        num_workers=None,
+        skip_failures=True,
+        progress=None,
+        skip_existing=True,
+        overwrite=True,
+        allow_existing=True,
+        warn_existing=False,
+        reload=True,
+    ):
+        """Incrementally extends this visualization with the new samples in
+        ``samples``.
+
+        Embeddings for the new samples are extracted (or accepted) and
+        transformed through the previously fitted reducer, then appended to
+        the index. This is significantly cheaper than recomputing the entire
+        visualization for datasets where only a few samples have been added.
+
+        By default, samples that are already in the visualization are skipped,
+        so it is safe to pass an entire dataset/view that contains both known
+        and new samples.
+
+        Only methods whose reducer supports ``transform()`` are supported
+        (currently UMAP and PCA). For UMAP, the original
+        ``config.embeddings_field`` must be set so that the kNN search
+        structure can be rebuilt on demand from the dataset.
+
+        The embedding source for the new samples is resolved in this order:
+
+        1. ``embeddings`` if provided (array, dict, or field name)
+        2. ``model`` if provided
+        3. ``config.embeddings_field`` if populated on the new samples
+        4. ``config.model`` (the zoo model name recorded on the original run),
+           if any
+        5. otherwise, an error is raised
+
+        Note: if the original :func:`compute_visualization` call was made with
+        a :class:`fiftyone.core.models.Model` instance (rather than a zoo
+        model name), ``config.model`` is ``None`` and you must pass ``model``
+        or ``embeddings`` explicitly here.
+
+        Args:
+            samples: a :class:`fiftyone.core.collections.SampleCollection`
+                containing samples to add to the visualization
+            embeddings (None): pre-computed embeddings for the new samples.
+                Can be a ``num_samples x num_dims`` array, a dict mapping
+                sample/label IDs to embeddings, or the name of a field from
+                which to load them. If the resolved source differs from
+                ``config.embeddings_field``, the new embeddings are also
+                written through to ``config.embeddings_field`` so that future
+                UMAP reloads can rehydrate consistently
+            model (None): a model to use to compute embeddings. If not
+                provided, ``config.model`` is used
+            model_kwargs (None): a dictionary of optional keyword arguments to
+                pass to the model's ``Config`` when a model name is provided
+            force_square (False): see :func:`compute_visualization`
+            alpha (None): see :func:`compute_visualization`
+            batch_size (None): see :func:`compute_visualization`
+            num_workers (None): see :func:`compute_visualization`
+            skip_failures (True): see :func:`compute_visualization`
+            progress (None): see :func:`compute_visualization`
+            skip_existing (True): if True, samples already in the
+                visualization are silently dropped from ``samples`` before
+                computing embeddings, so only new samples are projected
+                through the reducer
+            overwrite (True): whether to replace (True) or ignore (False)
+                existing points with the same sample/label IDs
+            allow_existing (True): whether to ignore (True) or raise an error
+                (False) when ``overwrite`` is False and a provided ID already
+                exists in the index
+            warn_existing (False): whether to log a warning if a point is not
+                added because its ID already exists in the index
+            reload (True): whether to refresh the current view after the
+                update
+
+        Returns:
+            self
+        """
+        self._prepare_reducer(samples)
+
+        config = self.config
+        patches_field = config.patches_field
+        canonical_field = config.embeddings_field
+
+        source_descriptor = _describe_embeddings_source(embeddings)
+
+        override_field = None
+        if isinstance(embeddings, str):
+            if embeddings != canonical_field:
+                override_field = embeddings
+            embeddings = None
+
+        if isinstance(embeddings, np.ndarray):
+            embeddings = _array_to_id_dict(
+                samples, embeddings, patches_field=patches_field
+            )
+
+        if skip_existing:
+            samples, embeddings = self._filter_known(samples, embeddings)
+            if len(samples) == 0:
+                logger.info(
+                    "No new samples to add to visualization '%s'", self.key
+                )
+                if reload:
+                    self.use_view(self._curr_view or self._samples)
+                return self
+
+        effective_model = model
+        effective_model_kwargs = model_kwargs
+
+        source_field = override_field or canonical_field
+
+        field_populated = _field_has_populated_values(
+            samples, source_field, patches_field
+        )
+
+        if (
+            embeddings is None
+            and effective_model is None
+            and not field_populated
+        ):
+            if config.model is not None:
+                effective_model = config.model
+                if effective_model_kwargs is None:
+                    effective_model_kwargs = config.model_kwargs
+            else:
+                raise ValueError(
+                    "No embeddings, model, or populated embeddings_field are "
+                    "available for the new samples. Pass `model=` or "
+                    "`embeddings=` explicitly to add_samples()"
+                )
+
+        forced_model_fallback = (
+            effective_model is not None
+            and source_field is not None
+            and not field_populated
+        )
+        extraction_field = None if forced_model_fallback else source_field
+
+        new_emb, new_sample_ids, new_label_ids = fbu.get_embeddings(
+            samples,
+            model=effective_model,
+            model_kwargs=effective_model_kwargs,
+            patches_field=patches_field,
+            embeddings_field=extraction_field,
+            embeddings=embeddings,
+            force_square=force_square,
+            alpha=alpha,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            skip_failures=skip_failures,
+            progress=progress,
+        )
+
+        expected_dim = _expected_input_dim(self._reducer)
+        if expected_dim is not None and new_emb.shape[1] != expected_dim:
+            raise ValueError(
+                "embeddings have dimension %d but the fitted reducer "
+                "expects dimension %d" % (new_emb.shape[1], expected_dim)
+            )
+
+        new_sample_ids_out, new_label_ids_out, ii, jj = fbu.add_ids(
+            new_sample_ids,
+            new_label_ids,
+            self.sample_ids,
+            self.label_ids,
+            patches_field=patches_field,
+            overwrite=overwrite,
+            allow_existing=allow_existing,
+            warn_existing=warn_existing,
+        )
+
+        if ii.size == 0:
+            if reload:
+                self.use_view(self._curr_view or self._samples)
+            return self
+
+        if isinstance(self._reducer, umap.UMAP):
+            n_new = int(ii.size)
+            n_train = self._reducer.embedding_.shape[0]
+            ratio = n_new / n_train
+            if ratio > 0.2:
+                logger.warning(
+                    "Projecting %d new samples through a fitted UMAP that "
+                    "was trained on %d samples (%.0f%%). This is an "
+                    "approximate transform — the manifold is not refit. "
+                    "For batches this large, consider recomputing the "
+                    "visualization via fob.compute_visualization for a more "
+                    "faithful embedding.",
+                    n_new,
+                    n_train,
+                    100 * ratio,
+                )
+            else:
+                logger.warning(
+                    "Projecting %d new samples through fitted UMAP; this is "
+                    "an approximate transform and not equivalent to a full "
+                    "refit. Quality depends on the new samples being "
+                    "in-distribution with the training set.",
+                    n_new,
+                )
+
+        new_points = np.asarray(self._reducer.transform(new_emb[ii, :]))
+
+        n = len(self.points)
+        m = int(jj.max()) - n + 1
+        if m > 0:
+            self.points = np.concatenate(
+                (
+                    self.points,
+                    np.empty(
+                        (m, self.points.shape[1]), dtype=self.points.dtype
+                    ),
+                )
+            )
+
+        self.points[jj] = new_points
+        self.sample_ids = new_sample_ids_out
+        if patches_field is not None:
+            self.label_ids = new_label_ids_out
+
+        if canonical_field is not None:
+            needs_write_through = (
+                source_descriptor in ("<dict>", "<ndarray>")
+                or (
+                    override_field is not None
+                    and override_field != canonical_field
+                )
+                or forced_model_fallback
+            )
+            if needs_write_through:
+                if forced_model_fallback:
+                    logger.info(
+                        "Computed %d new embeddings via model %r and stored "
+                        "them in embeddings_field=%r",
+                        int(ii.size),
+                        effective_model,
+                        canonical_field,
+                    )
+                else:
+                    logger.warning(
+                        "Embeddings for the new samples were sourced from "
+                        "%r but will also be stored in this run's "
+                        "embeddings_field=%r so that UMAP rehydration on "
+                        "future loads remains consistent",
+                        source_descriptor,
+                        canonical_field,
+                    )
+                fbu.add_embeddings(
+                    self._samples,
+                    new_emb[ii],
+                    new_sample_ids[ii],
+                    new_label_ids[ii] if new_label_ids is not None else None,
+                    canonical_field,
+                    patches_field=patches_field,
+                )
+
+        if config.points_field is not None:
+            self._write_points_field(
+                new_points,
+                new_sample_ids[ii],
+                new_label_ids[ii] if new_label_ids is not None else None,
+            )
+
+        if self.key is not None:
+            self.save()
+
+        if reload:
+            self.use_view(self._curr_view or self._samples)
+
+        return self
+
+    def _prepare_reducer(self, samples):
+        brain_method = self.config.build()
+        if not getattr(brain_method, "supports_add_embeddings", False):
+            raise ValueError(
+                "method '%s' does not support incremental updates; please "
+                "recompute via fob.compute_visualization" % self.config.method
+            )
+
+        if self._reducer is None:
+            if self._reducer_blob is None:
+                raise ValueError(
+                    "This visualization has no stored reducer; it was "
+                    "computed before incremental updates were supported. "
+                    "Please recompute via fob.compute_visualization to "
+                    "enable add_samples"
+                )
+
+            self._reducer = _unpickle_reducer(self._reducer_blob)
+
+        if isinstance(self._reducer, umap.UMAP):
+            if getattr(self._reducer, "_raw_data", None) is None:
+                if self.config.embeddings_field is None:
+                    raise ValueError(
+                        "UMAP incremental updates require an "
+                        "embeddings_field. Recompute compute_visualization "
+                        "with embeddings=<field_name> set"
+                    )
+
+                training_embeddings = self._load_training_embeddings()
+                _hydrate_umap_reducer(self._reducer, training_embeddings)
+
+    def _load_training_embeddings(self):
+        n_train = self._reducer.embedding_.shape[0]
+
+        patches_field = self.config.patches_field
+        if patches_field is not None:
+            training_ids = self.label_ids[:n_train]
+        else:
+            training_ids = self.sample_ids[:n_train]
+
+        training_view = (
+            self._samples.select(list(training_ids), ordered=True)
+            if patches_field is None
+            else self._samples.select_labels(
+                ids=list(training_ids), fields=patches_field
+            )
+        )
+
+        embeddings, sample_ids, label_ids = fbu.get_embeddings(
+            training_view,
+            patches_field=patches_field,
+            embeddings_field=self.config.embeddings_field,
+        )
+
+        ids_returned = label_ids if patches_field is not None else sample_ids
+        order = {_id: i for i, _id in enumerate(ids_returned)}
+        idx = np.array([order[_id] for _id in training_ids if _id in order])
+        return embeddings[idx]
+
+    def _filter_known(self, samples, embeddings):
+        patches_field = self.config.patches_field
+
+        if patches_field is not None and self.label_ids is not None:
+            _, label_ids_path = samples._get_label_field_path(
+                patches_field, "id"
+            )
+            all_label_ids = samples.values(label_ids_path, unwind=True)
+            known_label_ids = set(self.label_ids.tolist())
+            new_label_ids = [
+                _id for _id in all_label_ids if _id not in known_label_ids
+            ]
+
+            if len(new_label_ids) < len(all_label_ids):
+                if new_label_ids:
+                    samples = samples.select_labels(
+                        ids=new_label_ids, fields=patches_field
+                    )
+                else:
+                    samples = samples.limit(0)
+        else:
+            known_samples = set(self.sample_ids.tolist())
+            all_ids = samples.values("id")
+            new_ids = [_id for _id in all_ids if _id not in known_samples]
+            if len(new_ids) != len(all_ids):
+                samples = samples.select(new_ids)
+
+        if isinstance(embeddings, dict):
+            if patches_field is not None and self.label_ids is not None:
+                known_keys = set(self.label_ids.tolist())
+            else:
+                known_keys = set(self.sample_ids.tolist())
+            embeddings = {
+                _id: vec
+                for _id, vec in embeddings.items()
+                if _id not in known_keys
+            }
+
+        return samples, embeddings
+
+    def _write_points_field(self, new_points, sample_ids, label_ids):
+        config = self.config
+        points_field = config.points_field
+        patches_field = config.patches_field
+
+        dataset = self._samples._root_dataset
+        if patches_field is not None:
+            _, points_field_path = dataset._get_label_field_path(
+                patches_field, points_field
+            )
+            values = dict(zip(label_ids, new_points.astype(float).tolist()))
+            dataset.set_label_values(points_field_path, values)
+        else:
+            values = dict(zip(sample_ids, new_points.astype(float).tolist()))
+            dataset.set_values(points_field, values, key_field="id")
+
     @classmethod
     def _from_dict(cls, d, samples, config, brain_key):
         points = _parse_serialized_array(d["points"])
         sample_ids = _parse_serialized_array(d.get("sample_ids", None))
         label_ids = _parse_serialized_array(d.get("label_ids", None))
+
+        reducer_blob = d.get("reducer_blob", None)
 
         return cls(
             samples,
@@ -786,6 +1217,7 @@ class VisualizationResults(fob.BrainResults):
             points,
             sample_ids=sample_ids,
             label_ids=label_ids,
+            reducer_blob=reducer_blob,
         )
 
 
@@ -840,8 +1272,14 @@ class VisualizationConfig(fob.BrainMethodConfig):
 
 
 class Visualization(fob.BrainMethod):
+    supports_add_embeddings = False
+
+    def fit_reducer(self, embeddings):
+        raise NotImplementedError("subclass must implement fit_reducer()")
+
     def fit(self, embeddings):
-        raise NotImplementedError("subclass must implement fit()")
+        points, _ = self.fit_reducer(embeddings)
+        return points
 
     def get_fields(self, samples, brain_key):
         fields = []
@@ -962,6 +1400,8 @@ class UMAPVisualizationConfig(VisualizationConfig):
 
 
 class UMAPVisualization(Visualization):
+    supports_add_embeddings = True
+
     def ensure_requirements(self):
         fou.ensure_package(
             "umap-learn>=0.5",
@@ -973,7 +1413,7 @@ class UMAPVisualization(Visualization):
             ),
         )
 
-    def fit(self, embeddings):
+    def fit_reducer(self, embeddings):
         _umap = umap.UMAP(
             n_components=self.config.num_dims,
             n_neighbors=self.config.num_neighbors,
@@ -982,7 +1422,9 @@ class UMAPVisualization(Visualization):
             random_state=self.config.seed,
             verbose=self.config.verbose,
         )
-        return _umap.fit_transform(embeddings)
+        points = _umap.fit_transform(embeddings)
+        _strip_umap_training_data(_umap)
+        return points, _umap
 
 
 class TSNEVisualizationConfig(VisualizationConfig):
@@ -1077,7 +1519,7 @@ class TSNEVisualizationConfig(VisualizationConfig):
 
 
 class TSNEVisualization(Visualization):
-    def fit(self, embeddings):
+    def fit_reducer(self, embeddings):
         if self.config.pca_dims is not None:
             _pca = skd.PCA(
                 n_components=self.config.pca_dims,
@@ -1107,7 +1549,8 @@ class TSNEVisualization(Visualization):
             verbose=verbose,
             **{iter_param: self.config.max_iters},
         )
-        return _tsne.fit_transform(embeddings)
+        points = _tsne.fit_transform(embeddings)
+        return points, None
 
 
 class PCAVisualizationConfig(VisualizationConfig):
@@ -1168,13 +1611,16 @@ class PCAVisualizationConfig(VisualizationConfig):
 
 
 class PCAVisualization(Visualization):
-    def fit(self, embeddings):
+    supports_add_embeddings = True
+
+    def fit_reducer(self, embeddings):
         _pca = skd.PCA(
             n_components=self.config.num_dims,
             svd_solver=self.config.svd_solver,
             random_state=self.config.seed,
         )
-        return _pca.fit_transform(embeddings)
+        points = _pca.fit_transform(embeddings)
+        return points, _pca
 
 
 class ManualVisualizationConfig(VisualizationConfig):
@@ -1197,7 +1643,7 @@ class ManualVisualizationConfig(VisualizationConfig):
 
 
 class ManualVisualization(Visualization):
-    def fit(self, embeddings):
+    def fit_reducer(self, embeddings):
         raise NotImplementedError(
             "The low-dimensional representation must be manually provided "
             "when using this method"
@@ -1218,3 +1664,125 @@ def _parse_serialized_array(value):
         return fou.deserialize_numpy_array(value, ascii=True)
 
     return np.array(value)
+
+
+def _field_has_populated_values(samples, embeddings_field, patches_field=None):
+    if embeddings_field is None:
+        return False
+    if not fbu._has_embeddings_field(samples, embeddings_field, patches_field):
+        return False
+    try:
+        if patches_field is not None:
+            filtered = samples.filter_labels(
+                patches_field, foe.ViewField(embeddings_field) != None
+            )
+            _, ids_path = samples._get_label_field_path(patches_field, "id")
+            return len(filtered.values(ids_path, unwind=True)) > 0
+        return len(samples.exists(embeddings_field)) > 0
+    except Exception:
+        return False
+
+
+def _describe_embeddings_source(embeddings):
+    if isinstance(embeddings, str):
+        return embeddings
+    if isinstance(embeddings, dict):
+        return "<dict>"
+    if isinstance(embeddings, np.ndarray):
+        return "<ndarray>"
+    return None
+
+
+def _array_to_id_dict(samples, embeddings, patches_field=None):
+    embeddings = np.asarray(embeddings)
+    if embeddings.ndim != 2:
+        raise ValueError(
+            "embeddings array must be 2D; got shape %s" % (embeddings.shape,)
+        )
+
+    sample_ids, label_ids = fbu.get_ids(
+        samples,
+        patches_field=patches_field,
+        data=embeddings,
+        data_type="embeddings",
+    )
+
+    ids = label_ids if patches_field is not None else sample_ids
+    if len(ids) != len(embeddings):
+        raise ValueError(
+            "embeddings array length (%d) does not match the number of "
+            "samples (%d)" % (len(embeddings), len(ids))
+        )
+
+    return {_id: vec for _id, vec in zip(ids, embeddings)}
+
+
+def _expected_input_dim(reducer):
+    n_features = getattr(reducer, "n_features_in_", None)
+    if n_features is not None:
+        return n_features
+
+    raw = getattr(reducer, "_raw_data", None)
+    if raw is not None:
+        return raw.shape[1]
+
+    return None
+
+
+def _strip_umap_training_data(reducer):
+    reducer._raw_data = None
+    if getattr(reducer, "_knn_search_index", None) is not None:
+        reducer._knn_search_index = None
+
+
+def _hydrate_umap_reducer(reducer, embeddings):
+    reducer._raw_data = embeddings
+
+    if getattr(reducer, "_small_data", True):
+        return
+
+    # Need to reconstruct the index since we are not storing the search index by
+    # in the brain result as this would involve storing the embeddings vectors in
+    # the brain result
+
+    from pynndescent import NNDescent
+    from sklearn.utils import check_random_state
+
+    n = embeddings.shape[0]
+    n_trees = min(64, 5 + int(round(n**0.5 / 20.0)))
+    n_iters = max(5, int(round(np.log2(n))))
+
+    reducer._knn_search_index = NNDescent(
+        embeddings,
+        n_neighbors=reducer._n_neighbors,
+        metric=reducer.metric,
+        metric_kwds=reducer._metric_kwds,
+        random_state=check_random_state(reducer.random_state),
+        n_trees=n_trees,
+        n_iters=n_iters,
+        max_candidates=60,
+        low_memory=reducer.low_memory,
+        n_jobs=reducer.n_jobs,
+        verbose=reducer.verbose,
+        compressed=False,
+    )
+
+
+def _pickle_reducer(reducer):
+    if reducer is None:
+        return None
+
+    return base64.b64encode(pickle.dumps(reducer)).decode("ascii")
+
+
+def _unpickle_reducer(blob):
+    if blob is None:
+        return None
+
+    try:
+        return pickle.loads(base64.b64decode(blob))
+    except Exception as e:
+        raise RuntimeError(
+            "Failed to deserialize fitted reducer (likely a UMAP/sklearn "
+            "version mismatch); please recompute with `compute_visualization`"
+        ) from e

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -155,6 +155,14 @@ def compute_visualization(
 
         logger.info("Generating visualization...")
         points, reducer = brain_method.fit_reducer(embeddings)
+
+        if config.method == "umap" and embeddings_field is None:
+            logger.warning(
+                "Computed UMAP visualization without an `embeddings_field`; "
+                "incremental updates via `add_samples` won't be available. "
+                "Pass `embeddings=<field_name>` to enable them."
+            )
+            reducer = None
     else:
         points, sample_ids, label_ids = fbu.parse_data(
             samples,

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -11,6 +11,7 @@ from copy import deepcopy
 import inspect
 import logging
 import pickle
+import zlib
 from packaging import version
 
 import numpy as np
@@ -1898,7 +1899,8 @@ def _pickle_reducer(reducer):
     if reducer is None:
         return None
 
-    return base64.b64encode(pickle.dumps(reducer)).decode("ascii")
+    blob = zlib.compress(pickle.dumps(reducer))
+    return base64.b64encode(blob).decode("ascii")
 
 
 def _unpickle_reducer(blob):
@@ -1906,7 +1908,7 @@ def _unpickle_reducer(blob):
         return None
 
     try:
-        return pickle.loads(base64.b64decode(blob))
+        return pickle.loads(zlib.decompress(base64.b64decode(blob)))
     except Exception as e:
         raise RuntimeError(
             "Failed to deserialize fitted reducer (likely a UMAP/sklearn "

--- a/tests/intensive/test_visualization.py
+++ b/tests/intensive/test_visualization.py
@@ -726,11 +726,13 @@ def test_add_samples_umap_no_embeddings_field_raises():
 
     _add_new_samples(dataset, 5, 64, rng, populate_field=False)
 
+    # UMAP runs computed without an embeddings_field drop their reducer at
+    # compute time, so incremental updates are unavailable
     try:
         results.add_samples(dataset, embeddings=np.zeros((5, 64)))
         assert False, "expected ValueError"
     except ValueError as e:
-        assert "embeddings_field" in str(e)
+        assert "no stored reducer" in str(e)
 
     dataset.delete()
 

--- a/tests/intensive/test_visualization.py
+++ b/tests/intensive/test_visualization.py
@@ -525,6 +525,742 @@ def _make_patches_dataset(name):
     return dataset
 
 
+def _make_synthetic_dataset(name, n=80, dim=64, seed=7):
+    if fo.dataset_exists(name):
+        fo.delete_dataset(name)
+
+    dataset = fo.Dataset(name)
+    dataset.add_samples(
+        [fo.Sample(filepath="/tmp/%s_%d.jpg" % (name, i)) for i in range(n)]
+    )
+
+    rng = np.random.default_rng(seed)
+    for sample in dataset:
+        sample["emb"] = rng.normal(size=dim).astype("float32")
+        sample.save()
+
+    return dataset, rng
+
+
+def _make_synthetic_patches_dataset(
+    name, n_samples=20, patches_per_sample=3, dim=64, seed=7
+):
+    if fo.dataset_exists(name):
+        fo.delete_dataset(name)
+
+    dataset = fo.Dataset(name)
+    rng = np.random.default_rng(seed)
+
+    samples = []
+    for i in range(n_samples):
+        s = fo.Sample(filepath="/tmp/%s_%d.jpg" % (name, i))
+        detections = [
+            fo.Detection(
+                label="obj",
+                bounding_box=[0.05 + 0.1 * j, 0.1, 0.2, 0.2],
+            )
+            for j in range(patches_per_sample)
+        ]
+        s["ground_truth"] = fo.Detections(detections=detections)
+        samples.append(s)
+
+    dataset.add_samples(samples)
+
+    label_ids = dataset.values("ground_truth.detections.id", unwind=True)
+    embeddings = {
+        lid: rng.normal(size=dim).astype("float32") for lid in label_ids
+    }
+    dataset.set_label_values(
+        "ground_truth.detections.emb", embeddings, dynamic=True
+    )
+
+    return dataset, rng
+
+
+def _add_new_samples(dataset, n, dim, rng, prefix="new", populate_field=True):
+    new_samples = [
+        fo.Sample(filepath="/tmp/%s_%s_%d.jpg" % (dataset.name, prefix, i))
+        for i in range(n)
+    ]
+    dataset.add_samples(new_samples)
+    new_view = dataset.match({"filepath": {"$regex": "_%s_" % prefix}})
+    new_emb = rng.normal(size=(n, dim)).astype("float32")
+    new_ids = new_view.values("id")
+    if populate_field:
+        for sample, emb in zip(new_view, new_emb):
+            sample["emb"] = emb
+            sample.save()
+    return new_view, new_emb, new_ids
+
+
+def test_add_samples_umap_field():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_umap_field")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="umap",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+        verbose=False,
+    )
+
+    initial = results.total_index_size
+    new_view, _, new_ids = _add_new_samples(dataset, 20, 64, rng)
+
+    results.add_samples(new_view, embeddings="emb")
+
+    assert results.total_index_size == initial + 20
+    assert results.points.shape == (initial + 20, 2)
+    assert set(new_ids).issubset(set(results.sample_ids.tolist()))
+
+    reloaded = dataset.load_brain_results("vk")
+    assert reloaded.total_index_size == initial + 20
+
+    dataset.delete()
+
+
+def test_add_samples_umap_array():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_umap_array")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="umap",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+        verbose=False,
+    )
+
+    initial = results.total_index_size
+    new_view, new_emb, new_ids = _add_new_samples(
+        dataset, 15, 64, rng, populate_field=False
+    )
+
+    results.add_samples(new_view, embeddings=new_emb)
+
+    assert results.total_index_size == initial + 15
+    assert set(new_ids).issubset(set(results.sample_ids.tolist()))
+    for sample in new_view:
+        assert sample["emb"] is not None
+
+    dataset.delete()
+
+
+def test_add_samples_pca():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_pca")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    initial = results.total_index_size
+    new_view, _, new_ids = _add_new_samples(dataset, 20, 64, rng)
+    results.add_samples(new_view)
+
+    assert results.total_index_size == initial + 20
+
+    reloaded = dataset.load_brain_results("vk")
+    assert reloaded.total_index_size == initial + 20
+
+    dataset.delete()
+
+
+def test_add_samples_tsne_raises():
+    dataset, _ = _make_synthetic_dataset("test_add_samples_tsne", n=80, dim=64)
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="tsne",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+        verbose=False,
+    )
+
+    try:
+        results.add_samples(dataset)
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "does not support" in str(e)
+
+    dataset.delete()
+
+
+def test_add_samples_manual_raises():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_manual")
+
+    points = rng.normal(size=(len(dataset), 2))
+    results = fob.compute_visualization(dataset, points=points, brain_key="vk")
+
+    try:
+        results.add_samples(dataset)
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "does not support" in str(e)
+
+    dataset.delete()
+
+
+def test_add_samples_umap_no_embeddings_field_raises():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_no_ef")
+
+    embeddings = np.stack(dataset.values("emb"))
+    results = fob.compute_visualization(
+        dataset,
+        embeddings=embeddings,
+        method="umap",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+        verbose=False,
+    )
+
+    _add_new_samples(dataset, 5, 64, rng, populate_field=False)
+
+    try:
+        results.add_samples(dataset, embeddings=np.zeros((5, 64)))
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "embeddings_field" in str(e)
+
+    dataset.delete()
+
+
+def test_add_samples_legacy_result_raises():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_legacy")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    results._reducer = None
+    results._reducer_blob = None
+
+    new_view, _, _ = _add_new_samples(dataset, 5, 64, rng)
+
+    try:
+        results.add_samples(new_view)
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "before incremental updates" in str(e)
+
+    dataset.delete()
+
+
+def test_add_samples_dim_mismatch_raises():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_dim")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    new_view, _, _ = _add_new_samples(
+        dataset, 5, 64, rng, populate_field=False
+    )
+    bad = np.zeros((5, 32), dtype="float32")
+
+    try:
+        results.add_samples(new_view, embeddings=bad)
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "dimension" in str(e)
+
+    dataset.delete()
+
+
+def test_add_samples_duplicate_overwrite_false():
+    dataset, _ = _make_synthetic_dataset("test_add_samples_dup")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    initial = results.total_index_size
+    results.add_samples(
+        dataset,
+        skip_existing=False,
+        overwrite=False,
+        warn_existing=True,
+    )
+
+    assert results.total_index_size == initial
+
+    dataset.delete()
+
+
+def test_add_samples_skip_existing():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_skip")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    initial = results.total_index_size
+    _add_new_samples(dataset, 15, 64, rng)
+
+    results.add_samples(dataset)
+
+    assert results.total_index_size == initial + 15
+
+    dataset.delete()
+
+
+def test_add_samples_no_new_is_noop():
+    dataset, _ = _make_synthetic_dataset("test_add_samples_noop")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    initial = results.total_index_size
+    results.add_samples(dataset)
+
+    assert results.total_index_size == initial
+
+    dataset.delete()
+
+
+def test_add_samples_other_field_writes_through():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_otherfield")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    initial = results.total_index_size
+    new_view, _, _ = _add_new_samples(
+        dataset, 5, 64, rng, populate_field=False
+    )
+    for sample in new_view:
+        sample["emb_v2"] = rng.normal(size=64).astype("float32")
+        sample.save()
+
+    results.add_samples(new_view, embeddings="emb_v2")
+
+    assert results.total_index_size == initial + 5
+    for sample in new_view:
+        assert sample["emb"] is not None
+
+    dataset.delete()
+
+
+def test_add_samples_dict_writes_through():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_dictwt")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    initial = results.total_index_size
+    new_view, _, new_ids = _add_new_samples(
+        dataset, 5, 64, rng, populate_field=False
+    )
+    emb_dict = {_id: rng.normal(size=64).astype("float32") for _id in new_ids}
+
+    results.add_samples(new_view, embeddings=emb_dict)
+
+    assert results.total_index_size == initial + 5
+    for sample in new_view:
+        assert sample["emb"] is not None
+
+    dataset.delete()
+
+
+def test_add_samples_umap_rehydrate_training_set_only():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_rehydr")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="umap",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+        verbose=False,
+    )
+
+    n_train = results._reducer.embedding_.shape[0]
+
+    _add_new_samples(dataset, 10, 64, rng, prefix="r1")
+    results = dataset.load_brain_results("vk")
+    results.add_samples(dataset)
+
+    _add_new_samples(dataset, 10, 64, rng, prefix="r2")
+    results = dataset.load_brain_results("vk")
+    results.add_samples(dataset)
+
+    assert results._reducer.embedding_.shape[0] == n_train
+    assert results.total_index_size == n_train + 20
+
+    dataset.delete()
+
+
+def test_add_samples_persistence():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_persist")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    _, _, new_ids = _add_new_samples(dataset, 10, 64, rng)
+    results.add_samples(dataset)
+
+    del results
+
+    reloaded = dataset.load_brain_results("vk")
+    assert reloaded.total_index_size == 90
+    assert set(new_ids).issubset(set(reloaded.sample_ids.tolist()))
+
+    dataset.delete()
+
+
+def test_add_samples_requires_source_when_unset():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_unset")
+
+    embeddings = np.stack(dataset.values("emb"))
+    results = fob.compute_visualization(
+        dataset,
+        embeddings=embeddings,
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    new_view, _, _ = _add_new_samples(
+        dataset, 5, 64, rng, populate_field=False
+    )
+
+    try:
+        results.add_samples(new_view)
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "No embeddings" in str(e)
+
+    dataset.delete()
+
+
+def test_add_samples_field_unpopulated_falls_back_to_config_model():
+    """When the canonical embeddings_field is on the schema but unpopulated
+    for the new samples, add_samples should fall back to config.model."""
+    from unittest import mock
+
+    dataset, rng = _make_synthetic_dataset(
+        "test_add_samples_unpopulated_fallback", n=40, dim=64
+    )
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        model="fake-zoo-model",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+    assert results.config.model == "fake-zoo-model"
+
+    new_samples = [
+        fo.Sample(filepath="/tmp/%s_new_%d.jpg" % (dataset.name, i))
+        for i in range(8)
+    ]
+    dataset.add_samples(new_samples)
+    new_view = dataset.match({"filepath": {"$regex": "_new_"}})
+
+    class _StubModel:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _fake_compute_embeddings(
+        self_view, model, embeddings_field=None, **kwargs
+    ):
+        n = len(self_view)
+        out = rng.normal(size=(n, 64)).astype("float32")
+        if embeddings_field is not None:
+            ids = self_view.values("id")
+            self_view._dataset.set_values(
+                embeddings_field,
+                dict(zip(ids, out)),
+                key_field="id",
+            )
+        return out
+
+    with mock.patch(
+        "fiftyone.zoo.load_zoo_model", return_value=_StubModel()
+    ), mock.patch(
+        "fiftyone.core.collections.SampleCollection.compute_embeddings",
+        autospec=True,
+        side_effect=_fake_compute_embeddings,
+    ):
+        results.add_samples(new_view)
+
+    assert results.total_index_size == 48
+    for sample in new_view:
+        assert sample["emb"] is not None
+
+    dataset.delete()
+
+
+def test_add_samples_reuses_saved_model():
+    """End-to-end check with a real zoo model. Compute UMAP visualization with
+    model='mobilenet-v2-imagenet-torch', add new unpopulated samples, and
+    confirm add_samples computes their embeddings via the saved model and
+    writes them through to the canonical embeddings field."""
+    if fo.dataset_exists("test_add_samples_reuses_saved_model"):
+        fo.delete_dataset("test_add_samples_reuses_saved_model")
+
+    dataset = foz.load_zoo_dataset(
+        "quickstart",
+        max_samples=20,
+        dataset_name="test_add_samples_reuses_saved_model",
+    )
+    model = foz.load_zoo_model("mobilenet-v2-imagenet-torch")
+    dataset.compute_embeddings(model, embeddings_field="emb", batch_size=8)
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        model="mobilenet-v2-imagenet-torch",
+        method="umap",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+        verbose=False,
+    )
+    assert results.config.model == "mobilenet-v2-imagenet-torch"
+    initial = results.total_index_size
+
+    new_samples = [
+        fo.Sample(filepath=dataset.first().filepath) for _ in range(5)
+    ]
+    dataset.add_samples(new_samples)
+    new_view = dataset.match({"id": {"$in": [s.id for s in new_samples]}})
+    assert all(s["emb"] is None for s in new_view)
+
+    results.add_samples(dataset)
+
+    assert results.total_index_size == initial + 5
+    for sample in new_view:
+        assert sample["emb"] is not None
+
+    dataset.delete()
+
+
+def test_add_samples_patches_new_samples():
+    """Happy path: visualization over patches, then add new samples each
+    containing several detections. All new patches should be projected."""
+    dataset, rng = _make_synthetic_patches_dataset(
+        "test_add_samples_patches_new", n_samples=20, patches_per_sample=3
+    )
+
+    results = fob.compute_visualization(
+        dataset,
+        patches_field="ground_truth",
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    initial = results.total_index_size
+    assert initial == 20 * 3
+
+    new_samples = []
+    for i in range(5):
+        s = fo.Sample(filepath="/tmp/%s_new_%d.jpg" % (dataset.name, i))
+        detections = []
+        for j in range(3):
+            d = fo.Detection(
+                label="obj",
+                bounding_box=[0.1 * j, 0.1, 0.2, 0.2],
+            )
+            d["emb"] = rng.normal(size=64).astype("float32")
+            detections.append(d)
+        s["ground_truth"] = fo.Detections(detections=detections)
+        new_samples.append(s)
+    dataset.add_samples(new_samples)
+
+    results.add_samples(dataset)
+
+    assert results.total_index_size == initial + 5 * 3
+    new_label_ids = []
+    for s in dataset.match({"filepath": {"$regex": "_new_"}}):
+        new_label_ids.extend([d.id for d in s["ground_truth"].detections])
+    assert set(new_label_ids).issubset(set(results.label_ids.tolist()))
+
+    dataset.delete()
+
+
+def test_add_samples_patches_field_unpopulated_falls_back_to_config_model():
+    """Regression: when new patches in the dataset don't have embeddings
+    populated in `config.embeddings_field`, add_samples should fall back to
+    `config.model` and compute their embeddings via that model."""
+    from unittest import mock
+
+    dataset, rng = _make_synthetic_patches_dataset(
+        "test_add_samples_patches_unpop",
+        n_samples=15,
+        patches_per_sample=3,
+    )
+
+    results = fob.compute_visualization(
+        dataset,
+        patches_field="ground_truth",
+        embeddings="emb",
+        model="fake-zoo-model",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+    assert results.config.model == "fake-zoo-model"
+    initial = results.total_index_size
+    assert initial == 15 * 3
+
+    new_samples = []
+    for i in range(5):
+        s = fo.Sample(filepath="/tmp/%s_new_%d.jpg" % (dataset.name, i))
+        detections = [
+            fo.Detection(
+                label="obj",
+                bounding_box=[0.1 * j, 0.1, 0.2, 0.2],
+            )
+            for j in range(2)
+        ]
+        s["ground_truth"] = fo.Detections(detections=detections)
+        new_samples.append(s)
+    dataset.add_samples(new_samples)
+
+    class _StubModel:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _fake_compute_patch_embeddings(
+        self_view,
+        model,
+        patches_field,
+        embeddings_field=None,
+        **kwargs,
+    ):
+        out = {}
+        for sample in self_view:
+            n = len(sample[patches_field].detections)
+            if n > 0:
+                out[sample.id] = rng.normal(size=(n, 64)).astype("float32")
+        return out
+
+    with mock.patch(
+        "fiftyone.zoo.load_zoo_model", return_value=_StubModel()
+    ), mock.patch(
+        "fiftyone.core.collections.SampleCollection.compute_patch_embeddings",
+        autospec=True,
+        side_effect=_fake_compute_patch_embeddings,
+    ):
+        results.add_samples(dataset)
+
+    assert results.total_index_size == initial + 5 * 2
+
+    dataset.delete()
+
+
+def test_add_samples_patches_new_patches_in_existing_sample():
+    """Regression: adding new detections to an existing sample (same
+    sample_id, new label_ids) should pick up the new patches when
+    skip_existing=True."""
+    dataset, rng = _make_synthetic_patches_dataset(
+        "test_add_samples_patches_existing", n_samples=20, patches_per_sample=3
+    )
+
+    results = fob.compute_visualization(
+        dataset,
+        patches_field="ground_truth",
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    initial = results.total_index_size
+
+    first_sample = dataset.first()
+    new_detections = list(first_sample["ground_truth"].detections)
+    for j in range(2):
+        d = fo.Detection(
+            label="obj",
+            bounding_box=[0.4 + 0.1 * j, 0.4, 0.2, 0.2],
+        )
+        d["emb"] = rng.normal(size=64).astype("float32")
+        new_detections.append(d)
+    first_sample["ground_truth"] = fo.Detections(detections=new_detections)
+    first_sample.save()
+
+    new_label_ids = [d.id for d in new_detections[-2:]]
+
+    results.add_samples(dataset)
+
+    assert results.total_index_size == initial + 2
+    assert set(new_label_ids).issubset(set(results.label_ids.tolist()))
+
+    dataset.delete()
+
+
 if __name__ == "__main__":
     fo.config.show_progress_bars = True
     unittest.main(verbosity=2)


### PR DESCRIPTION
# Rationale

Embeddings visualization on FO datasets cannot be updated when a handful of new samples are added to the dataset. The whole visualization has to be recomputed. This PR introduces functionality that allows incremental embeddings visualization brain run updates to existing brain results. 

Design doc can be found [here](https://docs.google.com/document/d/1hRRlDp2asYZpmlBt3nyfLBQiWnO1o86DKO4Q9KnnU_c/edit?tab=t.0)

## Changes

Adding a new `add_samples` method to a VisualizationResult that allows for adding samples to an existing embeddings visualization run. 

## Testing

Tested manually as well as added python tests for both sample and patch embeddings.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->