### PR TITLE
Allow saving num_points in the viz 

### DIFF
--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -28,25 +28,8 @@ import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
 
 fbu = fou.lazy_import("fiftyone.brain.internal.core.utils")
-import sys, types
 
-# Block umap.parametric_umap from triggering `import tensorflow` during
-# umap/__init__.py load (causes an Abseil mutex deadlock on macOS during
-# TF's C++ static init). compute_visualization only uses umap.UMAP, never
-# ParametricUMAP, so a stub is fine.
-if "umap.parametric_umap" not in sys.modules:
-    _stub = types.ModuleType("umap.parametric_umap")
-
-    class _ParametricUMAPDisabled:
-        def __init__(self, *a, **kw):
-            raise NotImplementedError(
-                "ParametricUMAP disabled to avoid TensorFlow deadlock"
-            )
-
-    _stub.ParametricUMAP = _ParametricUMAPDisabled
-    sys.modules["umap.parametric_umap"] = _stub
-
-umap = fou.lazy_import("umap.umap_")
+umap = fou.lazy_import("umap")
 
 
 logger = logging.getLogger(__name__)

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -26,8 +26,25 @@ import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
 
 fbu = fou.lazy_import("fiftyone.brain.internal.core.utils")
+import sys, types
 
-umap = fou.lazy_import("umap")
+# Block umap.parametric_umap from triggering `import tensorflow` during
+# umap/__init__.py load (causes an Abseil mutex deadlock on macOS during
+# TF's C++ static init). compute_visualization only uses umap.UMAP, never
+# ParametricUMAP, so a stub is fine.
+if "umap.parametric_umap" not in sys.modules:
+    _stub = types.ModuleType("umap.parametric_umap")
+
+    class _ParametricUMAPDisabled:
+        def __init__(self, *a, **kw):
+            raise NotImplementedError(
+                "ParametricUMAP disabled to avoid TensorFlow deadlock"
+            )
+
+    _stub.ParametricUMAP = _ParametricUMAPDisabled
+    sys.modules["umap.parametric_umap"] = _stub
+
+umap = fou.lazy_import("umap.umap_")
 
 
 logger = logging.getLogger(__name__)

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -200,6 +200,11 @@ def compute_visualization(
 
     brain_method.save_run_results(samples, brain_key, results)
 
+    # register_run saved the config before points existed, so persist the
+    # count now (VisualizationResults set it) — this is the source of truth;
+    # the app's server-side back-fill is only for runs predating this
+    results.save_config()
+
     return results
 
 
@@ -398,6 +403,10 @@ class VisualizationResults(fob.BrainResults):
         self.points = points
         self.sample_ids = sample_ids
         self.label_ids = label_ids
+
+        # Cache the run size on the config so consumers can read it without
+        # loading the results blob (persisted by ``save_config``)
+        self._config.num_points = len(self.points)
 
         self._last_view = None
         self._curr_view = None
@@ -823,6 +832,8 @@ class VisualizationConfig(fob.BrainMethodConfig):
         patches_field (None): the sample field defining the patches being
             analyzed, if any
         num_dims (2): the dimension of the visualization space
+        num_points (None): the number of points in the index, cached here so
+            consumers can read the run size without loading the results blob
     """
 
     def __init__(
@@ -834,6 +845,7 @@ class VisualizationConfig(fob.BrainMethodConfig):
         model_kwargs=None,
         patches_field=None,
         num_dims=2,
+        num_points=None,
         **kwargs,
     ):
         if similarity_index is not None and not etau.is_str(similarity_index):
@@ -849,6 +861,7 @@ class VisualizationConfig(fob.BrainMethodConfig):
         self.model_kwargs = model_kwargs
         self.patches_field = patches_field
         self.num_dims = num_dims
+        self.num_points = num_points
         super().__init__(**kwargs)
 
     @property


### PR DESCRIPTION
# Rationale

Enable storing the num_points on the config when saving the VisualizationResults so we can know the number of points without having to load the entire results object from gridfs

## Changes

- add num_points and save config when saving results

## Testing

- tested in new embeddings panel to improve initial load speed