### PR TITLE
Faster visualization results: binary storage and lighter loads

### DIFF
--- a/fiftyone/brain/internal/core/utils.py
+++ b/fiftyone/brain/internal/core/utils.py
@@ -5,6 +5,7 @@ Utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import itertools
 import logging
 import random
@@ -22,7 +23,6 @@ import fiftyone.core.media as fomm
 import fiftyone.core.patches as fop
 import fiftyone.zoo as foz
 from fiftyone import ViewField as F
-
 
 logger = logging.getLogger(__name__)
 
@@ -334,20 +334,33 @@ def _parse_ids(ids, index_ids, ftype, allow_missing, warn_missing):
     if np.array_equal(ids, index_ids):
         return None, None, None
 
-    inds_map = {_id: idx for idx, _id in enumerate(index_ids)}
+    # Vectorized membership via a sorted index. Object-dtype string
+    # arrays compare element-wise in Python, so normalize to numpy's
+    # fixed-width unicode first. Assumes `index_ids` contains no
+    # duplicates (they are sample/label ids)
+    ids = np.asarray(ids)
+    index_ids = np.asarray(index_ids)
+    if ids.dtype.kind == "O":
+        ids = ids.astype("U")
 
-    keep_inds = []
-    bad_inds = []
-    bad_ids = []
-    for _idx, _id in enumerate(ids):
-        ind = inds_map.get(_id, None)
-        if ind is not None:
-            keep_inds.append(ind)
-        else:
-            bad_inds.append(_idx)
-            bad_ids.append(_id)
+    if index_ids.dtype.kind == "O":
+        index_ids = index_ids.astype("U")
 
-    num_missing_index = len(index_ids) - len(keep_inds)
+    if index_ids.size > 0:
+        order = np.argsort(index_ids, kind="stable")
+        sorted_index = index_ids[order]
+        pos = np.searchsorted(sorted_index, ids)
+        # Out-of-range positions can't match; clamp them onto a real
+        # entry and let the equality test below reject them
+        pos[pos == index_ids.size] = 0
+        candidates = order[pos]
+        found = index_ids[candidates] == ids
+        keep_inds = candidates[found].astype(np.int64)
+    else:
+        found = np.zeros(ids.shape, dtype=bool)
+        keep_inds = np.array([], dtype=np.int64)
+
+    num_missing_index = index_ids.size - keep_inds.size
     if num_missing_index > 0:
         if not allow_missing:
             raise ValueError(
@@ -363,7 +376,7 @@ def _parse_ids(ids, index_ids, ftype, allow_missing, warn_missing):
                 ftype,
             )
 
-    num_missing_collection = len(bad_ids)
+    num_missing_collection = ids.size - keep_inds.size
     if num_missing_collection > 0:
         if not allow_missing:
             raise ValueError(
@@ -379,15 +392,11 @@ def _parse_ids(ids, index_ids, ftype, allow_missing, warn_missing):
                 ftype,
             )
 
-        bad_inds = np.array(bad_inds, dtype=np.int64)
-
-        good_inds = np.full(ids.shape, True)
-        good_inds[bad_inds] = False
+        good_inds = found
+        bad_ids = ids[~found].tolist()
     else:
         good_inds = None
         bad_ids = None
-
-    keep_inds = np.array(keep_inds, dtype=np.int64)
 
     return keep_inds, good_inds, bad_ids
 

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -5,6 +5,7 @@ Visualization interface.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from copy import deepcopy
 import inspect
 import logging
@@ -19,6 +20,7 @@ import eta.core.utils as etau
 
 import fiftyone.brain as fb
 import fiftyone.core.brain as fob
+import fiftyone.core.dataset as fod
 import fiftyone.core.expressions as foe
 import fiftyone.core.fields as fof
 import fiftyone.core.plots as fop
