### PR TITLE
Actionable error for cross-environment reducer failures; opt-out for training size in get_new_ids

### DIFF
--- a/fiftyone/brain/visualization.py
+++ b/fiftyone/brain/visualization.py
@@ -40,6 +40,15 @@ logger = logging.getLogger(__name__)
 _DEFAULT_MODEL = "mobilenet-v2-imagenet-torch"
 _DEFAULT_BATCH_SIZE = None
 
+_REDUCER_APPLY_ERROR = (
+    "Failed to apply this visualization's stored reducer. This typically "
+    "means the run was computed in a different environment (e.g. a "
+    "different Python, umap-learn, or numba version), in which case the "
+    "stored reducer cannot be used here. Please recompute the "
+    "visualization (e.g. via compute_visualization()) to enable "
+    "incremental updates in this environment"
+)
+
 
 def compute_visualization(
     samples,
@@ -1051,7 +1060,12 @@ class VisualizationResults(fob.BrainResults):
                     100 * ratio,
                 )
 
-        new_points = np.asarray(self._reducer.transform(new_emb[ii, :]))
+        try:
+            new_points = np.asarray(self._reducer.transform(new_emb[ii, :]))
+        except Exception as e:
+            # same environment-mismatch failure mode as reducer hydration;
+            # see _prepare_reducer()
+            raise ValueError(_REDUCER_APPLY_ERROR) from e
 
         n = len(self.points)
         m = int(jj.max()) - n + 1
@@ -1152,7 +1166,14 @@ class VisualizationResults(fob.BrainResults):
         if self.config.method == "umap":
             if getattr(self._reducer, "_raw_data", None) is None:
                 training_embeddings = self._load_training_embeddings()
-                _hydrate_umap_reducer(self._reducer, training_embeddings)
+                try:
+                    _hydrate_umap_reducer(self._reducer, training_embeddings)
+                except Exception as e:
+                    # a reducer pickled under a different Python/umap/numba
+                    # unpickles cleanly but fails here, deep in numba (e.g.
+                    # ``AssertionError: key already in dictionary``), so
+                    # translate anything into an actionable error
+                    raise ValueError(_REDUCER_APPLY_ERROR) from e
 
     def _load_training_embeddings(self):
         n_train = self._reducer.embedding_.shape[0]
@@ -1250,7 +1271,7 @@ class VisualizationResults(fob.BrainResults):
         new_ids = [_id for _id in all_ids if _id not in known]
         return new_ids, len(all_ids)
 
-    def get_new_ids(self, samples=None):
+    def get_new_ids(self, samples=None, include_training_size=True):
         """Returns the IDs of the samples/patches in the given collection
         that are not present in this visualization, along with the number of
         embeddings that were used to fit this visualization's reducer.
@@ -1263,23 +1284,37 @@ class VisualizationResults(fob.BrainResults):
         new IDs is large relative to the training size (e.g. > 20%),
         recomputing the visualization will produce a more faithful embedding.
 
+        Computing the training size requires unpickling the stored reducer,
+        which for UMAP imports the ``umap`` package and can take several
+        seconds on the first use in a process. Pass
+        ``include_training_size=False`` to skip that work when only the IDs
+        are needed (e.g. to render a count in an interactive context).
+
         Args:
             samples (None): a
                 :class:`fiftyone.core.collections.SampleCollection` to check.
                 By default, the full collection on which this run was
                 performed is used
+            include_training_size (True): whether to compute the training
+                size, which loads the stored reducer. When ``False``, the
+                training size is returned as ``None``
 
         Returns:
             a tuple of
 
             -   a list of new IDs
             -   the number of embeddings used to fit the reducer, or ``None``
-                if no reducer is available for this run
+                if it was not computed or no reducer is available for this
+                run
         """
         if samples is None:
             samples = self._samples
 
         new_ids, _ = self._diff_ids(samples)
+
+        if not include_training_size:
+            return new_ids, None
+
         return new_ids, self._training_size()
 
     def needs_update(self, samples=None):

