### PR TITLE
Release v0.23.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone fiftyone-brain
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: true
       - name: Set up Python
@@ -67,18 +67,18 @@ jobs:
           - "3.12"
     steps:
       - name: Clone fiftyone-brain
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: true
       - name: Clone fiftyone
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           path: fiftyone-src
           ref: develop
           repository: voxel51/fiftyone
       - name: Clone voxel51-eta
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         if: ${{ !startsWith(github.ref, 'refs/heads/rel') && !startsWith(github.ref, 'refs/tags/') }}
         with:
           fetch-depth: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
           pip install imageio pytest torch torchvision
       - name: Cache Zoo
         id: fiftyone-cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             .fiftyone

--- a/fiftyone/brain/internal/core/mosaic.py
+++ b/fiftyone/brain/internal/core/mosaic.py
@@ -19,7 +19,7 @@ from fiftyone.brain.similarity import (
 )
 import fiftyone.brain.internal.core.utils as fbu
 
-vector_search_client = fou.lazy_import("databricks.vector_search.client")
+ai_search_client = fou.lazy_import("databricks.ai_search.client")
 
 
 logger = logging.getLogger(__name__)
@@ -137,10 +137,10 @@ class MosaicSimilarity(Similarity):
     """
 
     def ensure_requirements(self):
-        fou.ensure_package("databricks-vectorsearch")
+        fou.ensure_package("databricks-ai-search")
 
     def ensure_usage_requirements(self):
-        fou.ensure_package("databricks-vectorsearch")
+        fou.ensure_package("databricks-ai-search")
 
     def initialize(self, samples, brain_key):
         return MosaicSimilarityIndex(
@@ -165,7 +165,7 @@ class MosaicSimilarityIndex(SimilarityIndex):
         self._initialize()
 
     def _initialize(self):
-        self._client = vector_search_client.VectorSearchClient(
+        self._client = ai_search_client.AISearchClient(
             workspace_url=self.config.workspace_url,
             service_principal_client_id=self.config.service_principal_client_id,
             service_principal_client_secret=self.config.service_principal_client_secret,
@@ -222,9 +222,12 @@ class MosaicSimilarityIndex(SimilarityIndex):
             },
         )
 
+        # The index must finish provisioning before it can accept writes
+        self._index.wait_until_ready()
+
     @property
     def client(self):
-        """The ``databricks.vector_search.client.VectorSearchClient`` instance for this index."""
+        """The ``databricks.ai_search.client.AISearchClient`` instance for this index."""
         return self._client
 
     @property

--- a/fiftyone/brain/internal/core/utils.py
+++ b/fiftyone/brain/internal/core/utils.py
@@ -5,6 +5,7 @@ Utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import itertools
 import logging
 import random
@@ -22,7 +23,6 @@ import fiftyone.core.media as fomm
 import fiftyone.core.patches as fop
 import fiftyone.zoo as foz
 from fiftyone import ViewField as F
-
 
 logger = logging.getLogger(__name__)
 
@@ -334,20 +334,33 @@ def _parse_ids(ids, index_ids, ftype, allow_missing, warn_missing):
     if np.array_equal(ids, index_ids):
         return None, None, None
 
-    inds_map = {_id: idx for idx, _id in enumerate(index_ids)}
+    # Vectorized membership via a sorted index. Object-dtype string
+    # arrays compare element-wise in Python, so normalize to numpy's
+    # fixed-width unicode first. Assumes `index_ids` contains no
+    # duplicates (they are sample/label ids)
+    ids = np.asarray(ids)
+    index_ids = np.asarray(index_ids)
+    if ids.dtype.kind == "O":
+        ids = ids.astype("U")
 
-    keep_inds = []
-    bad_inds = []
-    bad_ids = []
-    for _idx, _id in enumerate(ids):
-        ind = inds_map.get(_id, None)
-        if ind is not None:
-            keep_inds.append(ind)
-        else:
-            bad_inds.append(_idx)
-            bad_ids.append(_id)
+    if index_ids.dtype.kind == "O":
+        index_ids = index_ids.astype("U")
 
-    num_missing_index = len(index_ids) - len(keep_inds)
+    if index_ids.size > 0:
+        order = np.argsort(index_ids, kind="stable")
+        sorted_index = index_ids[order]
+        pos = np.searchsorted(sorted_index, ids)
+        # Out-of-range positions can't match; clamp them onto a real
+        # entry and let the equality test below reject them
+        pos[pos == index_ids.size] = 0
+        candidates = order[pos]
+        found = index_ids[candidates] == ids
+        keep_inds = candidates[found].astype(np.int64)
+    else:
+        found = np.zeros(ids.shape, dtype=bool)
+        keep_inds = np.array([], dtype=np.int64)
+
+    num_missing_index = index_ids.size - keep_inds.size
     if num_missing_index > 0:
         if not allow_missing:
             raise ValueError(
@@ -363,7 +376,7 @@ def _parse_ids(ids, index_ids, ftype, allow_missing, warn_missing):
                 ftype,
             )
 
-    num_missing_collection = len(bad_ids)
+    num_missing_collection = ids.size - keep_inds.size
     if num_missing_collection > 0:
         if not allow_missing:
             raise ValueError(
@@ -379,15 +392,11 @@ def _parse_ids(ids, index_ids, ftype, allow_missing, warn_missing):
                 ftype,
             )
 
-        bad_inds = np.array(bad_inds, dtype=np.int64)
-
-        good_inds = np.full(ids.shape, True)
-        good_inds[bad_inds] = False
+        good_inds = found
+        bad_ids = ids[~found].tolist()
     else:
         good_inds = None
         bad_ids = None
-
-    keep_inds = np.array(keep_inds, dtype=np.int64)
 
     return keep_inds, good_inds, bad_ids
 

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -40,6 +40,15 @@ logger = logging.getLogger(__name__)
 _DEFAULT_MODEL = "mobilenet-v2-imagenet-torch"
 _DEFAULT_BATCH_SIZE = None
 
+_REDUCER_APPLY_ERROR = (
+    "Failed to apply this visualization's stored reducer. This typically "
+    "means the run was computed in a different environment (e.g. a "
+    "different Python, umap-learn, or numba version), in which case the "
+    "stored reducer cannot be used here. Please recompute the "
+    "visualization (e.g. via compute_visualization()) to enable "
+    "incremental updates in this environment"
+)
+
 
 def compute_visualization(
     samples,
@@ -1051,7 +1060,12 @@ class VisualizationResults(fob.BrainResults):
                     100 * ratio,
                 )
 
-        new_points = np.asarray(self._reducer.transform(new_emb[ii, :]))
+        try:
+            new_points = np.asarray(self._reducer.transform(new_emb[ii, :]))
+        except Exception as e:
+            # same environment-mismatch failure mode as reducer hydration;
+            # see _prepare_reducer()
+            raise ValueError(_REDUCER_APPLY_ERROR) from e
 
         n = len(self.points)
         m = int(jj.max()) - n + 1
@@ -1152,7 +1166,14 @@ class VisualizationResults(fob.BrainResults):
         if self.config.method == "umap":
             if getattr(self._reducer, "_raw_data", None) is None:
                 training_embeddings = self._load_training_embeddings()
-                _hydrate_umap_reducer(self._reducer, training_embeddings)
+                try:
+                    _hydrate_umap_reducer(self._reducer, training_embeddings)
+                except Exception as e:
+                    # a reducer pickled under a different Python/umap/numba
+                    # unpickles cleanly but fails here, deep in numba (e.g.
+                    # ``AssertionError: key already in dictionary``), so
+                    # translate anything into an actionable error
+                    raise ValueError(_REDUCER_APPLY_ERROR) from e
 
     def _load_training_embeddings(self):
         n_train = self._reducer.embedding_.shape[0]
@@ -1250,7 +1271,7 @@ class VisualizationResults(fob.BrainResults):
         new_ids = [_id for _id in all_ids if _id not in known]
         return new_ids, len(all_ids)
 
-    def get_new_ids(self, samples=None):
+    def get_new_ids(self, samples=None, include_training_size=True):
         """Returns the IDs of the samples/patches in the given collection
         that are not present in this visualization, along with the number of
         embeddings that were used to fit this visualization's reducer.
@@ -1263,23 +1284,37 @@ class VisualizationResults(fob.BrainResults):
         new IDs is large relative to the training size (e.g. > 20%),
         recomputing the visualization will produce a more faithful embedding.
 
+        Computing the training size requires unpickling the stored reducer,
+        which for UMAP imports the ``umap`` package and can take several
+        seconds on the first use in a process. Pass
+        ``include_training_size=False`` to skip that work when only the IDs
+        are needed (e.g. to render a count in an interactive context).
+
         Args:
             samples (None): a
                 :class:`fiftyone.core.collections.SampleCollection` to check.
                 By default, the full collection on which this run was
                 performed is used
+            include_training_size (True): whether to compute the training
+                size, which loads the stored reducer. When ``False``, the
+                training size is returned as ``None``
 
         Returns:
             a tuple of
 
             -   a list of new IDs
             -   the number of embeddings used to fit the reducer, or ``None``
