### PR TITLE
Bump develop to 0.24.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import os
 from setuptools import setup
 
 
-VERSION = "0.22.0"
+VERSION = "0.24.0"
 
 
 def get_version():


### PR DESCRIPTION
Advances `develop` to the next version now that `release/v0.23.0` is cut (#297).

`setup.py` `VERSION`: `0.22.0` -> `0.24.0`