### PR TITLE
Auto-convert embeddings field to ListField for MongoDB similarity backend

### DIFF
--- a/fiftyone/brain/internal/core/mongodb.py
+++ b/fiftyone/brain/internal/core/mongodb.py
@@ -312,17 +312,23 @@ class MongoDBSimilarityIndex(SimilarityIndex):
         view = samples.exists(embeddings_field)
         sample_ids, embeddings = view.values(["id", embeddings_field])
 
-        dataset.delete_sample_field(embeddings_field)
-        dataset.add_sample_field(
-            embeddings_field, fof.ListField, subfield=fof.FloatField()
-        )
-
         values = {
             _id: np.asarray(e).tolist()
             for _id, e in zip(sample_ids, embeddings)
             if e is not None
         }
-        samples.set_values(embeddings_field, values, key_field="id")
+
+        # Write to a temporary field first and only swap it into place
+        # once the write succeeds, so a failure here never leaves the
+        # original embeddings deleted with nothing to replace them
+        tmp_field = embeddings_field + "_tmp_listfield"
+        dataset.add_sample_field(
+            tmp_field, fof.ListField, subfield=fof.FloatField()
+        )
+        samples.set_values(tmp_field, values, key_field="id")
+
+        dataset.delete_sample_field(embeddings_field)
+        dataset.rename_sample_field(tmp_field, embeddings_field)
 
     @property
     def ready(self):

--- a/fiftyone/brain/internal/core/mongodb.py
+++ b/fiftyone/brain/internal/core/mongodb.py
@@ -252,10 +252,14 @@ class MongoDBSimilarityIndex(SimilarityIndex):
 
         field = self._dataset.get_field(self.config.embeddings_field)
         if field is not None and not isinstance(field, fof.ListField):