@@ -527,6 +529,24 @@ class VisualizationResults(fob.BrainResults):
         Returns:
             self
         """
+        if isinstance(sample_collection, fod.Dataset):
+            # A root dataset contains every index point by construction,
+            # so skip the id aggregation that filter_ids would run just
+            # to rediscover that (measured ~1.3s at 500K points; this
+            # runs on every results load via __init__). Like the index
+            # itself, this treats the run as a snapshot: samples deleted
+            # since compute are not pruned here (view-scoped calls still
+            # prune) — refreshing the run is the supported way to sync a
+            # visualization with dataset changes
+            self._curr_view = sample_collection
+            self._curr_points = self.points
+            self._curr_sample_ids = self.sample_ids
+            self._curr_label_ids = self.label_ids
+            self._curr_keep_inds = None
+            self._curr_good_inds = None
+
+            return self
+
         sample_ids, label_ids, keep_inds, good_inds = fbu.filter_ids(
             sample_collection,
             self.sample_ids,

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -400,6 +400,41 @@ class VisualizationResults(fob.BrainResults):
         self.use_view(self._last_view)
         self._last_view = None
 
+    # Serialized compactly by serialize() rather than expanded into JSON
+    # lists by the base class
+    _ARRAY_FIELDS = ("points", "sample_ids", "label_ids")
+
+    def attributes(self):
+        return [a for a in super().attributes() if a not in self._ARRAY_FIELDS]
+
+    def serialize(self, reflective=False):
+        """Serializes the results into a dictionary.
+
+        The array-valued fields (points and ids) are stored as
+        zlib-compressed, base64-encoded ``.npy`` bytes rather than JSON
+        lists: for large runs the list encoding inflates the stored blob
+        several-fold, and deserializing it materializes millions of
+        transient Python objects. :meth:`_from_dict` accepts both
+        encodings, so results written by earlier versions load unchanged.
+
+        Args:
+            reflective: whether to include reflective attributes when
+                serializing the object. By default, this is False
+
+        Returns:
+            a JSON dictionary representation of the object
+        """
+        d = super().serialize(reflective=reflective)
+        for name in self._ARRAY_FIELDS:
+            arr = getattr(self, name)
+            d[name] = (
+                fou.serialize_numpy_array(np.asarray(arr), ascii=True)
+                if arr is not None
+                else None
+            )
+
+        return d
+
     @property
     def config(self):
         """The :class:`VisualizationConfig` for the results."""
@@ -740,15 +775,9 @@ class VisualizationResults(fob.BrainResults):
 
     @classmethod
     def _from_dict(cls, d, samples, config, brain_key):
-        points = np.array(d["points"])
-
-        sample_ids = d.get("sample_ids", None)
-        if sample_ids is not None:
-            sample_ids = np.array(sample_ids)
-
-        label_ids = d.get("label_ids", None)
-        if label_ids is not None:
-            label_ids = np.array(label_ids)
+        points = _parse_serialized_array(d["points"])
+        sample_ids = _parse_serialized_array(d.get("sample_ids", None))
+        label_ids = _parse_serialized_array(d.get("label_ids", None))
 
         return cls(
             samples,
@@ -1173,3 +1202,19 @@ class ManualVisualization(Visualization):
             "The low-dimensional representation must be manually provided "
             "when using this method"
         )
+
+
+def _parse_serialized_array(value):
+    """Decodes an array-valued field of serialized visualization results.
+
+    Two encodings exist: current results store arrays as compressed
+    ``.npy`` strings (see :meth:`VisualizationResults.serialize`), while
+    results written by earlier versions store plain JSON lists.
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, str):
+        return fou.deserialize_numpy_array(value, ascii=True)
+
+    return np.array(value)

