### PR TITLE
Add Python 3.13 and 3.14 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,8 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
+          - "3.14"
     steps:
       - name: Clone fiftyone-brain
         uses: actions/checkout@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           fetch-depth: 1
           path: eta
-          ref: develop
+          ref: main
           repository: voxel51/eta
       # ETA tests will create a storage client which, 
       # in it's __init__, tries to log in to GCP.

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
     scripts=[],
     python_requires=">=3.10",


### PR DESCRIPTION
Extends the CI test matrix from 3.10–3.12 to 3.10–3.14 and declares the corresponding classifiers.

Notes:
- No tensorflow in the test deps, so no cp314 wheel gaps; `torch`/`torchvision` ship cp314 wheels.
- The 3.14 leg exercises `fiftyone` develop, which is gaining 3.14 support in voxel51/fiftyone#8212 — if that leg is red here, it likely needs that PR to merge first.
- Verified locally on Python 3.14.5: full install resolves and `fiftyone.brain` imports cleanly.