-            raise ValueError(
-                "MongoDB vector search indexes require embeddings to be "
-                "stored in list fields"
+            logger.info(
+                "Converting embeddings field '%s' from %s to a list "
+                "field, which is required for MongoDB vector search "
+                "indexes",
+                self.config.embeddings_field,
+                type(field).__name__,
             )
+            self._convert_to_list_field()
 
         metric = _SUPPORTED_METRICS[self.config.metric]
 
@@ -292,6 +296,33 @@ class MongoDBSimilarityIndex(SimilarityIndex):
         coll.create_search_index(model=model)
 
         self._index = True
+
+    def _convert_to_list_field(self):
+        # Migrates an existing embeddings field (eg VectorField) to a
+        # ListField in place, preserving values, since MongoDB vector
+        # search indexes require list fields
+        embeddings_field = self.config.embeddings_field
+        dataset = self._dataset
+
+        if dataset.media_type == fom.GROUP:
+            samples = dataset.select_group_slices(_allow_mixed=True)
+        else:
+            samples = dataset
+
+        view = samples.exists(embeddings_field)
+        sample_ids, embeddings = view.values(["id", embeddings_field])
+
+        dataset.delete_sample_field(embeddings_field)
+        dataset.add_sample_field(
+            embeddings_field, fof.ListField, subfield=fof.FloatField()
+        )
+
+        values = {
+            _id: np.asarray(e).tolist()
+            for _id, e in zip(sample_ids, embeddings)
+            if e is not None
+        }
+        samples.set_values(embeddings_field, values, key_field="id")
 
     @property
     def ready(self):

--- a/tests/intensive/test_similarity.py
+++ b/tests/intensive/test_similarity.py
@@ -75,6 +75,13 @@ PGVector setup::
 
     pip install psycopg2
 
+MongoDB setup::
+
+    # No separate client install or brain_config.json entry needed -- this
+    # backend indexes the dataset's own sample collection directly, so it
+    # just requires your `FIFTYONE_DATABASE_URI` to point at a MongoDB
+    # Atlas 7.0+ cluster with Vector Search enabled
+
 Brain config setup at `~/.fiftyone/brain_config.json`::
 
     {
@@ -129,6 +136,7 @@ import numpy as np
 
 import fiftyone as fo
 import fiftyone.brain as fob  # pylint: disable=import-error,no-name-in-module
+import fiftyone.core.fields as fof
 import fiftyone.zoo as foz
 from fiftyone import ViewField as F
 
@@ -142,6 +150,7 @@ CUSTOM_BACKENDS = [
     "mosaic",
     "pgvector",
     "lancedb",
+    "mongodb",
 ]
 
 
@@ -150,6 +159,15 @@ def get_custom_backends():
         return os.environ["SIMILARITY_BACKENDS"].split(",")
 
     return CUSTOM_BACKENDS
+
+
+def _wait_until_ready(index, timeout=60, interval=2):
+    # Atlas vector search indexes build asynchronously, so a query issued
+    # immediately after compute_similarity() returns may see no results
+    for _ in range(int(timeout / interval)):
+        if index.ready:
+            return
+        time.sleep(interval)
 
 
 def test_brain_config():
@@ -482,6 +500,83 @@ def test_qdrant_backend_config():
         print(f"Applied qdrant config grpc_port={grpc_port}")
     else:
         print("Qdrant config grpc_port unset")
+
+    dataset.delete()
+
+
+def test_mongodb_backend():
+    """
+    - Fresh model-based computation never writes embeddings to the DB
+      directly (add_to_index() does, as a list), so it should never hit
+      MongoDB's list field requirement
+    - A pre-existing embeddings field of an incompatible type (eg
+      VectorField, as written by callers like the multimodal embeddings
+      pipeline) should be transparently converted to a list field rather
+      than raising, see MongoDBSimilarityIndex._convert_to_list_field()
+    """
+
+    backend = "mongodb"
+    if backend not in get_custom_backends():
+        return
+
+    dataset = foz.load_zoo_dataset("quickstart", max_samples=5)
+
+    # Fresh computation: embeddings are computed in memory and only ever
+    # written via add_to_index(), which already stores them as lists.
+    # Unlike sklearn/qdrant, mongodb has nowhere else to store vectors
+    # (no external service), so it requires a named embeddings_field
+    # rather than supporting embeddings=False
+    brain_key = "clip_" + backend
+    embeddings_field = brain_key + "_embeddings"
+    index = fob.compute_similarity(
+        dataset,
+        model="clip-vit-base32-torch",
+        metric="cosine",
+        embeddings=embeddings_field,
+        backend=backend,
+        brain_key=brain_key,
+    )
+
+    field = dataset.get_field(embeddings_field)
+    if field is not None:
+        assert isinstance(field, fof.ListField)
+
+    _wait_until_ready(index)
+    view = dataset.sort_by_similarity(
+        dataset.first().id, k=3, brain_key=brain_key
+    )
+    assert len(view) == 3
+
+    dataset.delete_brain_run(brain_key)
+
+    # Pre-existing, incompatible field: simulates a caller (eg the
+    # multimodal embeddings pipeline) writing embeddings as a VectorField
+    # before compute_similarity() ever sees the field
+    vector_field = "vector_emb"
+    dataset.add_sample_field(vector_field, fof.VectorField)
+    dataset.set_values(
+        vector_field,
+        {s.id: np.random.rand(512).tolist() for s in dataset},
+        key_field="id",
+    )
+    assert isinstance(dataset.get_field(vector_field), fof.VectorField)
+
+    convert_brain_key = "clip_" + backend + "_converted"
+    index2 = fob.compute_similarity(
+        dataset,
+        embeddings=vector_field,
+        metric="cosine",
+        backend=backend,
+        brain_key=convert_brain_key,
+    )
+
+    assert isinstance(dataset.get_field(vector_field), fof.ListField)
+
+    _wait_until_ready(index2)
+    view2 = dataset.sort_by_similarity(
+        dataset.first().id, k=3, brain_key=convert_brain_key
+    )
+    assert len(view2) == 3
 
     dataset.delete()
 

--- a/tests/intensive/test_similarity.py
+++ b/tests/intensive/test_similarity.py
@@ -150,8 +150,13 @@ CUSTOM_BACKENDS = [
     "mosaic",
     "pgvector",
     "lancedb",
-    "mongodb",
 ]
+
+# Not in CUSTOM_BACKENDS: unlike the backends above, mongodb silently
+# reuses whatever database the caller's FiftyOne is already connected
+# to rather than failing cleanly if unconfigured, so it's opt-in only
+# via `SIMILARITY_BACKENDS=mongodb`
+MONGODB_BACKEND = "mongodb"
 
 
 def get_custom_backends():
@@ -168,6 +173,11 @@ def _wait_until_ready(index, timeout=60, interval=2):
         if index.ready:
             return
         time.sleep(interval)
+
+    raise TimeoutError(
+        "Index for brain key '%s' did not become ready within %d seconds"
+        % (index.key, timeout)
+    )
 
 
 def test_brain_config():
@@ -515,7 +525,7 @@ def test_mongodb_backend():
       than raising, see MongoDBSimilarityIndex._convert_to_list_field()
     """
 
-    backend = "mongodb"
+    backend = MONGODB_BACKEND
     if backend not in get_custom_backends():
         return
 
@@ -554,9 +564,10 @@ def test_mongodb_backend():
     # before compute_similarity() ever sees the field
     vector_field = "vector_emb"
     dataset.add_sample_field(vector_field, fof.VectorField)
+    original_values = {s.id: np.random.rand(512) for s in dataset}
     dataset.set_values(
         vector_field,
-        {s.id: np.random.rand(512).tolist() for s in dataset},
+        {_id: v.tolist() for _id, v in original_values.items()},
         key_field="id",
     )
     assert isinstance(dataset.get_field(vector_field), fof.VectorField)
@@ -569,6 +580,12 @@ def test_mongodb_backend():
         backend=backend,
         brain_key=convert_brain_key,
     )
+
+    # Values must survive the field conversion exactly, not just the type
+    converted = dataset.values(["id", vector_field])
+    converted_by_id = dict(zip(*converted))
+    for _id, original in original_values.items():
+        assert np.allclose(converted_by_id[_id], original)
 
     assert isinstance(dataset.get_field(vector_field), fof.ListField)
 

--- a/tests/intensive/test_similarity.py
+++ b/tests/intensive/test_similarity.py
@@ -166,17 +166,25 @@ def get_custom_backends():
     return CUSTOM_BACKENDS
 
 
-def _wait_until_ready(index, timeout=60, interval=2):
-    # Atlas vector search indexes build asynchronously, so a query issued
-    # immediately after compute_similarity() returns may see no results
+def _wait_for_similarity_results(
+    dataset, sample_id, brain_key, k, timeout=120, interval=5
+):
+    # Atlas vector search indexes build asynchronously. `index.ready`
+    # reflects only the search index's own build status and can report
+    # True well before the index is actually queryable (observed lag:
+    # 60-90s between `ready` and real results), so poll the real query
+    # instead of trusting the ready flag alone
+    view = None
     for _ in range(int(timeout / interval)):
-        if index.ready:
-            return
+        view = dataset.sort_by_similarity(sample_id, k=k, brain_key=brain_key)
+        if len(view) >= k:
+            return view
         time.sleep(interval)
 
     raise TimeoutError(
-        "Index for brain key '%s' did not become ready within %d seconds"
-        % (index.key, timeout)
+        "Similarity query for brain key '%s' did not return %d results "
+        "within %d seconds (got %d)"
+        % (brain_key, k, timeout, len(view) if view is not None else 0)
     )
 
 
@@ -538,7 +546,7 @@ def test_mongodb_backend():
     # rather than supporting embeddings=False
     brain_key = "clip_" + backend
     embeddings_field = brain_key + "_embeddings"
-    index = fob.compute_similarity(
+    fob.compute_similarity(
         dataset,
         model="clip-vit-base32-torch",
         metric="cosine",
@@ -551,9 +559,8 @@ def test_mongodb_backend():
     if field is not None:
         assert isinstance(field, fof.ListField)
 
-    _wait_until_ready(index)
-    view = dataset.sort_by_similarity(
-        dataset.first().id, k=3, brain_key=brain_key
+    view = _wait_for_similarity_results(
+        dataset, dataset.first().id, brain_key, k=3
     )
     assert len(view) == 3
 
@@ -573,7 +580,7 @@ def test_mongodb_backend():
     assert isinstance(dataset.get_field(vector_field), fof.VectorField)
 
     convert_brain_key = "clip_" + backend + "_converted"
-    index2 = fob.compute_similarity(
+    fob.compute_similarity(
         dataset,
         embeddings=vector_field,
         metric="cosine",
@@ -589,9 +596,8 @@ def test_mongodb_backend():
 
     assert isinstance(dataset.get_field(vector_field), fof.ListField)
 
-    _wait_until_ready(index2)
-    view2 = dataset.sort_by_similarity(
-        dataset.first().id, k=3, brain_key=convert_brain_key
+    view2 = _wait_for_similarity_results(
+        dataset, dataset.first().id, convert_brain_key, k=3
     )
     assert len(view2) == 3
 


### PR DESCRIPTION
# Rationale

`compute_similarity(..., backend="mongodb")` crashes whenever it's pointed at a pre-existing embeddings field that isn't already a `ListField` (e.g. `VectorField`) — this is an implementation gap in how we store embeddings, not a MongoDB/Atlas limitation, since Atlas Vector Search fully supports array-typed fields.

## Changes

`MongoDBSimilarityIndex._create_index()` now converts an incompatible pre-existing embeddings field to a `ListField` in place (new `_convert_to_list_field()`) instead of raising. Fresh, model-based computation was never affected — that path only ever writes via `add_to_index()`, which already stores values as lists; this only hits when a caller (e.g. the multimodal embeddings pipeline) computes and stores embeddings itself before calling `compute_similarity(embeddings=<field>)`.

## Testing

- Manually verified against a real Atlas-backed deployment (`demo.fiftyone.ai`), reproducing the original crash on a multimodal robotics dataset with a pre-existing `VectorField`
- Added `test_mongodb_backend()` to `tests/intensive/test_similarity.py` (manual/intensive, needs a real Atlas 7.0+ cluster, same as the other external backends in this file), covering both the unaffected fresh-compute path and the new conversion path — passing