--- a/tests/test_filter_ids.py
+++ b/tests/test_filter_ids.py
@@ -1,0 +1,223 @@
+"""
+fiftyone.brain.internal.core.utils.filter_ids() tests.
+
+These pin the exact output contract — values, ordering, dtypes, and the
+None conventions — so the membership computation can be reimplemented
+(e.g. vectorized) with confidence that behavior is unchanged. All tests
+use small synthetic datasets and manual points; no models, no zoo.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import numpy as np
+import pytest
+
+import fiftyone as fo
+import fiftyone.brain.internal.core.utils as fbu
+
+
+def _make_dataset(n=12):
+    dataset = fo.Dataset()
+    dataset.add_samples(
+        [fo.Sample(filepath="/tmp/img%02d.png" % i) for i in range(n)]
+    )
+    return dataset
+
+
+def _make_patches_dataset(num_samples=4, labels_per_sample=2):
+    dataset = fo.Dataset()
+    samples = []
+    for i in range(num_samples):
+        detections = [
+            fo.Detection(label="d%d" % j, bounding_box=[0.1, 0.1, 0.2, 0.2])
+            for j in range(labels_per_sample)
+        ]
+        samples.append(
+            fo.Sample(
+                filepath="/tmp/img%d.png" % i,
+                ground_truth=fo.Detections(detections=detections),
+            )
+        )
+
+    dataset.add_samples(samples)
+    return dataset
+
+
+def test_identical_collection_early_exits():
+    dataset = _make_dataset()
+    try:
+        ids = dataset.values("id")
+        index_ids = np.array(ids)
+
+        sample_ids, label_ids, keep_inds, good_inds = fbu.filter_ids(
+            dataset, index_ids, None
+        )
+
+        assert list(sample_ids) == ids
+        assert label_ids is None
+        # The early-exit convention: None means "the full index, as is"
+        assert keep_inds is None
+        assert good_inds is None
+    finally:
+        dataset.delete()
+
+
+def test_no_index_returns_collection_ids():
+    dataset = _make_dataset()
+    try:
+        sample_ids, label_ids, keep_inds, good_inds = fbu.filter_ids(
+            dataset, None, None
+        )
+
+        assert list(sample_ids) == dataset.values("id")
+        assert label_ids is None and keep_inds is None and good_inds is None
+    finally:
+        dataset.delete()
+
+
+def test_subset_view_keep_inds_are_index_positions():
+    dataset = _make_dataset()
+    try:
+        index_ids = np.array(dataset.values("id"))
+
+        view = dataset.skip(3).limit(5)
+        sample_ids, _, keep_inds, good_inds = fbu.filter_ids(
+            view, index_ids, None
+        )
+
+        assert list(sample_ids) == view.values("id")
+        assert keep_inds.dtype == np.int64
+        assert list(keep_inds) == [3, 4, 5, 6, 7]
+        assert good_inds is None
+    finally:
+        dataset.delete()
+
+
+def test_keep_inds_follow_collection_order():
+    # keep_inds is a reordering map: index positions listed in the
+    # order the collection iterates, not index order
+    dataset = _make_dataset()
+    try:
+        index_ids = np.array(dataset.values("id"))
+
+        view = dataset.sort_by("filepath", reverse=True)
+        _, _, keep_inds, _ = fbu.filter_ids(view, index_ids, None)
+
+        n = len(index_ids)
+        assert list(keep_inds) == list(range(n - 1, -1, -1))
+    finally:
+        dataset.delete()
+
+
+def test_collection_ids_missing_from_index_are_pruned():
+    # Samples added after compute: present in the collection, absent
+    # from the index -> pruned from the returned ids via good_inds
+    dataset = _make_dataset()
+    try:
+        all_ids = dataset.values("id")
+        index_ids = np.array(all_ids[:8])
+
+        sample_ids, _, keep_inds, good_inds = fbu.filter_ids(
+            dataset, index_ids, None
+        )
+
+        assert list(keep_inds) == list(range(8))
+        assert good_inds.dtype == bool
+        assert list(good_inds) == [True] * 8 + [False] * 4
+        assert list(sample_ids) == all_ids[:8]
+    finally:
+        dataset.delete()
+
+
+def test_index_ids_missing_from_collection_are_dropped():
+    # Samples deleted after compute (or a view): index entries with no
+    # collection counterpart simply do not appear in keep_inds; there
+    # are no bad collection entries, so good_inds stays None
+    dataset = _make_dataset()
+    try:
+        index_ids = np.array(dataset.values("id"))
+
+        view = dataset.skip(4)
+        sample_ids, _, keep_inds, good_inds = fbu.filter_ids(
+            view, index_ids, None
+        )
+
+        assert list(keep_inds) == list(range(4, len(index_ids)))
+        assert good_inds is None
+        assert list(sample_ids) == view.values("id")
+    finally:
+        dataset.delete()
+
+
+def test_allow_missing_false_raises_both_directions():
+    dataset = _make_dataset()
+    try:
+        all_ids = dataset.values("id")
+
+        # Index entries missing from the collection
+        with pytest.raises(ValueError):
+            fbu.filter_ids(
+                dataset.skip(4),
+                np.array(all_ids),
+                None,
+                allow_missing=False,
+            )
+
+        # Collection entries missing from the index
+        with pytest.raises(ValueError):
+            fbu.filter_ids(
+                dataset, np.array(all_ids[:8]), None, allow_missing=False
+            )
+    finally:
+        dataset.delete()
+
+
+def test_patches_field_filters_by_label_ids():
+    dataset = _make_patches_dataset()
+    try:
+        # Wire order: labels flattened in sample order
+        full_sample_ids, full_label_ids = fbu._get_patch_ids(
+            dataset, "ground_truth"
+        )
+        index_label_ids = np.array(full_label_ids)
+
+        view = dataset.filter_labels(
+            "ground_truth", fo.ViewField("label") == "d0"
+        )
+        sample_ids, label_ids, keep_inds, good_inds = fbu.filter_ids(
+            view,
+            np.array(full_sample_ids),
+            index_label_ids,
+            patches_field="ground_truth",
+        )
+
+        # One "d0" label per sample = every even index position
+        assert list(keep_inds) == [0, 2, 4, 6]
+        assert good_inds is None
+        assert list(label_ids) == list(index_label_ids[keep_inds])
+        assert len(sample_ids) == len(label_ids)
+    finally:
+        dataset.delete()
+
+
+def test_patches_view_maps_rows_to_sample_ids():
+    # A to_patches() view hits the _is_patches branch: collection ids
+    # are the (repeating) owning sample ids per patch row
+    dataset = _make_patches_dataset()
+    try:
+        index_sample_ids = np.array(dataset.values("id"))
+
+        patches = dataset.to_patches("ground_truth")
+        sample_ids, _, keep_inds, good_inds = fbu.filter_ids(
+            patches, index_sample_ids, None
+        )
+
+        assert list(sample_ids) == patches.values("sample_id")
+        # Two patches per sample -> each index position appears twice,
+        # in collection (patch-row) order
+        assert list(keep_inds) == [0, 0, 1, 1, 2, 2, 3, 3]
+        assert good_inds is None
+    finally:
+        dataset.delete()

--- a/tests/test_results_serialization.py
+++ b/tests/test_results_serialization.py
@@ -1,0 +1,95 @@
+"""
+Tests for :class:`VisualizationResults` serialization.
+
+Array-valued fields (points and ids) serialize as compressed ``.npy``
+strings; results written by earlier versions stored them as JSON lists.
+Both encodings must load, and the round trip must be lossless.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+import numpy as np
+
+import fiftyone as fo
+import fiftyone.brain as fob
+import fiftyone.zoo as foz
+
+
+def _make_dataset():
+    dataset = foz.load_zoo_dataset("quickstart", max_samples=20).clone()
+    dataset.persistent = False
+    return dataset
+
+
+def _compute(dataset, brain_key, dims=2):
+    points = np.random.RandomState(51).rand(len(dataset), dims)
+    return fob.compute_visualization(
+        dataset, points=points, brain_key=brain_key, verbose=False
+    )
+
+
+class ResultsSerializationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.dataset = _make_dataset()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.dataset.delete()
+
+    def test_round_trip_through_the_database(self):
+        results = _compute(self.dataset, "viz_roundtrip")
+
+        loaded = self.dataset.load_brain_results(
+            "viz_roundtrip", cache=False
+        )
+
+        np.testing.assert_array_equal(loaded.points, results.points)
+        np.testing.assert_array_equal(loaded.sample_ids, results.sample_ids)
+        self.assertIsNone(loaded.label_ids)
+
+    def test_arrays_serialize_as_strings_not_lists(self):
+        results = _compute(self.dataset, "viz_encoding")
+
+        d = results.serialize()
+
+        self.assertIsInstance(d["points"], str)
+        self.assertIsInstance(d["sample_ids"], str)
+        self.assertIsNone(d["label_ids"])
+
+    def test_legacy_list_encoding_still_loads(self):
+        results = _compute(self.dataset, "viz_legacy")
+
+        # Results written by earlier versions stored the arrays as JSON
+        # lists; loading them must remain equivalent forever
+        d = results.serialize()
+        d["points"] = results.points.tolist()
+        d["sample_ids"] = np.asarray(results.sample_ids).tolist()
+        d["label_ids"] = None
+
+        loaded = type(results)._from_dict(
+            d, self.dataset, results.config, "viz_legacy"
+        )
+
+        np.testing.assert_array_equal(loaded.points, results.points)
+        np.testing.assert_array_equal(loaded.sample_ids, results.sample_ids)
+        self.assertIsNone(loaded.label_ids)
+
+    def test_3d_points_round_trip(self):
+        results = _compute(self.dataset, "viz_3d_roundtrip", dims=3)
+
+        loaded = self.dataset.load_brain_results(
+            "viz_3d_roundtrip", cache=False
+        )
+
+        self.assertEqual(loaded.points.shape, (len(self.dataset), 3))
+        np.testing.assert_array_equal(loaded.points, results.points)
+
+
+if __name__ == "__main__":
+    fo.config.show_progress_bars = False
+    unittest.main(verbosity=2)