--- a/tests/test_refresh_errors.py
+++ b/tests/test_refresh_errors.py
@@ -1,0 +1,121 @@
+"""
+Refresh error-handling and lazy-training-size tests.
+
+These pin two contracts around the stored reducer:
+
+-   ``get_new_ids(..., include_training_size=False)`` must never load the
+    reducer, so interactive callers can count new samples without paying
+    the unpickle (which imports ``umap`` and can take ~10s cold)
+-   failures while *applying* the reducer (hydration or transform) must
+    raise an actionable recompute error rather than leak internals such as
+    numba's ``AssertionError`` — the failure mode when a reducer pickled
+    under one Python/umap/numba version is used under another, where the
+    unpickle itself succeeds
+
+All tests use small synthetic datasets and stub reducers; no models, no
+zoo, and ``umap`` itself is never imported.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from unittest import mock
+
+import numpy as np
+import pytest
+
+import fiftyone as fo
+import fiftyone.brain.visualization as fbv
+
+
+def _make_umap_run(n=8, n_new=3, dim=4):
+    """A sample-level UMAP-method run over the first ``n`` samples of an
+    ``n + n_new``-sample dataset, built directly (no umap import)."""
+    dataset = fo.Dataset()
+    dataset.add_samples(
+        [fo.Sample(filepath="/tmp/img%02d.png" % i) for i in range(n + n_new)]
+    )
+
+    config = fbv.UMAPVisualizationConfig(embeddings_field="emb")
+    points = np.zeros((n, 2))
+    results = fbv.VisualizationResults(dataset.limit(n), config, "viz", points)
+    return dataset, results
+
+
+class _BoomReducer:
+    """A hydrated-looking reducer whose transform fails the way a
+    cross-environment numba failure does."""
+
+    def __init__(self, n_train=8, dim=4):
+        self._raw_data = np.zeros((n_train, dim))
+        self.embedding_ = np.zeros((n_train, 2))
+
+    def transform(self, X):
+        raise AssertionError("key already in dictionary: 56")
+
+
+def test_get_new_ids_opt_out_never_loads_reducer():
+    dataset, results = _make_umap_run()
+    try:
+        results._reducer_blob = "sentinel-blob"
+        with mock.patch.object(
+            fbv, "_unpickle_reducer", side_effect=AssertionError("loaded!")
+        ) as unpickle:
+            new_ids, train_size = results.get_new_ids(
+                dataset, include_training_size=False
+            )
+
+        assert unpickle.call_count == 0
+        assert results._reducer is None
+        assert train_size is None
+        assert len(new_ids) == 3
+    finally:
+        dataset.delete()
+
+
+def test_get_new_ids_default_behavior_unchanged():
+    dataset, results = _make_umap_run()
+    try:
+        # unreadable blob: the default path must degrade to None, not raise
+        results._reducer_blob = "not-a-real-blob"
+        new_ids, train_size = results.get_new_ids(dataset)
+
+        assert train_size is None
+        assert len(new_ids) == 3
+    finally:
+        dataset.delete()
+
+
+def test_hydration_failure_raises_actionable_error():
+    dataset, results = _make_umap_run()
+    try:
+        reducer = _BoomReducer()
+        reducer._raw_data = None  # not hydrated -> hydration path runs
+        results._reducer = reducer
+
+        with mock.patch.object(
+            fbv,
+            "_hydrate_umap_reducer",
+            side_effect=AssertionError("key already in dictionary: 56"),
+        ), mock.patch.object(
+            results, "_load_training_embeddings", return_value=np.zeros((8, 4))
+        ):
+            with pytest.raises(ValueError, match="different environment"):
+                results._prepare_reducer(dataset)
+    finally:
+        dataset.delete()
+
+
+def test_transform_failure_raises_actionable_error():
+    dataset, results = _make_umap_run()
+    try:
+        results._reducer = _BoomReducer()
+
+        new_view = dataset.skip(8)
+        embeddings = np.random.rand(3, 4)
+
+        with pytest.raises(ValueError, match="different environment"):
+            results.add_samples(new_view, embeddings=embeddings)
+    finally:
+        dataset.delete()


### PR DESCRIPTION
# Rationale

Two follow-ups from the incremental refresh work in #289, both driven by the App integration (voxel51/fiftyone-teams#3425):

1. A reducer pickled under a different Python/umap/numba version unpickles cleanly but fails deep inside numba when hydrated or applied (`AssertionError: key already in dictionary: 56`), leaving users with no path forward. Root cause and repro are in [this #289 comment](https://github.com/voxel51/fiftyone-brain/pull/289#issuecomment-5073532401).
2. `get_new_ids()` unconditionally computes the training size, which unpickles the stored reducer — for UMAP that imports `umap` (~10s cold, ~200MB resident) even for callers that only need the ids. This is what froze the App's refresh form for ~10s on every cold worker.

## Changes

- Both reducer failure sites (hydration in `_prepare_reducer()` and `transform()` in `add_samples()`) now raise a recompute-required `ValueError` phrased for both UI and SDK audiences, with the original exception chained for debugging
- `get_new_ids(..., include_training_size=False)` skips the training-size computation entirely and returns `None` for it. Additive; default behavior unchanged

## Testing

- 4 new tests in `tests/test_refresh_errors.py`: the opt-out never touches the reducer, the default path still degrades gracefully on an unreadable blob, and both failure sites raise the actionable error (the transform case through the real `add_samples()` pipeline). All stub-based — no models, no zoo, `umap` never imported
- Existing lightweight suites pass unchanged

## Notes

⚠️ **Release coordination**: the App's refresh form (voxel51/fiftyone-teams#3425) now calls `get_new_ids(include_training_size=False)`, so this PR should ship in the same release as #289 — note that `release/v0.23.0` currently contains neither. If this misses the cut the form degrades gracefully (the new-sample count is omitted), but the modal-delay fix doesn't ship.