-                if no reducer is available for this run
+                if it was not computed or no reducer is available for this
+                run
         """
         if samples is None:
             samples = self._samples
 
         new_ids, _ = self._diff_ids(samples)
+
+        if not include_training_size:
+            return new_ids, None
+
         return new_ids, self._training_size()
 
     def needs_update(self, samples=None):

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -5,6 +5,7 @@ Visualization interface.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from copy import deepcopy
 import inspect
 import logging
@@ -19,6 +20,7 @@ import eta.core.utils as etau
 
 import fiftyone.brain as fb
 import fiftyone.core.brain as fob
+import fiftyone.core.dataset as fod
 import fiftyone.core.expressions as foe
 import fiftyone.core.fields as fof
 import fiftyone.core.plots as fop
@@ -398,6 +400,41 @@ class VisualizationResults(fob.BrainResults):
         self.use_view(self._last_view)
         self._last_view = None
 
+    # Serialized compactly by serialize() rather than expanded into JSON
+    # lists by the base class
+    _ARRAY_FIELDS = ("points", "sample_ids", "label_ids")
+
+    def attributes(self):
+        return [a for a in super().attributes() if a not in self._ARRAY_FIELDS]
+
+    def serialize(self, reflective=False):
+        """Serializes the results into a dictionary.
+
+        The array-valued fields (points and ids) are stored as
+        zlib-compressed, base64-encoded ``.npy`` bytes rather than JSON
+        lists: for large runs the list encoding inflates the stored blob
+        several-fold, and deserializing it materializes millions of
+        transient Python objects. :meth:`_from_dict` accepts both
+        encodings, so results written by earlier versions load unchanged.
+
+        Args:
+            reflective: whether to include reflective attributes when
+                serializing the object. By default, this is False
+
+        Returns:
+            a JSON dictionary representation of the object
+        """
+        d = super().serialize(reflective=reflective)
+        for name in self._ARRAY_FIELDS:
+            arr = getattr(self, name)
+            d[name] = (
+                fou.serialize_numpy_array(np.asarray(arr), ascii=True)
+                if arr is not None
+                else None
+            )
+
+        return d
+
     @property
     def config(self):
         """The :class:`VisualizationConfig` for the results."""
@@ -527,6 +564,24 @@ class VisualizationResults(fob.BrainResults):
         Returns:
             self
         """
