### PR TITLE
chore: prep for trunk-based development

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,11 @@ name: Build
 on:
   pull_request:
     branches:
-      - develop
+      - main
     types: [opened, synchronize]
   push:
     branches:
-      - develop
+      - main
     tags:
       - v*
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ fobh.compute_hardness(...)
 ```
 
 To achieve this, follow the existing pattern of declaring new public methods in
-[`fiftyone/brain/__init__.py`](https://github.com/voxel51/fiftyone-brain/blob/develop/fiftyone/brain/__init__.py).
+[`fiftyone/brain/__init__.py`](https://github.com/voxel51/fiftyone-brain/blob/main/fiftyone/brain/__init__.py).
 
 Be sure to include a detailed docstring for all methods in this file, as they
 are pulled in by FiftyOne documentation builds and are made available in the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,41 +3,47 @@
 > [!NOTE]
 > These steps are to be performed by authorized Voxel51 engineers.
 
-The `fiftyone-brain` repository follows `Gitflow`.
-Releases will be initiated when a teammate submits a 
-pull request from their respective `release/v*` branch to `main`.
-We can see an example PR for
-[version 0.21.4](https://github.com/voxel51/fiftyone-brain/pull/265). 
-Reviewers should always check that the version in the `setup.py`
-matches the branch version.
+`main` is the trunk: every PR merges to `main`, and nothing originates on a
+release branch. Between releases, `VERSION` in `setup.py` is the next planned
+version. Reviewers of version-bump PRs should always check that the version
+matches the tag being cut.
 
-The release engineer will merge the pull request once it is approved.
+## Minor / major release (vX.Y.0)
 
-The PyPI uploads will be triggered when a release tag is pushed to the
-repository:
+1. Confirm `VERSION` in `setup.py` on `main` is `X.Y.0`.
 
 1. Navigate to the
-   [releases page](https://github.com/voxel51/fiftyone-brain/pull/265).
+   [releases page](https://github.com/voxel51/fiftyone-brain/releases) and
+   select `Draft a new release`.
 
-1. Select `Draft a new release`.
+1. Select `Create new tag` with tag `vX.Y.0` and set the target to `main`.
 
-1. Select `Create new tag` with the appropriate version and set the target to
-   `main`.
+1. Select `Generate release notes`, then `Set as the latest release`, then
+   `Publish release`.
 
-    1. The tag format is `v<semantic-version>`.
-       For example, `v0.21.4`. 
-       This should match the `setup.py` and release branch.
+   Pushing the tag triggers the
+   [build workflow](https://github.com/voxel51/fiftyone-brain/blob/main/.github/workflows/build.yml),
+   which builds the `.whl` artifacts and publishes them to
+   [PyPI](https://pypi.org/project/fiftyone-brain/).
 
-1. Select `Generate release notes`.
+1. Open a version-bump PR to `main` advancing `VERSION` to the next planned
+   version.
 
-1. Select `Set as the latest release`.
+## Patch release (vX.Y.Z)
 
-1. Select `Publish release`.
+1. Cut `release/vX.Y.Z` from the `vX.Y.Z-1` tag.
 
-This will create a new tag in the repository and will trigger the
-[build/publish workflow](https://github.com/voxel51/fiftyone-brain/actions/workflows/build.yml).
-This workflow will build the `.whl` artifacts and publish them to
-[PyPI](https://pypi.org/project/fiftyone-brain/).
+1. Land the fixes on `main` first, then `git cherry-pick -x` them to the
+   release branch via PR. A release branch accepts only cherry-picks of
+   `main` commits and its version bump — no back-merges in either direction.
 
-Once the build are finished, submit a PR from `main` to `develop` to complete
-the `Gitflow` process.
+1. Open a PR to the release branch bumping `VERSION` to `X.Y.Z`.
+
+1. Draft the GitHub release with tag `vX.Y.Z` targeting `release/vX.Y.Z`,
+   following the steps above.
+
+## Release candidates
+
+Tag `vX.Y.Z-rc.N` on the branch being released. The build workflow builds
+the rc version via the `RELEASE_VERSION` environment variable and validates
+it against `setup.py`.


### PR DESCRIPTION
# Rationale

File-content half of the git flow → trunk-based conversion, following voxel51/eta#728. eta was the pilot; fiftyone-brain is next. **Merges as step 2 of the cutover below.**

## Changes

- `RELEASING.md` rewritten for the trunk model: `main` is the trunk; minor/major releases tag `main` directly; patches cut `release/vX.Y.Z` from the prior tag and take only gated cherry-picks of `main` commits; no back-merges
- `build.yml` CI triggers move from `develop` to `main`
- `voxel51/fiftyone-brain/blob/develop` URL in CONTRIBUTING.md → `main`

`.github/renovate.json` (from #305) already targets `main`, and dependabot follows the default branch automatically.

## Cutover checklist

1. [x] Merge #305 into `develop`
2. [x] Merge this PR into `develop`
3. [x] Open + merge the `develop` → `main` merge PR
4. [x] Flip the default branch to `main`; move branch protection from `develop` to `main`
5. [x] Delete `develop`

## Testing

Workflow YAML validated; content changes are docs and CI triggers only.

## Related

- voxel51/eta#728