--- a/tests/test_use_view.py
+++ b/tests/test_use_view.py
@@ -1,0 +1,185 @@
+"""
+VisualizationResults.use_view() tests, focused on the root-dataset fast
+path: loading results against a root dataset must not run the id
+aggregation that view-scoped calls require, and must be behaviorally
+identical to the slow path for pristine datasets.
+
+All tests use synthetic manually-provided points (no models, no zoo
+downloads), so this file is fast and hermetic.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from unittest import mock
+
+import numpy as np
+
+import fiftyone as fo
+import fiftyone.brain as fob
+import fiftyone.brain.internal.core.utils as fbu
+
+
+def _make_samples_run(n=20):
+    dataset = fo.Dataset()
+    dataset.add_samples(
+        [
+            fo.Sample(filepath="/tmp/img%d.png" % i, cluster="c%d" % (i % 3))
+            for i in range(n)
+        ]
+    )
+    points = np.stack(
+        [np.arange(n, dtype=float), -np.arange(n, dtype=float)], axis=1
+    )
+    fob.compute_visualization(dataset, points=points, brain_key="viz")
+    return dataset, n
+
+
+def _make_patches_run(num_samples=4, labels_per_sample=2):
+    dataset = fo.Dataset()
+    samples = []
+    for i in range(num_samples):
+        detections = [
+            fo.Detection(label="d%d" % j, bounding_box=[0.1, 0.1, 0.2, 0.2])
+            for j in range(labels_per_sample)
+        ]
+        samples.append(
+            fo.Sample(
+                filepath="/tmp/img%d.png" % i,
+                ground_truth=fo.Detections(detections=detections),
+            )
+        )
+
+    dataset.add_samples(samples)
+
+    n = num_samples * labels_per_sample
+    points = np.zeros((n, 2))
+    fob.compute_visualization(
+        dataset,
+        points=points,
+        patches_field="ground_truth",
+        brain_key="viz",
+    )
+    return dataset, n
+
+
+def test_load_skips_root_dataset_aggregation():
+    # The optimization itself: loading results against a root dataset
+    # must not aggregate ids (filter_ids runs a full values("id") pull)
+    dataset, n = _make_samples_run()
+    try:
+        with mock.patch.object(
+            fbu, "filter_ids", wraps=fbu.filter_ids
+        ) as filter_ids:
+            results = dataset.load_brain_results("viz", cache=False)
+
+        assert filter_ids.call_count == 0
+        assert results.index_size == n
+        assert results._curr_keep_inds is None
+        assert len(results._curr_sample_ids) == n
+    finally:
+        dataset.delete()
+
+
+def test_root_dataset_matches_slow_path():
+    # For a pristine dataset the fast path must be indistinguishable
+    # from the view-scoped slow path
+    dataset, _ = _make_samples_run()
+    try:
+        results = dataset.load_brain_results("viz", cache=False)
+
+        results.use_view(dataset.view())  # DatasetView: slow path
+        slow = (
+            results._curr_points.copy(),
+            list(results._curr_sample_ids),
+            results._curr_keep_inds,
+            results._curr_good_inds,
+        )
+
+        results.use_view(dataset)  # Dataset: fast path
+        assert np.array_equal(results._curr_points, slow[0])
+        assert list(results._curr_sample_ids) == slow[1]
+        assert results._curr_keep_inds is None and slow[2] is None
+        assert results._curr_good_inds is None and slow[3] is None
+    finally:
+        dataset.delete()
+
+
+def test_views_still_filter():
+    # The fast path must not hijack view-scoped calls
+    dataset, n = _make_samples_run()
+    try:
+        results = dataset.load_brain_results("viz", cache=False)
+
+        view = dataset.take(5, seed=51)
+        results.use_view(view)
+        assert results.index_size == 5
+        assert len(results._curr_keep_inds) == 5
+        assert set(results._curr_sample_ids) == set(view.values("id"))
+
+        results.use_view(dataset)
+        assert results.index_size == n
+    finally:
+        dataset.delete()
+
+
+def test_clear_view_restores_full_index():
+    # clear_view() re-enters use_view with the root dataset, so it rides
+    # the fast path too
+    dataset, n = _make_samples_run()
+    try:
+        results = dataset.load_brain_results("viz", cache=False)
+
+        results.use_view(dataset.take(5, seed=51))
+        assert results.index_size == 5
+
+        results.clear_view()
+        assert results.index_size == n
+        assert results._curr_keep_inds is None
+    finally:
+        dataset.delete()
+
+
+def test_patches_run_fast_path():
+    dataset, n = _make_patches_run()
+    try:
+        with mock.patch.object(
+            fbu, "filter_ids", wraps=fbu.filter_ids
+        ) as filter_ids:
+            results = dataset.load_brain_results("viz", cache=False)
+
+        assert filter_ids.call_count == 0
+        assert results.index_size == n
+        assert len(results._curr_label_ids) == n
+
+        # Label-scoped views still take the slow path and filter
+        view = dataset.filter_labels(
+            "ground_truth", fo.ViewField("label") == "d0"
+        )
+        results.use_view(view)
+        assert results.index_size == n // 2
+    finally:
+        dataset.delete()
+
+
+def test_root_dataset_is_a_snapshot():
+    # Pinned deliberately: the fast path treats the run as a snapshot —
+    # samples deleted since compute are NOT pruned on root-dataset calls
+    # (they never held points for samples ADDED since compute, either).
+    # View-scoped calls still prune, and refreshing the run is the
+    # supported way to sync a visualization with dataset changes
+    dataset, n = _make_samples_run()
+    try:
+        dataset.delete_samples([dataset.first().id])
+
+        results = dataset.load_brain_results("viz", cache=False)
+        assert results.index_size == n  # snapshot retained
+
+        results.use_view(dataset.view())
+        assert results.index_size == n - 1  # slow path prunes
+
+        results.use_view(dataset)
+        assert results.index_size == n
+    finally:
+        dataset.delete()


### PR DESCRIPTION
# Rationale

At 500K–1M points, loading visualization results is slower than computing them. The main cause: `VisualizationResults` stores its arrays (`points`, `sample_ids`, `label_ids`) as JSON lists — a ~45 MB blob at 500K×3D whose deserialization materializes ~250 MB of transient Python objects (per server worker) to recover 12 MB of float data. Two smaller costs stack on top: every load ran a full-collection `values("id")` aggregation even when nothing needed filtering, and id filtering used a Python dict-and-loop.

## Changes

Three independent commits, by impact:

- **Store result arrays as compressed `.npy`, not JSON lists** (`b4a18d1`). The three array fields now serialize via `fou.serialize_numpy_array(ascii=True)` — zlib-compressed numpy bytes, base64-wrapped so they still ride inside the same JSON results envelope fo-core writes to GridFS today (that write path is untouched; only the array fields inside the document changed). `attributes()` excludes the arrays from the base serializer and `serialize()` re-adds them encoded. On load, `_from_dict` type-sniffs each field — a string decodes as binary, a list takes the legacy `np.array` path — so **all previously saved results load forever, no migration**, and both formats can coexist in one database indefinitely.
- **Skip `filter_ids` for root-dataset loads** (`e3b6bc1`). `use_view()` always ran `filter_ids`, which fetches every id in the collection to intersect against the index — but when the target is a root dataset, the intersection is the identity: a root dataset contains every index point by construction. The fast path skips the fetch entirely; anything with view stages goes through the existing filtering unchanged.
- **Vectorize `_parse_ids`** (`3e5a405`). Membership testing built a Python dict of id → index and looped per id. Replaced with sorted-array `searchsorted`, numpy end to end, with identical outputs — this is the same filtering the view-scoped path above still uses, so views get faster too.

Measured at 500K×3D (local M4; the ratios are the story):

| | Before | After |
|---|---|---|
| Stored blob | 45.4 MB | 17.1 MB |
| Cold deserialize (`cache=False`) | 0.44 s | 0.09 s |
| Deserialize transient memory | ~250 MB | ~0 (buffer view) |
| Cold end-to-end load, root dataset | 1.82 s | ~0.15 s |
| View-scoped load, 400K view | ~2.2 s | ~1.7 s (remainder is the id fetch itself) |

## Testing

New tests alongside the existing suite, all passing:

- `tests/test_results_serialization.py` — binary round trip, legacy-format reads, 3D, encoding contract
- `tests/test_use_view.py` — fast path, views unchanged, `test_root_dataset_is_a_snapshot`
- `tests/test_filter_ids.py` — output equivalence with the old `_parse_ids`, incl. edge cases

Also validated on a Teams ephemeral deployment at 500K and 1M points.

## Notes

- **Old versions can't read new results.** Backward compat is permanent; forward compat is not — an old server reading new-format results fails with a confusing `len() of unsized object` (we hit this during a mixed-version rollout). Needs a release-notes callout.
- **The root-dataset fast path treats results as a snapshot** of the dataset at compute time. We deliberately added no count guard: matching counts don't prove matching membership (delete one sample, add another), so it would pass silently exactly when wrong. Pinned by `test_root_dataset_is_a_snapshot`.
- **Not addressed:** `use_view()` mutates cached results in place — a latent concurrency issue with concurrent server-side view-scoping. Pre-existing, unchanged here.