+        if isinstance(sample_collection, fod.Dataset):
+            # A root dataset contains every index point by construction,
+            # so skip the id aggregation that filter_ids would run just
+            # to rediscover that (measured ~1.3s at 500K points; this
+            # runs on every results load via __init__). Like the index
+            # itself, this treats the run as a snapshot: samples deleted
+            # since compute are not pruned here (view-scoped calls still
+            # prune) — refreshing the run is the supported way to sync a
+            # visualization with dataset changes
+            self._curr_view = sample_collection
+            self._curr_points = self.points
+            self._curr_sample_ids = self.sample_ids
+            self._curr_label_ids = self.label_ids
+            self._curr_keep_inds = None
+            self._curr_good_inds = None
+
+            return self
+
         sample_ids, label_ids, keep_inds, good_inds = fbu.filter_ids(
             sample_collection,
             self.sample_ids,
@@ -720,15 +775,9 @@ class VisualizationResults(fob.BrainResults):
 
     @classmethod
     def _from_dict(cls, d, samples, config, brain_key):
-        points = np.array(d["points"])
-
-        sample_ids = d.get("sample_ids", None)
-        if sample_ids is not None:
-            sample_ids = np.array(sample_ids)
-
-        label_ids = d.get("label_ids", None)
-        if label_ids is not None:
-            label_ids = np.array(label_ids)
+        points = _parse_serialized_array(d["points"])
+        sample_ids = _parse_serialized_array(d.get("sample_ids", None))
+        label_ids = _parse_serialized_array(d.get("label_ids", None))
 
         return cls(
             samples,
@@ -1153,3 +1202,19 @@ class ManualVisualization(Visualization):
             "The low-dimensional representation must be manually provided "
             "when using this method"
         )
+
+
+def _parse_serialized_array(value):
+    """Decodes an array-valued field of serialized visualization results.
+
+    Two encodings exist: current results store arrays as compressed
+    ``.npy`` strings (see :meth:`VisualizationResults.serialize`), while
+    results written by earlier versions store plain JSON lists.
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, str):
+        return fou.deserialize_numpy_array(value, ascii=True)
+
+    return np.array(value)

--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -6,9 +6,12 @@ Visualization interface.
 |
 """
 
+import base64
 from copy import deepcopy
 import inspect
 import logging
+import pickle
+import zlib
 from packaging import version
 
 import numpy as np
@@ -133,6 +136,7 @@ def compute_visualization(
     if brain_key is not None:
         brain_method.register_run(samples, brain_key)
 
+    reducer = None
     if points is None:
         embeddings, sample_ids, label_ids = fbu.get_embeddings(
             samples,
@@ -151,7 +155,15 @@ def compute_visualization(
         )
 
         logger.info("Generating visualization...")
-        points = brain_method.fit(embeddings)
+        points, reducer = brain_method.fit_reducer(embeddings)
+
+        if config.method == "umap" and embeddings_field is None:
+            logger.info(
+                "Computed UMAP visualization without an embeddings field; "
+                "incremental updates via add_samples() won't be available. "
+                "Pass `embeddings=<field name>` next time to enable them"
+            )
+            reducer = None
     else:
         points, sample_ids, label_ids = fbu.parse_data(
             samples,
@@ -179,6 +191,7 @@ def compute_visualization(
         points,
         sample_ids=sample_ids,
         label_ids=label_ids,
+        reducer=reducer,
     )
 
     brain_method.save_run_results(samples, brain_key, results)
@@ -355,6 +368,11 @@ class VisualizationResults(fob.BrainResults):
         points: a ``num_points x num_dims`` array of visualization points
         sample_ids (None): a ``num_points`` array of sample IDs
         label_ids (None): a ``num_points`` array of label IDs, if applicable
+        reducer (None): the fitted dimensionality reduction model used to
+            generate ``points``, retained to support incremental updates via
+            :meth:`add_samples`. Not applicable to all methods
+        reducer_blob (None): a base64-encoded pickled form of ``reducer``,
+            used when reconstructing the results from a persisted run
         backend (None): a :class:`Visualization` backend
     """
 
@@ -366,6 +384,8 @@ class VisualizationResults(fob.BrainResults):
         points,
         sample_ids=None,
         label_ids=None,
+        reducer=None,
+        reducer_blob=None,
         backend=None,
     ):
         super().__init__(samples, config, brain_key, backend=backend)
@@ -382,6 +402,9 @@ class VisualizationResults(fob.BrainResults):
         self.sample_ids = sample_ids
         self.label_ids = label_ids
 
+        self._reducer = reducer
+        self._reducer_blob = reducer_blob
+
         self._last_view = None
         self._curr_view = None
         self._curr_points = None
@@ -391,6 +414,13 @@ class VisualizationResults(fob.BrainResults):
         self._curr_good_inds = None
 
         self.use_view(samples)
+
+    @property
+    def reducer_blob(self):
+        if self._reducer_blob is None and self._reducer is not None:
+            self._reducer_blob = _pickle_reducer(self._reducer)
+
+        return self._reducer_blob
 
     def __enter__(self):
         self._last_view = self.view
@@ -405,7 +435,11 @@ class VisualizationResults(fob.BrainResults):
     _ARRAY_FIELDS = ("points", "sample_ids", "label_ids")
 
     def attributes(self):
-        return [a for a in super().attributes() if a not in self._ARRAY_FIELDS]
+        attrs = [
+            a for a in super().attributes() if a not in self._ARRAY_FIELDS
+        ]
+        attrs.append("reducer_blob")
+        return attrs
 
     def serialize(self, reflective=False):
         """Serializes the results into a dictionary.
@@ -773,11 +807,548 @@ class VisualizationResults(fob.BrainResults):
             self.config.points_field = None
             self.save_config()
 
+    @property
+    def supports_auto_updates(self):
+        """Whether this index can be incrementally updated by calling
+        :meth:`add_samples` without manually providing `embeddings` or a
+        `model`.
+        """
+
+        # Some visualization methods do not support incremental updates
+        if not getattr(self.config.build(), "SUPPORTS_UPDATES", False):
+            return False
+
+        # The string name of a zoo model is required in order to call
+        # `add_samples()` without manually providing `embeddings` or a `model`
+        if self.config.model is None:
+            return False
+
+        # UMAP requires the embeddings to be stored on a field of the dataset
+        # in order to rehydrate its reducer
+        if (
+            self.config.method == "umap"
+            and self.config.embeddings_field is None
+        ):
+            return False
+
+        # If no reducer/blob is stored, this is an older visualization that
+        # cannot be incrementally updated
+        if self._reducer is None and self._reducer_blob is None:
+            return False
+
+        return True
+
+    def add_samples(
+        self,
+        samples,
+        embeddings=None,
+        model=None,
+        model_kwargs=None,
+        force_square=False,
+        alpha=None,
+        batch_size=None,
+        num_workers=None,
+        skip_failures=True,
+        progress=None,
+        skip_existing=True,
+        allow_existing=True,
+        warn_existing=False,
+        reload=True,
+    ):
+        """Incrementally extends this visualization with the new samples in
+        ``samples``.
+
+        Embeddings for the new samples are extracted (or accepted) and
+        transformed through the previously fitted reducer, then appended to
+        the index. This is significantly cheaper than recomputing the entire
+        visualization for datasets where only a few samples have been added.
+
+        By default, samples that are already in the visualization are skipped,
+        so it is safe to pass an entire dataset/view that contains both known
+        and new samples.
+
+        Only methods whose reducer supports ``transform()`` are supported
+        (currently UMAP and PCA). For UMAP, the original
+        ``config.embeddings_field`` must be set so that the kNN search
+        structure can be rebuilt on demand from the dataset.
+
+        The embedding source for the new samples is resolved in this order:
+
+        1. ``embeddings`` if provided (array, dict, or field name)
+        2. ``model`` if provided
+        3. ``config.embeddings_field`` if populated on the new samples
+        4. ``config.model`` if the zoo model name recorded on the original run
+        5. otherwise, an error is raised
+
+        Note that if the original :func:`compute_visualization` call was made
+        with a :class:`fiftyone.core.models.Model` instance rather than the
+        string name of a zoo model, ``config.model`` is ``None`` and you must
+        pass ``model`` or ``embeddings`` explicitly here to extend the
+        visualization.
+
+        Args:
+            samples: a :class:`fiftyone.core.collections.SampleCollection`
+                containing samples to add to the visualization
+            embeddings (None): pre-computed embeddings for the new samples.
+                Can be a ``num_samples x num_dims`` array, a dict mapping
+                sample/label IDs to embeddings, or the name of a field from
+                which to load them. If the resolved source differs from
+                ``config.embeddings_field``, the new embeddings are also
+                written through to ``config.embeddings_field`` so that future
+                UMAP reloads can rehydrate consistently
+            model (None): a model to use to compute embeddings. If not
+                provided, ``config.model`` is used if available
+            model_kwargs (None): a dictionary of optional keyword arguments to
+                pass to the model's ``Config`` when a model name is provided
+            force_square (False): see :func:`compute_visualization`
+            alpha (None): see :func:`compute_visualization`
+            batch_size (None): see :func:`compute_visualization`
+            num_workers (None): see :func:`compute_visualization`
+            skip_failures (True): see :func:`compute_visualization`
+            progress (None): see :func:`compute_visualization`
+            skip_existing (True): if True, samples already in the
+                visualization are silently dropped from ``samples`` before
+                computing embeddings, so only new samples are projected
+                through the reducer
+            allow_existing (True): if False, raise an error when
+                ``skip_existing`` is False and and a provided sample contains
+                an ID that already exists in the index
+            warn_existing (False): whether to log a warning if a point is not
+                added because its ID already exists in the index
+            reload (True): whether to refresh the current view after the
+                update
+        """
+        fov.validate_collection(samples)
+        if samples._root_dataset is not self._samples._root_dataset:
+            raise ValueError(
+                "You can only add samples from the same dataset to an "
+                "existing visualization"
+            )
+
+        self._prepare_reducer(samples)
+
+        config = self.config
+        patches_field = config.patches_field
+        canonical_field = config.embeddings_field
+        source_descriptor = _describe_embeddings_source(embeddings)
+
+        override_field = None
+        if isinstance(embeddings, str):
+            if embeddings != canonical_field:
+                override_field = embeddings
+            embeddings = None
+
+        if isinstance(embeddings, np.ndarray):
+            embeddings = _array_to_id_dict(
+                samples, embeddings, patches_field=patches_field
+            )
+
+        if skip_existing:
+            samples, embeddings = self._filter_known(samples, embeddings)
+            if len(samples) == 0:
+                logger.info("No new samples to add")
+                if reload:
+                    self.use_view(self._curr_view or self._samples)
+
+                return
+
+        effective_model = model
+        effective_model_kwargs = model_kwargs
+
+        source_field = override_field or canonical_field
+
+        field_populated = _field_has_populated_values(
+            samples, source_field, patches_field
+        )
+
+        if (
+            embeddings is None
+            and effective_model is None
+            and not field_populated
+        ):
+            if config.model is not None:
+                effective_model = config.model
+                if effective_model_kwargs is None:
+                    effective_model_kwargs = config.model_kwargs
+            else:
+                raise ValueError(
+                    "No embeddings, model, or embeddings field are available "
+                    "for the new samples. You must pass `model=` or "
+                    "`embeddings=` explicitly to add_samples()"
+                )
+
+        forced_model_fallback = (
+            effective_model is not None
+            and source_field is not None
+            and not field_populated
+        )
+        extraction_field = None if forced_model_fallback else source_field
+
+        new_emb, new_sample_ids, new_label_ids = fbu.get_embeddings(
+            samples,
+            model=effective_model,
+            model_kwargs=effective_model_kwargs,
+            patches_field=patches_field,
+            embeddings_field=extraction_field,
+            embeddings=embeddings,
+            force_square=force_square,
+            alpha=alpha,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            skip_failures=skip_failures,
+            progress=progress,
+        )
+
+        expected_dim = _expected_input_dim(self._reducer)
+        if expected_dim is not None and new_emb.shape[1] != expected_dim:
+            raise ValueError(
+                "embeddings have dimension %d but the fitted reducer "
+                "expects dimension %d" % (new_emb.shape[1], expected_dim)
+            )
+
+        new_sample_ids_out, new_label_ids_out, ii, jj = fbu.add_ids(
+            new_sample_ids,
+            new_label_ids,
+            self.sample_ids,
+            self.label_ids,
+            patches_field=patches_field,
+            overwrite=skip_existing,
+            allow_existing=allow_existing,
+            warn_existing=warn_existing,
+        )
+
+        if ii.size == 0:
+            if reload:
+                self.use_view(self._curr_view or self._samples)
+
+            return
+
+        if self.config.method == "umap":
+            n_new = int(ii.size)
+            n_train = self._reducer.embedding_.shape[0]
+            ratio = n_new / n_train
+            if ratio > 0.2:
+                logger.warning(
+                    "Projecting %d new samples through a fitted UMAP that "
+                    "was trained on %d samples (%.0f%%). This is an "
+                    "approximate transform — the manifold is not refit. "
+                    "For batches this large, consider recomputing the "
+                    "visualization via compute_visualization() for a more "
+                    "faithful embedding",
+                    n_new,
+                    n_train,
+                    100 * ratio,
+                )
+            else:
+                logger.warning(
+                    "Projecting %d new samples through a fitted UMAP that "
+                    "was trained on %d samples (%.0f%%). This is an "
+                    "approximate transform and not equivalent to a full "
+                    "refit. Quality depends on the new samples being "
+                    "in-distribution with the training set",
+                    n_new,
+                    n_train,
+                    100 * ratio,
+                )
+
+        new_points = np.asarray(self._reducer.transform(new_emb[ii, :]))
+
+        n = len(self.points)
+        m = int(jj.max()) - n + 1
+        if m > 0:
+            self.points = np.concatenate(
+                (
+                    self.points,
+                    np.empty(
+                        (m, self.points.shape[1]), dtype=self.points.dtype
+                    ),
+                )
+            )
+
+        self.points[jj] = new_points
+        self.sample_ids = new_sample_ids_out
+        if patches_field is not None:
+            self.label_ids = new_label_ids_out
+
+        if canonical_field is not None:
+            needs_write_through = (
+                source_descriptor in ("<dict>", "<ndarray>")
+                or (
+                    override_field is not None
+                    and override_field != canonical_field
+                )
+                or forced_model_fallback
+            )
+            if needs_write_through:
+                if forced_model_fallback:
+                    logger.info(
+                        "Computed %d new embeddings via model %r and stored "
+                        "them in embeddings_field=%r",
+                        int(ii.size),
+                        effective_model,
+                        canonical_field,
+                    )
+                else:
+                    logger.warning(
+                        "Embeddings for the new samples were sourced from "
+                        "%r but will also be stored in this run's "
+                        "embeddings_field=%r so that UMAP rehydration on "
+                        "future loads remains consistent",
+                        source_descriptor,
+                        canonical_field,
+                    )
+
+                fbu.add_embeddings(
+                    self._samples,
+                    new_emb[ii],
+                    new_sample_ids[ii],
+                    new_label_ids[ii] if new_label_ids is not None else None,
+                    canonical_field,
+                    patches_field=patches_field,
+                )
+
+        if config.points_field is not None:
+            self._write_points_field(
+                new_points,
+                new_sample_ids[ii],
+                new_label_ids[ii] if new_label_ids is not None else None,
+            )
+
+        if self.key is not None:
+            self.save()
+
+        if reload:
+            self.use_view(self._curr_view or self._samples)
+
+    def _prepare_reducer(self, samples):
+        if not getattr(self.config.build(), "SUPPORTS_UPDATES", False):
+            raise ValueError(
+                "method '%s' does not support incremental updates; please "
+                "recompute via compute_visualization()" % self.config.method
+            )
+
+        if (
+            self.config.method == "umap"
+            and self.config.embeddings_field is None
+        ):
+            raise ValueError(
+                "UMAP incremental updates require an embeddings field. "
+                "Please recompute via "
+                "compute_visualization(..., embeddings=<field name>) to "
+                "enable incremental updates"
+            )
+
+        if self._reducer is None:
+            if self._reducer_blob is None:
+                raise ValueError(
+                    "This visualization has no stored reducer. It may have "
+                    "been computed before incremental updates were supported. "
+                    "Please recompute via compute_visualization() to enable "
+                    "incremental updates"
+                )
+
+            self._reducer = _unpickle_reducer(self._reducer_blob)
+
+        if self.config.method == "umap":
+            if getattr(self._reducer, "_raw_data", None) is None:
+                training_embeddings = self._load_training_embeddings()
+                _hydrate_umap_reducer(self._reducer, training_embeddings)
+
+    def _load_training_embeddings(self):
+        n_train = self._reducer.embedding_.shape[0]
+
+        patches_field = self.config.patches_field
+        if patches_field is not None:
+            training_ids = self.label_ids[:n_train]
+        else:
+            training_ids = self.sample_ids[:n_train]
+
+        training_view = (
+            self._samples.select(list(training_ids), ordered=True)
+            if patches_field is None
+            else self._samples.select_labels(
+                ids=list(training_ids), fields=patches_field
+            )
+        )
+
+        embeddings, sample_ids, label_ids = fbu.get_embeddings(
+            training_view,
+            patches_field=patches_field,
+            embeddings_field=self.config.embeddings_field,
+        )
+
+        ids_returned = label_ids if patches_field is not None else sample_ids
+
+        returned_set = set(
+            ids_returned.tolist()
+            if hasattr(ids_returned, "tolist")
+            else ids_returned
+        )
+        expected_set = set(training_ids.tolist())
+        if expected_set != returned_set:
+            missing = sorted(expected_set - returned_set)
+            raise ValueError(
+                "Cannot rehydrate UMAP reducer: %d training %s are missing "
+                "from embeddings_field=%r (e.g. %s). The original training "
+                "embeddings are not recoverable; please recompute the "
+                "visualization"
+                % (
+                    len(missing),
+                    "labels" if patches_field is not None else "samples",
+                    self.config.embeddings_field,
+                    missing[:5],
+                )
+            )
+
+        order = {_id: i for i, _id in enumerate(ids_returned)}
+        idx = np.array([order[_id] for _id in training_ids])
+        return embeddings[idx]
+
+    def _filter_known(self, samples, embeddings):
+        patches_field = self.config.patches_field
+
+        new_ids, num_total = self._diff_ids(samples)
+
+        if patches_field is not None and self.label_ids is not None:
+            if len(new_ids) < num_total:
+                if new_ids:
+                    samples = samples.select_labels(
+                        ids=new_ids, fields=patches_field
+                    )
+                else:
+                    samples = samples.limit(0)
+        else:
+            if len(new_ids) != num_total:
+                samples = samples.select(new_ids)
+
+        if isinstance(embeddings, dict):
+            if patches_field is not None and self.label_ids is not None:
+                known_keys = set(self.label_ids.tolist())
+            else:
+                known_keys = set(self.sample_ids.tolist())
+            embeddings = {
+                _id: vec
+                for _id, vec in embeddings.items()
+                if _id not in known_keys
+            }
+
+        return samples, embeddings
+
+    def _diff_ids(self, samples):
+        patches_field = self.config.patches_field
+
+        if patches_field is not None and self.label_ids is not None:
+            _, label_ids_path = samples._get_label_field_path(
+                patches_field, "id"
+            )
+            all_ids = samples.values(label_ids_path, unwind=True)
+            known = set(self.label_ids.tolist())
+        else:
+            all_ids = samples.values("id")
+            known = set(self.sample_ids.tolist())
+
+        new_ids = [_id for _id in all_ids if _id not in known]
+        return new_ids, len(all_ids)
+
+    def get_new_ids(self, samples=None):
+        """Returns the IDs of the samples/patches in the given collection
+        that are not present in this visualization, along with the number of
+        embeddings that were used to fit this visualization's reducer.
+
+        For sample-level visualizations, sample IDs are returned; for
+        patch-level visualizations, label IDs are returned.
+
+        The training size can be used to decide whether an incremental
+        update via :meth:`add_samples` is appropriate; when the number of
+        new IDs is large relative to the training size (e.g. > 20%),
+        recomputing the visualization will produce a more faithful embedding.
+
+        Args:
+            samples (None): a
+                :class:`fiftyone.core.collections.SampleCollection` to check.
+                By default, the full collection on which this run was
+                performed is used
+
+        Returns:
+            a tuple of
+
+            -   a list of new IDs
+            -   the number of embeddings used to fit the reducer, or ``None``
+                if no reducer is available for this run
+        """
+        if samples is None:
+            samples = self._samples
+
+        new_ids, _ = self._diff_ids(samples)
+        return new_ids, self._training_size()
+
+    def needs_update(self, samples=None):
+        """Determines whether the given collection contains samples/patches
+        that are not present in this visualization.
+
+        Use :meth:`add_samples` to add the new samples to the visualization.
+
+        Args:
+            samples (None): a
+                :class:`fiftyone.core.collections.SampleCollection` to check.
+                By default, the full collection on which this run was
+                performed is used
+
+        Returns:
+            True/False
+        """
+        if samples is None:
+            samples = self._samples
+
+        new_ids, _ = self._diff_ids(samples)
+        return len(new_ids) > 0
+
+    def _training_size(self):
+        if self._reducer is None and self._reducer_blob is not None:
+            try:
+                self._reducer = _unpickle_reducer(self._reducer_blob)
+            except RuntimeError:
+                return None
+
+        reducer = self._reducer
+        if reducer is None:
+            return None
+
+        # UMAP
+        embedding = getattr(reducer, "embedding_", None)
+        if embedding is not None:
+            return embedding.shape[0]
+
+        # PCA
+        n_samples = getattr(reducer, "n_samples_", None)
+        if n_samples is not None:
+            return int(n_samples)
+
+        return None
+
+    def _write_points_field(self, new_points, sample_ids, label_ids):
+        config = self.config
+        points_field = config.points_field
+        patches_field = config.patches_field
+
+        dataset = self._samples._root_dataset
+        if patches_field is not None:
+            _, points_field_path = dataset._get_label_field_path(
+                patches_field, points_field
+            )
+            values = dict(zip(label_ids, new_points.astype(float).tolist()))
+            dataset.set_label_values(points_field_path, values)
+        else:
+            values = dict(zip(sample_ids, new_points.astype(float).tolist()))
+            dataset.set_values(points_field, values, key_field="id")
+
     @classmethod
     def _from_dict(cls, d, samples, config, brain_key):
         points = _parse_serialized_array(d["points"])
         sample_ids = _parse_serialized_array(d.get("sample_ids", None))
         label_ids = _parse_serialized_array(d.get("label_ids", None))
+
+        reducer_blob = d.get("reducer_blob", None)
 
         return cls(
             samples,
@@ -786,6 +1357,7 @@ class VisualizationResults(fob.BrainResults):
             points,
             sample_ids=sample_ids,
             label_ids=label_ids,
+            reducer_blob=reducer_blob,
         )
 
 
@@ -840,8 +1412,10 @@ class VisualizationConfig(fob.BrainMethodConfig):
 
 
 class Visualization(fob.BrainMethod):
-    def fit(self, embeddings):
-        raise NotImplementedError("subclass must implement fit()")
+    SUPPORTS_UPDATES = False
+
+    def fit_reducer(self, embeddings):
+        raise NotImplementedError("subclass must implement fit_reducer()")
 
     def get_fields(self, samples, brain_key):
         fields = []
@@ -962,6 +1536,8 @@ class UMAPVisualizationConfig(VisualizationConfig):
 
 
 class UMAPVisualization(Visualization):
+    SUPPORTS_UPDATES = True
+
     def ensure_requirements(self):
         fou.ensure_package(
             "umap-learn>=0.5",
@@ -973,7 +1549,7 @@ class UMAPVisualization(Visualization):
             ),
         )
 
-    def fit(self, embeddings):
+    def fit_reducer(self, embeddings):
         _umap = umap.UMAP(
             n_components=self.config.num_dims,
             n_neighbors=self.config.num_neighbors,
@@ -982,7 +1558,9 @@ class UMAPVisualization(Visualization):
             random_state=self.config.seed,
             verbose=self.config.verbose,
         )
-        return _umap.fit_transform(embeddings)
+        points = _umap.fit_transform(embeddings)
+        _strip_umap_training_data(_umap)
+        return points, _umap
 
 
 class TSNEVisualizationConfig(VisualizationConfig):
@@ -1077,7 +1655,7 @@ class TSNEVisualizationConfig(VisualizationConfig):
 
 
 class TSNEVisualization(Visualization):
-    def fit(self, embeddings):
+    def fit_reducer(self, embeddings):
         if self.config.pca_dims is not None:
             _pca = skd.PCA(
                 n_components=self.config.pca_dims,
@@ -1107,7 +1685,9 @@ class TSNEVisualization(Visualization):
             verbose=verbose,
             **{iter_param: self.config.max_iters},
         )
-        return _tsne.fit_transform(embeddings)
+        points = _tsne.fit_transform(embeddings)
+
+        return points, None
 
 
 class PCAVisualizationConfig(VisualizationConfig):
@@ -1168,13 +1748,16 @@ class PCAVisualizationConfig(VisualizationConfig):
 
 
 class PCAVisualization(Visualization):
-    def fit(self, embeddings):
+    SUPPORTS_UPDATES = True
+
+    def fit_reducer(self, embeddings):
         _pca = skd.PCA(
             n_components=self.config.num_dims,
             svd_solver=self.config.svd_solver,
             random_state=self.config.seed,
         )
-        return _pca.fit_transform(embeddings)
+        points = _pca.fit_transform(embeddings)
+        return points, _pca
 
 
 class ManualVisualizationConfig(VisualizationConfig):
@@ -1197,7 +1780,7 @@ class ManualVisualizationConfig(VisualizationConfig):
 
 
 class ManualVisualization(Visualization):
-    def fit(self, embeddings):
+    def fit_reducer(self, embeddings):
         raise NotImplementedError(
             "The low-dimensional representation must be manually provided "
             "when using this method"
@@ -1218,3 +1801,136 @@ def _parse_serialized_array(value):
         return fou.deserialize_numpy_array(value, ascii=True)
 
     return np.array(value)
+
+
+def _field_has_populated_values(samples, embeddings_field, patches_field=None):
+    if embeddings_field is None:
+        return False
+
+    if not fbu._has_embeddings_field(samples, embeddings_field, patches_field):
+        return False
+
+    try:
+        if patches_field is not None:
+            filtered = samples.filter_labels(
+                patches_field, foe.ViewField(embeddings_field) != None
+            )
+            _, ids_path = samples._get_label_field_path(patches_field, "id")
+            return len(filtered.values(ids_path, unwind=True)) > 0
+
+        return len(samples.exists(embeddings_field)) > 0
+    except Exception:
+        return False
+
+
+def _describe_embeddings_source(embeddings):
+    if isinstance(embeddings, str):
+        return embeddings
+
+    if isinstance(embeddings, dict):
+        return "<dict>"
+
+    if isinstance(embeddings, np.ndarray):
+        return "<ndarray>"
+
+    return None
+
+
+def _array_to_id_dict(samples, embeddings, patches_field=None):
+    embeddings = np.asarray(embeddings)
+    if embeddings.ndim != 2:
+        raise ValueError(
+            "embeddings array must be 2D; got shape %s" % (embeddings.shape,)
+        )
+
+    sample_ids, label_ids = fbu.get_ids(
+        samples,
+        patches_field=patches_field,
+        data=embeddings,
+        data_type="embeddings",
+    )
+
+    ids = label_ids if patches_field is not None else sample_ids
+    if len(ids) != len(embeddings):
+        raise ValueError(
+            "embeddings array length (%d) does not match the number of "
+            "samples (%d)" % (len(embeddings), len(ids))
+        )
+
+    return {_id: vec for _id, vec in zip(ids, embeddings)}
+
+
+def _expected_input_dim(reducer):
+    n_features = getattr(reducer, "n_features_in_", None)
+    if n_features is not None:
+        return n_features
+
+    raw = getattr(reducer, "_raw_data", None)
+    if raw is not None:
+        return raw.shape[1]
+
+    return None
+
+
+def _strip_umap_training_data(reducer):
+    reducer._raw_data = None
+    if getattr(reducer, "_knn_search_index", None) is not None:
+        idx = reducer._knn_search_index
+        reducer._knn_index_params = {
+            "n_trees": idx.n_trees,
+            "n_iters": idx.n_iters,
+            "max_candidates": idx.max_candidates,
+        }
+        reducer._knn_search_index = None
+
+
+def _hydrate_umap_reducer(reducer, embeddings):
+    reducer._raw_data = embeddings
+
+    if getattr(reducer, "_small_data", True):
+        return
+
+    # Need to reconstruct the index since we are not storing the search index by
+    # in the brain result as this would involve storing the embeddings vectors in
+    # the brain result
+
+    from pynndescent import NNDescent
+    from sklearn.utils import check_random_state
+
+    params = reducer._knn_index_params
+
+    reducer._knn_search_index = NNDescent(
+        embeddings,
+        n_neighbors=reducer._n_neighbors,
+        metric=reducer.metric,
+        metric_kwds=reducer._metric_kwds,
+        random_state=check_random_state(reducer.random_state),
+        n_trees=params["n_trees"],
+        n_iters=params["n_iters"],
+        max_candidates=params["max_candidates"],
+        low_memory=reducer.low_memory,
+        n_jobs=reducer.n_jobs,
+        verbose=reducer.verbose,
+        compressed=False,
+    )
+
+
+def _pickle_reducer(reducer):
+    if reducer is None:
+        return None
+
+    blob = zlib.compress(pickle.dumps(reducer))
+    return base64.b64encode(blob).decode("ascii")
+
+
+def _unpickle_reducer(blob):
+    if blob is None:
+        return None
+
+    try:
+        return pickle.loads(zlib.decompress(base64.b64decode(blob)))
+    except Exception as e:
+        raise RuntimeError(
+            "Failed to deserialize fitted reducer (likely a UMAP/sklearn "
+            "version mismatch); please recompute with compute_visualization()"
+        ) from e

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import os
 from setuptools import setup
 
 
-VERSION = "0.22.0"
+VERSION = "0.23.0"
 
 
 def get_version():

--- a/tests/intensive/test_similarity.py
+++ b/tests/intensive/test_similarity.py
@@ -61,7 +61,7 @@ Mosaic setup::
     # You will also need to create a catalog and schema in your workspace.
     # You will have to create an endpoint under `compute` -> `vector search`
 
-    pip install databricks-vectorsearch
+    pip install databricks-ai-search
 
 PGVector setup::
 

--- a/tests/intensive/test_visualization.py
+++ b/tests/intensive/test_visualization.py
@@ -525,6 +525,744 @@ def _make_patches_dataset(name):
     return dataset
 
 
+def _make_synthetic_dataset(name, n=80, dim=64, seed=7):
+    if fo.dataset_exists(name):
+        fo.delete_dataset(name)
+
+    dataset = fo.Dataset(name)
+    dataset.add_samples(
+        [fo.Sample(filepath="/tmp/%s_%d.jpg" % (name, i)) for i in range(n)]
+    )
+
+    rng = np.random.default_rng(seed)
+    for sample in dataset:
+        sample["emb"] = rng.normal(size=dim).astype("float32")
+        sample.save()
+
+    return dataset, rng
+
+
+def _make_synthetic_patches_dataset(
+    name, n_samples=20, patches_per_sample=3, dim=64, seed=7
+):
+    if fo.dataset_exists(name):
+        fo.delete_dataset(name)
+
+    dataset = fo.Dataset(name)
+    rng = np.random.default_rng(seed)
+
+    samples = []
+    for i in range(n_samples):
+        s = fo.Sample(filepath="/tmp/%s_%d.jpg" % (name, i))
+        detections = [
+            fo.Detection(
+                label="obj",
+                bounding_box=[0.05 + 0.1 * j, 0.1, 0.2, 0.2],
+            )
+            for j in range(patches_per_sample)
+        ]
+        s["ground_truth"] = fo.Detections(detections=detections)
+        samples.append(s)
+
+    dataset.add_samples(samples)
+
+    label_ids = dataset.values("ground_truth.detections.id", unwind=True)
+    embeddings = {
+        lid: rng.normal(size=dim).astype("float32") for lid in label_ids
+    }
+    dataset.set_label_values(
+        "ground_truth.detections.emb", embeddings, dynamic=True
+    )
+
+    return dataset, rng
+
+
+def _add_new_samples(dataset, n, dim, rng, prefix="new", populate_field=True):
+    new_samples = [
+        fo.Sample(filepath="/tmp/%s_%s_%d.jpg" % (dataset.name, prefix, i))
+        for i in range(n)
+    ]
+    dataset.add_samples(new_samples)
+    new_view = dataset.match({"filepath": {"$regex": "_%s_" % prefix}})
+    new_emb = rng.normal(size=(n, dim)).astype("float32")
+    new_ids = new_view.values("id")
+    if populate_field:
+        for sample, emb in zip(new_view, new_emb):
+            sample["emb"] = emb
+            sample.save()
+    return new_view, new_emb, new_ids
+
+
+def test_add_samples_umap_field():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_umap_field")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="umap",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+        verbose=False,
+    )
+
+    initial = results.total_index_size
+    new_view, _, new_ids = _add_new_samples(dataset, 20, 64, rng)
+
+    results.add_samples(new_view, embeddings="emb")
+
+    assert results.total_index_size == initial + 20
+    assert results.points.shape == (initial + 20, 2)
+    assert set(new_ids).issubset(set(results.sample_ids.tolist()))
+
+    reloaded = dataset.load_brain_results("vk")
+    assert reloaded.total_index_size == initial + 20
+
+    dataset.delete()
+
+
+def test_add_samples_umap_array():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_umap_array")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="umap",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+        verbose=False,
+    )
+
+    initial = results.total_index_size
+    new_view, new_emb, new_ids = _add_new_samples(
+        dataset, 15, 64, rng, populate_field=False
+    )
+
+    results.add_samples(new_view, embeddings=new_emb)
+
+    assert results.total_index_size == initial + 15
+    assert set(new_ids).issubset(set(results.sample_ids.tolist()))
+    for sample in new_view:
+        assert sample["emb"] is not None
+
+    dataset.delete()
+
+
+def test_add_samples_pca():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_pca")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    initial = results.total_index_size
+    new_view, _, new_ids = _add_new_samples(dataset, 20, 64, rng)
+    results.add_samples(new_view)
+
+    assert results.total_index_size == initial + 20
+
+    reloaded = dataset.load_brain_results("vk")
+    assert reloaded.total_index_size == initial + 20
+
+    dataset.delete()
+
+
+def test_add_samples_tsne_raises():
+    dataset, _ = _make_synthetic_dataset("test_add_samples_tsne", n=80, dim=64)
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="tsne",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+        verbose=False,
+    )
+
+    try:
+        results.add_samples(dataset)
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "does not support" in str(e)
+
+    dataset.delete()
+
+
+def test_add_samples_manual_raises():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_manual")
+
+    points = rng.normal(size=(len(dataset), 2))
+    results = fob.compute_visualization(dataset, points=points, brain_key="vk")
+
+    try:
+        results.add_samples(dataset)
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "does not support" in str(e)
+
+    dataset.delete()
+
+
+def test_add_samples_umap_no_embeddings_field_raises():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_no_ef")
+
+    embeddings = np.stack(dataset.values("emb"))
+    results = fob.compute_visualization(
+        dataset,
+        embeddings=embeddings,
+        method="umap",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+        verbose=False,
+    )
+
+    _add_new_samples(dataset, 5, 64, rng, populate_field=False)
+
+    # UMAP runs computed without an embeddings_field drop their reducer at
+    # compute time, so incremental updates are unavailable
+    try:
+        results.add_samples(dataset, embeddings=np.zeros((5, 64)))
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "no stored reducer" in str(e)
+
+    dataset.delete()
+
+
+def test_add_samples_legacy_result_raises():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_legacy")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    results._reducer = None
+    results._reducer_blob = None
+
+    new_view, _, _ = _add_new_samples(dataset, 5, 64, rng)
+
+    try:
+        results.add_samples(new_view)
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "before incremental updates" in str(e)
+
+    dataset.delete()
+
+
+def test_add_samples_dim_mismatch_raises():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_dim")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    new_view, _, _ = _add_new_samples(
+        dataset, 5, 64, rng, populate_field=False
+    )
+    bad = np.zeros((5, 32), dtype="float32")
+
+    try:
+        results.add_samples(new_view, embeddings=bad)
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "dimension" in str(e)
+
+    dataset.delete()
+
+
+def test_add_samples_duplicate_overwrite_false():
+    dataset, _ = _make_synthetic_dataset("test_add_samples_dup")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    initial = results.total_index_size
+    results.add_samples(
+        dataset,
+        skip_existing=False,
+        overwrite=False,
+        warn_existing=True,
+    )
+
+    assert results.total_index_size == initial
+
+    dataset.delete()
+
+
+def test_add_samples_skip_existing():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_skip")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    initial = results.total_index_size
+    _add_new_samples(dataset, 15, 64, rng)
+
+    results.add_samples(dataset)
+
+    assert results.total_index_size == initial + 15
+
+    dataset.delete()
+
+
+def test_add_samples_no_new_is_noop():
+    dataset, _ = _make_synthetic_dataset("test_add_samples_noop")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    initial = results.total_index_size
+    results.add_samples(dataset)
+
+    assert results.total_index_size == initial
+
+    dataset.delete()
+
+
+def test_add_samples_other_field_writes_through():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_otherfield")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    initial = results.total_index_size
+    new_view, _, _ = _add_new_samples(
+        dataset, 5, 64, rng, populate_field=False
+    )
+    for sample in new_view:
+        sample["emb_v2"] = rng.normal(size=64).astype("float32")
+        sample.save()
+
+    results.add_samples(new_view, embeddings="emb_v2")
+
+    assert results.total_index_size == initial + 5
+    for sample in new_view:
+        assert sample["emb"] is not None
+
+    dataset.delete()
+
+
+def test_add_samples_dict_writes_through():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_dictwt")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    initial = results.total_index_size
+    new_view, _, new_ids = _add_new_samples(
+        dataset, 5, 64, rng, populate_field=False
+    )
+    emb_dict = {_id: rng.normal(size=64).astype("float32") for _id in new_ids}
+
+    results.add_samples(new_view, embeddings=emb_dict)
+
+    assert results.total_index_size == initial + 5
+    for sample in new_view:
+        assert sample["emb"] is not None
+
+    dataset.delete()
+
+
+def test_add_samples_umap_rehydrate_training_set_only():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_rehydr")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="umap",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+        verbose=False,
+    )
+
+    n_train = results._reducer.embedding_.shape[0]
+
+    _add_new_samples(dataset, 10, 64, rng, prefix="r1")
+    results = dataset.load_brain_results("vk")
+    results.add_samples(dataset)
+
+    _add_new_samples(dataset, 10, 64, rng, prefix="r2")
+    results = dataset.load_brain_results("vk")
+    results.add_samples(dataset)
+
+    assert results._reducer.embedding_.shape[0] == n_train
+    assert results.total_index_size == n_train + 20
+
+    dataset.delete()
+
+
+def test_add_samples_persistence():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_persist")
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    _, _, new_ids = _add_new_samples(dataset, 10, 64, rng)
+    results.add_samples(dataset)
+
+    del results
+
+    reloaded = dataset.load_brain_results("vk")
+    assert reloaded.total_index_size == 90
+    assert set(new_ids).issubset(set(reloaded.sample_ids.tolist()))
+
+    dataset.delete()
+
+
+def test_add_samples_requires_source_when_unset():
+    dataset, rng = _make_synthetic_dataset("test_add_samples_unset")
+
+    embeddings = np.stack(dataset.values("emb"))
+    results = fob.compute_visualization(
+        dataset,
+        embeddings=embeddings,
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    new_view, _, _ = _add_new_samples(
+        dataset, 5, 64, rng, populate_field=False
+    )
+
+    try:
+        results.add_samples(new_view)
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "No embeddings" in str(e)
+
+    dataset.delete()
+
+
+def test_add_samples_field_unpopulated_falls_back_to_config_model():
+    """When the canonical embeddings_field is on the schema but unpopulated
+    for the new samples, add_samples should fall back to config.model."""
+    from unittest import mock
+
+    dataset, rng = _make_synthetic_dataset(
+        "test_add_samples_unpopulated_fallback", n=40, dim=64
+    )
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        model="fake-zoo-model",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+    assert results.config.model == "fake-zoo-model"
+
+    new_samples = [
+        fo.Sample(filepath="/tmp/%s_new_%d.jpg" % (dataset.name, i))
+        for i in range(8)
+    ]
+    dataset.add_samples(new_samples)
+    new_view = dataset.match({"filepath": {"$regex": "_new_"}})
+
+    class _StubModel:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _fake_compute_embeddings(
+        self_view, model, embeddings_field=None, **kwargs
+    ):
+        n = len(self_view)
+        out = rng.normal(size=(n, 64)).astype("float32")
+        if embeddings_field is not None:
+            ids = self_view.values("id")
+            self_view._dataset.set_values(
+                embeddings_field,
+                dict(zip(ids, out)),
+                key_field="id",
+            )
+        return out
+
+    with mock.patch(
+        "fiftyone.zoo.load_zoo_model", return_value=_StubModel()
+    ), mock.patch(
+        "fiftyone.core.collections.SampleCollection.compute_embeddings",
+        autospec=True,
+        side_effect=_fake_compute_embeddings,
+    ):
+        results.add_samples(new_view)
+
+    assert results.total_index_size == 48
+    for sample in new_view:
+        assert sample["emb"] is not None
+
+    dataset.delete()
+
+
+def test_add_samples_reuses_saved_model():
+    """End-to-end check with a real zoo model. Compute UMAP visualization with
+    model='mobilenet-v2-imagenet-torch', add new unpopulated samples, and
+    confirm add_samples computes their embeddings via the saved model and
+    writes them through to the canonical embeddings field."""
+    if fo.dataset_exists("test_add_samples_reuses_saved_model"):
+        fo.delete_dataset("test_add_samples_reuses_saved_model")
+
+    dataset = foz.load_zoo_dataset(
+        "quickstart",
+        max_samples=20,
+        dataset_name="test_add_samples_reuses_saved_model",
+    )
+    model = foz.load_zoo_model("mobilenet-v2-imagenet-torch")
+    dataset.compute_embeddings(model, embeddings_field="emb", batch_size=8)
+
+    results = fob.compute_visualization(
+        dataset,
+        embeddings="emb",
+        model="mobilenet-v2-imagenet-torch",
+        method="umap",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+        verbose=False,
+    )
+    assert results.config.model == "mobilenet-v2-imagenet-torch"
+    initial = results.total_index_size
+
+    new_samples = [
+        fo.Sample(filepath=dataset.first().filepath) for _ in range(5)
+    ]
+    dataset.add_samples(new_samples)
+    new_view = dataset.match({"id": {"$in": [s.id for s in new_samples]}})
+    assert all(s["emb"] is None for s in new_view)
+
+    results.add_samples(dataset)
+
+    assert results.total_index_size == initial + 5
+    for sample in new_view:
+        assert sample["emb"] is not None
+
+    dataset.delete()
+
+
+def test_add_samples_patches_new_samples():
+    """Happy path: visualization over patches, then add new samples each
+    containing several detections. All new patches should be projected."""
+    dataset, rng = _make_synthetic_patches_dataset(
+        "test_add_samples_patches_new", n_samples=20, patches_per_sample=3
+    )
+
+    results = fob.compute_visualization(
+        dataset,
+        patches_field="ground_truth",
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    initial = results.total_index_size
+    assert initial == 20 * 3
+
+    new_samples = []
+    for i in range(5):
+        s = fo.Sample(filepath="/tmp/%s_new_%d.jpg" % (dataset.name, i))
+        detections = []
+        for j in range(3):
+            d = fo.Detection(
+                label="obj",
+                bounding_box=[0.1 * j, 0.1, 0.2, 0.2],
+            )
+            d["emb"] = rng.normal(size=64).astype("float32")
+            detections.append(d)
+        s["ground_truth"] = fo.Detections(detections=detections)
+        new_samples.append(s)
+    dataset.add_samples(new_samples)
+
+    results.add_samples(dataset)
+
+    assert results.total_index_size == initial + 5 * 3
+    new_label_ids = []
+    for s in dataset.match({"filepath": {"$regex": "_new_"}}):
+        new_label_ids.extend([d.id for d in s["ground_truth"].detections])
+    assert set(new_label_ids).issubset(set(results.label_ids.tolist()))
+
+    dataset.delete()
+
+
+def test_add_samples_patches_field_unpopulated_falls_back_to_config_model():
+    """Regression: when new patches in the dataset don't have embeddings
+    populated in `config.embeddings_field`, add_samples should fall back to
+    `config.model` and compute their embeddings via that model."""
+    from unittest import mock
+
+    dataset, rng = _make_synthetic_patches_dataset(
+        "test_add_samples_patches_unpop",
+        n_samples=15,
+        patches_per_sample=3,
+    )
+
+    results = fob.compute_visualization(
+        dataset,
+        patches_field="ground_truth",
+        embeddings="emb",
+        model="fake-zoo-model",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+    assert results.config.model == "fake-zoo-model"
+    initial = results.total_index_size
+    assert initial == 15 * 3
+
+    new_samples = []
+    for i in range(5):
+        s = fo.Sample(filepath="/tmp/%s_new_%d.jpg" % (dataset.name, i))
+        detections = [
+            fo.Detection(
+                label="obj",
+                bounding_box=[0.1 * j, 0.1, 0.2, 0.2],
+            )
+            for j in range(2)
+        ]
+        s["ground_truth"] = fo.Detections(detections=detections)
+        new_samples.append(s)
+    dataset.add_samples(new_samples)
+
+    class _StubModel:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _fake_compute_patch_embeddings(
+        self_view,
+        model,
+        patches_field,
+        embeddings_field=None,
+        **kwargs,
+    ):
+        out = {}
+        for sample in self_view:
+            n = len(sample[patches_field].detections)
+            if n > 0:
+                out[sample.id] = rng.normal(size=(n, 64)).astype("float32")
+        return out
+
+    with mock.patch(
+        "fiftyone.zoo.load_zoo_model", return_value=_StubModel()
+    ), mock.patch(
+        "fiftyone.core.collections.SampleCollection.compute_patch_embeddings",
+        autospec=True,
+        side_effect=_fake_compute_patch_embeddings,
+    ):
+        results.add_samples(dataset)
+
+    assert results.total_index_size == initial + 5 * 2
+
+    dataset.delete()
+
+
+def test_add_samples_patches_new_patches_in_existing_sample():
+    """Regression: adding new detections to an existing sample (same
+    sample_id, new label_ids) should pick up the new patches when
+    skip_existing=True."""
+    dataset, rng = _make_synthetic_patches_dataset(
+        "test_add_samples_patches_existing", n_samples=20, patches_per_sample=3
+    )
+
+    results = fob.compute_visualization(
+        dataset,
+        patches_field="ground_truth",
+        embeddings="emb",
+        method="pca",
+        brain_key="vk",
+        num_dims=2,
+        seed=42,
+    )
+
+    initial = results.total_index_size
+
+    first_sample = dataset.first()
+    new_detections = list(first_sample["ground_truth"].detections)
+    for j in range(2):
+        d = fo.Detection(
+            label="obj",
+            bounding_box=[0.4 + 0.1 * j, 0.4, 0.2, 0.2],
+        )
+        d["emb"] = rng.normal(size=64).astype("float32")
+        new_detections.append(d)
+    first_sample["ground_truth"] = fo.Detections(detections=new_detections)
+    first_sample.save()
+
+    new_label_ids = [d.id for d in new_detections[-2:]]
+
+    results.add_samples(dataset)
+
+    assert results.total_index_size == initial + 2
+    assert set(new_label_ids).issubset(set(results.label_ids.tolist()))
+
+    dataset.delete()
+
+
 if __name__ == "__main__":
     fo.config.show_progress_bars = True
     unittest.main(verbosity=2)

--- a/tests/test_filter_ids.py
+++ b/tests/test_filter_ids.py
@@ -1,0 +1,223 @@
+"""
+fiftyone.brain.internal.core.utils.filter_ids() tests.
+
+These pin the exact output contract — values, ordering, dtypes, and the
+None conventions — so the membership computation can be reimplemented
+(e.g. vectorized) with confidence that behavior is unchanged. All tests
+use small synthetic datasets and manual points; no models, no zoo.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import numpy as np
+import pytest
+
+import fiftyone as fo
+import fiftyone.brain.internal.core.utils as fbu
+
+
+def _make_dataset(n=12):
+    dataset = fo.Dataset()
+    dataset.add_samples(
+        [fo.Sample(filepath="/tmp/img%02d.png" % i) for i in range(n)]
+    )
+    return dataset
+
+
+def _make_patches_dataset(num_samples=4, labels_per_sample=2):
+    dataset = fo.Dataset()
+    samples = []
+    for i in range(num_samples):
+        detections = [
+            fo.Detection(label="d%d" % j, bounding_box=[0.1, 0.1, 0.2, 0.2])
+            for j in range(labels_per_sample)
+        ]
+        samples.append(
+            fo.Sample(
+                filepath="/tmp/img%d.png" % i,
+                ground_truth=fo.Detections(detections=detections),
+            )
+        )
+
+    dataset.add_samples(samples)
+    return dataset
+
+
+def test_identical_collection_early_exits():
+    dataset = _make_dataset()
+    try:
+        ids = dataset.values("id")
+        index_ids = np.array(ids)
+
+        sample_ids, label_ids, keep_inds, good_inds = fbu.filter_ids(
+            dataset, index_ids, None
+        )
+
+        assert list(sample_ids) == ids
+        assert label_ids is None
+        # The early-exit convention: None means "the full index, as is"
+        assert keep_inds is None
+        assert good_inds is None
+    finally:
+        dataset.delete()
+
+
+def test_no_index_returns_collection_ids():
+    dataset = _make_dataset()
+    try:
+        sample_ids, label_ids, keep_inds, good_inds = fbu.filter_ids(
+            dataset, None, None
+        )
+
+        assert list(sample_ids) == dataset.values("id")
+        assert label_ids is None and keep_inds is None and good_inds is None
+    finally:
+        dataset.delete()
+
+
+def test_subset_view_keep_inds_are_index_positions():
+    dataset = _make_dataset()
+    try:
+        index_ids = np.array(dataset.values("id"))
+
+        view = dataset.skip(3).limit(5)
+        sample_ids, _, keep_inds, good_inds = fbu.filter_ids(
+            view, index_ids, None
+        )
+
+        assert list(sample_ids) == view.values("id")
+        assert keep_inds.dtype == np.int64
+        assert list(keep_inds) == [3, 4, 5, 6, 7]
+        assert good_inds is None
+    finally:
+        dataset.delete()
+
+
+def test_keep_inds_follow_collection_order():
+    # keep_inds is a reordering map: index positions listed in the
+    # order the collection iterates, not index order
+    dataset = _make_dataset()
+    try:
+        index_ids = np.array(dataset.values("id"))
+
+        view = dataset.sort_by("filepath", reverse=True)
+        _, _, keep_inds, _ = fbu.filter_ids(view, index_ids, None)
+
+        n = len(index_ids)
+        assert list(keep_inds) == list(range(n - 1, -1, -1))
+    finally:
+        dataset.delete()
+
+
+def test_collection_ids_missing_from_index_are_pruned():
+    # Samples added after compute: present in the collection, absent
+    # from the index -> pruned from the returned ids via good_inds
+    dataset = _make_dataset()
+    try:
+        all_ids = dataset.values("id")
+        index_ids = np.array(all_ids[:8])
+
+        sample_ids, _, keep_inds, good_inds = fbu.filter_ids(
+            dataset, index_ids, None
+        )
+
+        assert list(keep_inds) == list(range(8))
+        assert good_inds.dtype == bool
+        assert list(good_inds) == [True] * 8 + [False] * 4
+        assert list(sample_ids) == all_ids[:8]
+    finally:
+        dataset.delete()
+
+
+def test_index_ids_missing_from_collection_are_dropped():
+    # Samples deleted after compute (or a view): index entries with no
+    # collection counterpart simply do not appear in keep_inds; there
+    # are no bad collection entries, so good_inds stays None
+    dataset = _make_dataset()
+    try:
+        index_ids = np.array(dataset.values("id"))
+
+        view = dataset.skip(4)
+        sample_ids, _, keep_inds, good_inds = fbu.filter_ids(
+            view, index_ids, None
+        )
+
+        assert list(keep_inds) == list(range(4, len(index_ids)))
+        assert good_inds is None
+        assert list(sample_ids) == view.values("id")
+    finally:
+        dataset.delete()
+
+
+def test_allow_missing_false_raises_both_directions():
+    dataset = _make_dataset()
+    try:
+        all_ids = dataset.values("id")
+
+        # Index entries missing from the collection
+        with pytest.raises(ValueError):
+            fbu.filter_ids(
+                dataset.skip(4),
+                np.array(all_ids),
+                None,
+                allow_missing=False,
+            )
+
+        # Collection entries missing from the index
+        with pytest.raises(ValueError):
+            fbu.filter_ids(
+                dataset, np.array(all_ids[:8]), None, allow_missing=False
+            )
+    finally:
+        dataset.delete()
+
+
+def test_patches_field_filters_by_label_ids():
+    dataset = _make_patches_dataset()
+    try:
+        # Wire order: labels flattened in sample order
+        full_sample_ids, full_label_ids = fbu._get_patch_ids(
+            dataset, "ground_truth"
+        )
+        index_label_ids = np.array(full_label_ids)
+
+        view = dataset.filter_labels(
+            "ground_truth", fo.ViewField("label") == "d0"
+        )
+        sample_ids, label_ids, keep_inds, good_inds = fbu.filter_ids(
+            view,
+            np.array(full_sample_ids),
+            index_label_ids,
+            patches_field="ground_truth",
+        )
+
+        # One "d0" label per sample = every even index position
+        assert list(keep_inds) == [0, 2, 4, 6]
+        assert good_inds is None
+        assert list(label_ids) == list(index_label_ids[keep_inds])
+        assert len(sample_ids) == len(label_ids)
+    finally:
+        dataset.delete()
+
+
+def test_patches_view_maps_rows_to_sample_ids():
+    # A to_patches() view hits the _is_patches branch: collection ids
+    # are the (repeating) owning sample ids per patch row
+    dataset = _make_patches_dataset()
+    try:
+        index_sample_ids = np.array(dataset.values("id"))
+
+        patches = dataset.to_patches("ground_truth")
+        sample_ids, _, keep_inds, good_inds = fbu.filter_ids(
+            patches, index_sample_ids, None
+        )
+
+        assert list(sample_ids) == patches.values("sample_id")
+        # Two patches per sample -> each index position appears twice,
+        # in collection (patch-row) order
+        assert list(keep_inds) == [0, 0, 1, 1, 2, 2, 3, 3]
+        assert good_inds is None
+    finally:
+        dataset.delete()

--- a/tests/test_refresh_errors.py
+++ b/tests/test_refresh_errors.py
@@ -1,0 +1,121 @@
+"""
+Refresh error-handling and lazy-training-size tests.
+
+These pin two contracts around the stored reducer:
+
+-   ``get_new_ids(..., include_training_size=False)`` must never load the
+    reducer, so interactive callers can count new samples without paying
+    the unpickle (which imports ``umap`` and can take ~10s cold)
+-   failures while *applying* the reducer (hydration or transform) must
+    raise an actionable recompute error rather than leak internals such as
+    numba's ``AssertionError`` — the failure mode when a reducer pickled
+    under one Python/umap/numba version is used under another, where the
+    unpickle itself succeeds
+
+All tests use small synthetic datasets and stub reducers; no models, no
+zoo, and ``umap`` itself is never imported.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from unittest import mock
+
+import numpy as np
+import pytest
+
+import fiftyone as fo
+import fiftyone.brain.visualization as fbv
+
+
+def _make_umap_run(n=8, n_new=3, dim=4):
+    """A sample-level UMAP-method run over the first ``n`` samples of an
+    ``n + n_new``-sample dataset, built directly (no umap import)."""
+    dataset = fo.Dataset()
+    dataset.add_samples(
+        [fo.Sample(filepath="/tmp/img%02d.png" % i) for i in range(n + n_new)]
+    )
+
+    config = fbv.UMAPVisualizationConfig(embeddings_field="emb")
+    points = np.zeros((n, 2))
+    results = fbv.VisualizationResults(dataset.limit(n), config, "viz", points)
+    return dataset, results
+
+
+class _BoomReducer:
+    """A hydrated-looking reducer whose transform fails the way a
+    cross-environment numba failure does."""
+
+    def __init__(self, n_train=8, dim=4):
+        self._raw_data = np.zeros((n_train, dim))
+        self.embedding_ = np.zeros((n_train, 2))
+
+    def transform(self, X):
+        raise AssertionError("key already in dictionary: 56")
+
+
+def test_get_new_ids_opt_out_never_loads_reducer():
+    dataset, results = _make_umap_run()
+    try:
+        results._reducer_blob = "sentinel-blob"
+        with mock.patch.object(
+            fbv, "_unpickle_reducer", side_effect=AssertionError("loaded!")
+        ) as unpickle:
+            new_ids, train_size = results.get_new_ids(
+                dataset, include_training_size=False
+            )
+
+        assert unpickle.call_count == 0
+        assert results._reducer is None
+        assert train_size is None
+        assert len(new_ids) == 3
+    finally:
+        dataset.delete()
+
+
+def test_get_new_ids_default_behavior_unchanged():
+    dataset, results = _make_umap_run()
+    try:
+        # unreadable blob: the default path must degrade to None, not raise
+        results._reducer_blob = "not-a-real-blob"
+        new_ids, train_size = results.get_new_ids(dataset)
+
+        assert train_size is None
+        assert len(new_ids) == 3
+    finally:
+        dataset.delete()
+
+
+def test_hydration_failure_raises_actionable_error():
+    dataset, results = _make_umap_run()
+    try:
+        reducer = _BoomReducer()
+        reducer._raw_data = None  # not hydrated -> hydration path runs
+        results._reducer = reducer
+
+        with mock.patch.object(
+            fbv,
+            "_hydrate_umap_reducer",
+            side_effect=AssertionError("key already in dictionary: 56"),
+        ), mock.patch.object(
+            results, "_load_training_embeddings", return_value=np.zeros((8, 4))
+        ):
+            with pytest.raises(ValueError, match="different environment"):
+                results._prepare_reducer(dataset)
+    finally:
+        dataset.delete()
+
+
+def test_transform_failure_raises_actionable_error():
+    dataset, results = _make_umap_run()
+    try:
+        results._reducer = _BoomReducer()
+
+        new_view = dataset.skip(8)
+        embeddings = np.random.rand(3, 4)
+
+        with pytest.raises(ValueError, match="different environment"):
+            results.add_samples(new_view, embeddings=embeddings)
+    finally:
+        dataset.delete()

--- a/tests/test_results_serialization.py
+++ b/tests/test_results_serialization.py
@@ -1,0 +1,95 @@
+"""
+Tests for :class:`VisualizationResults` serialization.
+
+Array-valued fields (points and ids) serialize as compressed ``.npy``
+strings; results written by earlier versions stored them as JSON lists.
+Both encodings must load, and the round trip must be lossless.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+import numpy as np
+
+import fiftyone as fo
+import fiftyone.brain as fob
+import fiftyone.zoo as foz
+
+
+def _make_dataset():
+    dataset = foz.load_zoo_dataset("quickstart", max_samples=20).clone()
+    dataset.persistent = False
+    return dataset
+
+
+def _compute(dataset, brain_key, dims=2):
+    points = np.random.RandomState(51).rand(len(dataset), dims)
+    return fob.compute_visualization(
+        dataset, points=points, brain_key=brain_key, verbose=False
+    )
+
+
+class ResultsSerializationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.dataset = _make_dataset()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.dataset.delete()
+
+    def test_round_trip_through_the_database(self):
+        results = _compute(self.dataset, "viz_roundtrip")
+
+        loaded = self.dataset.load_brain_results(
+            "viz_roundtrip", cache=False
+        )
+
+        np.testing.assert_array_equal(loaded.points, results.points)
+        np.testing.assert_array_equal(loaded.sample_ids, results.sample_ids)
+        self.assertIsNone(loaded.label_ids)
+
+    def test_arrays_serialize_as_strings_not_lists(self):
+        results = _compute(self.dataset, "viz_encoding")
+
+        d = results.serialize()
+
+        self.assertIsInstance(d["points"], str)
+        self.assertIsInstance(d["sample_ids"], str)
+        self.assertIsNone(d["label_ids"])
+
+    def test_legacy_list_encoding_still_loads(self):
+        results = _compute(self.dataset, "viz_legacy")
+
+        # Results written by earlier versions stored the arrays as JSON
+        # lists; loading them must remain equivalent forever
+        d = results.serialize()
+        d["points"] = results.points.tolist()
+        d["sample_ids"] = np.asarray(results.sample_ids).tolist()
+        d["label_ids"] = None
+
+        loaded = type(results)._from_dict(
+            d, self.dataset, results.config, "viz_legacy"
+        )
+
+        np.testing.assert_array_equal(loaded.points, results.points)
+        np.testing.assert_array_equal(loaded.sample_ids, results.sample_ids)
+        self.assertIsNone(loaded.label_ids)
+
+    def test_3d_points_round_trip(self):
+        results = _compute(self.dataset, "viz_3d_roundtrip", dims=3)
+
+        loaded = self.dataset.load_brain_results(
+            "viz_3d_roundtrip", cache=False
+        )
+
+        self.assertEqual(loaded.points.shape, (len(self.dataset), 3))
+        np.testing.assert_array_equal(loaded.points, results.points)
+
+
+if __name__ == "__main__":
+    fo.config.show_progress_bars = False
+    unittest.main(verbosity=2)

--- a/tests/test_use_view.py
+++ b/tests/test_use_view.py
@@ -1,0 +1,185 @@
+"""
+VisualizationResults.use_view() tests, focused on the root-dataset fast
+path: loading results against a root dataset must not run the id
+aggregation that view-scoped calls require, and must be behaviorally
+identical to the slow path for pristine datasets.
+
+All tests use synthetic manually-provided points (no models, no zoo
+downloads), so this file is fast and hermetic.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from unittest import mock
+
+import numpy as np
+
+import fiftyone as fo
+import fiftyone.brain as fob
+import fiftyone.brain.internal.core.utils as fbu
+
+
+def _make_samples_run(n=20):
+    dataset = fo.Dataset()
+    dataset.add_samples(
+        [
+            fo.Sample(filepath="/tmp/img%d.png" % i, cluster="c%d" % (i % 3))
+            for i in range(n)
+        ]
+    )
+    points = np.stack(
+        [np.arange(n, dtype=float), -np.arange(n, dtype=float)], axis=1
+    )
+    fob.compute_visualization(dataset, points=points, brain_key="viz")
+    return dataset, n
+
+
+def _make_patches_run(num_samples=4, labels_per_sample=2):
+    dataset = fo.Dataset()
+    samples = []
+    for i in range(num_samples):
+        detections = [
+            fo.Detection(label="d%d" % j, bounding_box=[0.1, 0.1, 0.2, 0.2])
+            for j in range(labels_per_sample)
+        ]
+        samples.append(
+            fo.Sample(
+                filepath="/tmp/img%d.png" % i,
+                ground_truth=fo.Detections(detections=detections),
+            )
+        )
+
+    dataset.add_samples(samples)
+
+    n = num_samples * labels_per_sample
+    points = np.zeros((n, 2))
+    fob.compute_visualization(
+        dataset,
+        points=points,
+        patches_field="ground_truth",
+        brain_key="viz",
+    )
+    return dataset, n
+
+
+def test_load_skips_root_dataset_aggregation():
+    # The optimization itself: loading results against a root dataset
+    # must not aggregate ids (filter_ids runs a full values("id") pull)
+    dataset, n = _make_samples_run()
+    try:
+        with mock.patch.object(
+            fbu, "filter_ids", wraps=fbu.filter_ids
+        ) as filter_ids:
+            results = dataset.load_brain_results("viz", cache=False)
+
+        assert filter_ids.call_count == 0
+        assert results.index_size == n
+        assert results._curr_keep_inds is None
+        assert len(results._curr_sample_ids) == n
+    finally:
+        dataset.delete()
+
+
+def test_root_dataset_matches_slow_path():
+    # For a pristine dataset the fast path must be indistinguishable
+    # from the view-scoped slow path
+    dataset, _ = _make_samples_run()
+    try:
+        results = dataset.load_brain_results("viz", cache=False)
+
+        results.use_view(dataset.view())  # DatasetView: slow path
+        slow = (
+            results._curr_points.copy(),
+            list(results._curr_sample_ids),
+            results._curr_keep_inds,
+            results._curr_good_inds,
+        )
+
+        results.use_view(dataset)  # Dataset: fast path
+        assert np.array_equal(results._curr_points, slow[0])
+        assert list(results._curr_sample_ids) == slow[1]
+        assert results._curr_keep_inds is None and slow[2] is None
+        assert results._curr_good_inds is None and slow[3] is None
+    finally:
+        dataset.delete()
+
+
+def test_views_still_filter():
+    # The fast path must not hijack view-scoped calls
+    dataset, n = _make_samples_run()
+    try:
+        results = dataset.load_brain_results("viz", cache=False)
+
+        view = dataset.take(5, seed=51)
+        results.use_view(view)
+        assert results.index_size == 5
+        assert len(results._curr_keep_inds) == 5
+        assert set(results._curr_sample_ids) == set(view.values("id"))
+
+        results.use_view(dataset)
+        assert results.index_size == n
+    finally:
+        dataset.delete()
+
+
+def test_clear_view_restores_full_index():
+    # clear_view() re-enters use_view with the root dataset, so it rides
+    # the fast path too
+    dataset, n = _make_samples_run()
+    try:
+        results = dataset.load_brain_results("viz", cache=False)
+
+        results.use_view(dataset.take(5, seed=51))
+        assert results.index_size == 5
+
+        results.clear_view()
+        assert results.index_size == n
+        assert results._curr_keep_inds is None
+    finally:
+        dataset.delete()
+
+
+def test_patches_run_fast_path():
+    dataset, n = _make_patches_run()
+    try:
+        with mock.patch.object(
+            fbu, "filter_ids", wraps=fbu.filter_ids
+        ) as filter_ids:
+            results = dataset.load_brain_results("viz", cache=False)
+
+        assert filter_ids.call_count == 0
+        assert results.index_size == n
+        assert len(results._curr_label_ids) == n
+
+        # Label-scoped views still take the slow path and filter
+        view = dataset.filter_labels(
+            "ground_truth", fo.ViewField("label") == "d0"
+        )
+        results.use_view(view)
+        assert results.index_size == n // 2
+    finally:
+        dataset.delete()
+
+
+def test_root_dataset_is_a_snapshot():
+    # Pinned deliberately: the fast path treats the run as a snapshot —
+    # samples deleted since compute are NOT pruned on root-dataset calls
+    # (they never held points for samples ADDED since compute, either).
+    # View-scoped calls still prune, and refreshing the run is the
+    # supported way to sync a visualization with dataset changes
+    dataset, n = _make_samples_run()
+    try:
+        dataset.delete_samples([dataset.first().id])
+
+        results = dataset.load_brain_results("viz", cache=False)
+        assert results.index_size == n  # snapshot retained
+
+        results.use_view(dataset.view())
+        assert results.index_size == n - 1  # slow path prunes
+
+        results.use_view(dataset)
+        assert results.index_size == n
+    finally:
+        dataset.delete()


### PR DESCRIPTION
Release PR for `fiftyone-brain` 0.23.0, per [RELEASING.md](https://github.com/voxel51/fiftyone-brain/blob/develop/RELEASING.md).

## Contents (develop since v0.22.0)

- Incremental embeddings visualization: `add_samples` on visualization results (#289)
- Faster visualization results: binary storage and lighter loads (#295)
- Update databricks ai search package (#294)
- CI: bump actions/checkout to 7 (#292), actions/cache to 6 (#293)

`setup.py` `VERSION` is bumped to `0.23.0` on this branch.

## Publish steps (after merge)

1. Draft a new GitHub release with tag `v0.23.0` targeting `main` (triggers the PyPI build/publish workflow)
2. PR `main` -> `develop` to complete Gitflow

Note: `fiftyone` pins `fiftyone-brain>=0.22.0,<0.23` — a pin bump to `<0.24` will follow on `develop` + `release/v1.20.0` once 0.23.0 is on PyPI.
