### PR TITLE
Updating pgvector backend to support IVFFlat indexes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           fetch-depth: 1
           path: fiftyone-src
-          ref: develop
+          ref: main
           repository: voxel51/fiftyone
       - name: Clone voxel51-eta
         uses: actions/checkout@v7
@@ -102,7 +102,7 @@ jobs:
           path: eta
           ref: main
           repository: voxel51/eta
-      # ETA tests will create a storage client which, 
+      # ETA tests will create a storage client which,
       # in it's __init__, tries to log in to GCP.
       # See tests/tests_uniqueness.py
       - name: Authenticate to Google Cloud

--- a/fiftyone/brain/internal/core/pgvector.py
+++ b/fiftyone/brain/internal/core/pgvector.py
@@ -40,6 +40,25 @@ _SUPPORTED_INDEX_TYPES = ("hnsw", "ivfflat")
 # Metrics supported by pgvector's ivfflat access method
 _IVFFLAT_SUPPORTED_METRICS = ("cosine", "dotproduct", "euclidean")
 
+# Supported vector column types for pgvector
+_SUPPORTED_VECTOR_TYPES = ("vector", "halfvec")
+
+# Metrics supported on halfvec columns (no jaccard/hamming opclasses)
+_HALFVEC_SUPPORTED_METRICS = ("cosine", "dotproduct", "euclidean", "l1")
+
+# Operator classes for halfvec columns (l1 is HNSW-only, enforced by the
+# ivfflat metric check)
+_HALFVEC_OPCLASSES = {
+    "cosine": "halfvec_cosine_ops",
+    "dotproduct": "halfvec_ip_ops",
+    "euclidean": "halfvec_l2_ops",
+    "l1": "halfvec_l1_ops",
+}
+
+# Maximum indexable dimensions per column type (applies to both hnsw and
+# ivfflat indexes)
+_MAX_INDEXABLE_DIMS = {"vector": 2000, "halfvec": 4000}
+
 # Query operators for each metric; "%" is doubled because these are
 # interpolated into parameterized psycopg2 queries
 _METRIC_OPERATORS = {
@@ -69,6 +88,17 @@ class PgVectorSimilarityConfig(SimilarityConfig):
             authority (CA) certificate(s).
         work_mem ("64MB"): the base maximum amount of memory to be used by a query operation
             (such as a sort or hash table) before writing to temporary disk files
+        maintenance_work_mem (None): an optional maximum amount of memory to
+            be used by index builds. If not provided, the server default
+            (typically 64MB) is used. Increase this for high-dimensional
+            embeddings or IVFFlat indexes with many lists
+        vector_type ("vector"): the pgvector column type to use for storing
+            embeddings. Supported values are ``("vector", "halfvec")``.
+            ``"halfvec"`` stores half-precision (float16) vectors and
+            supports indexes with up to 4000 dimensions, versus 2000 for
+            ``"vector"``, and requires pgvector >= 0.7.0. Note that halfvec
+            columns only support the
+            ``("cosine", "dotproduct", "euclidean", "l1")`` metrics
         index_type ("hnsw"): the type of index to use. Supported values are
             ``("hnsw", "ivfflat")``. Note that IVFFlat indexes only support
             the ``("cosine", "dotproduct", "euclidean")`` metrics
@@ -94,6 +124,8 @@ class PgVectorSimilarityConfig(SimilarityConfig):
         ssl_key=None,
         ssl_root_cert=None,
         work_mem="64MB",
+        maintenance_work_mem=None,
+        vector_type="vector",
         index_type="hnsw",
         hnsw_m=16,
         hnsw_ef_construction=64,
@@ -123,6 +155,21 @@ class PgVectorSimilarityConfig(SimilarityConfig):
                 f"Supported values are {_IVFFLAT_SUPPORTED_METRICS}"
             )
 
+        if vector_type not in _SUPPORTED_VECTOR_TYPES:
+            raise ValueError(
+                f"Unsupported vector_type '{vector_type}'. "
+                f"Supported values are {_SUPPORTED_VECTOR_TYPES}"
+            )
+
+        if (
+            vector_type == "halfvec"
+            and metric not in _HALFVEC_SUPPORTED_METRICS
+        ):
+            raise ValueError(
+                f"Metric '{metric}' is not supported by halfvec columns. "
+                f"Supported values are {_HALFVEC_SUPPORTED_METRICS}"
+            )
+
         super().__init__(**kwargs)
 
         self.metric = metric
@@ -130,8 +177,10 @@ class PgVectorSimilarityConfig(SimilarityConfig):
         self.ssl_key = ssl_key
         self.ssl_root_cert = ssl_root_cert
         self.work_mem = work_mem
+        self.maintenance_work_mem = maintenance_work_mem
         self.index_name = index_name
         self.table_name = table_name
+        self.vector_type = vector_type
         self.index_type = index_type
         self.hnsw_m = hnsw_m
         self.hnsw_ef_construction = hnsw_ef_construction
@@ -250,6 +299,18 @@ class PgVectorSimilarityIndex(SimilarityIndex):
                 )
                 raise
 
+        if self.config.vector_type == "halfvec":
+            self._cur.execute(
+                "SELECT 1 FROM pg_type WHERE typname = 'halfvec'"
+            )
+            if self._cur.fetchone() is None:
+                raise ValueError(
+                    "vector_type='halfvec' requires pgvector >= 0.7.0, but "
+                    "the 'halfvec' type was not found in the database. "
+                    "Upgrade the pgvector extension and run "
+                    "'ALTER EXTENSION vector UPDATE'"
+                )
+
         if self.config.table_name is None:
             table_names = self._get_table_names()
             root = "fiftyone-" + fou.to_slug(self.samples._root_dataset.name)
@@ -288,7 +349,7 @@ class PgVectorSimilarityIndex(SimilarityIndex):
                     CREATE TABLE IF NOT EXISTS "{self.config.table_name}" (
                     id TEXT PRIMARY KEY,
                     sample_id TEXT,
-                    embedding_vector VECTOR({dimension})
+                    embedding_vector {self.config.vector_type.upper()}({dimension})
                 );
                 """
             )
@@ -300,7 +361,11 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             raise
 
     def create_index(self):
-        operator_class = _SUPPORTED_METRICS[self.config.metric]
+        if self.config.vector_type == "halfvec":
+            operator_class = _HALFVEC_OPCLASSES[self.config.metric]
+        else:
+            operator_class = _SUPPORTED_METRICS[self.config.metric]
+
         index_type = self.config.index_type
         try:
             self._cur.execute(
@@ -370,8 +435,31 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             self._initialize()
         self._cur.execute(f"SET work_mem TO '{self.config.work_mem}'")
 
+        if self.config.maintenance_work_mem is not None:
+            self._cur.execute(
+                f"SET maintenance_work_mem TO "
+                f"'{self.config.maintenance_work_mem}'"
+            )
+
+        dimension = embeddings.shape[1]
+        max_dims = _MAX_INDEXABLE_DIMS[self.config.vector_type]
+        if dimension > max_dims:
+            msg = (
+                f"Embeddings with {dimension} dimensions exceed the maximum "
+                f"of {max_dims} indexable dimensions for "
+                f"'{self.config.vector_type}' columns"
+            )
+            if self.config.vector_type == "vector":
+                msg += (
+                    ". Pass vector_type='halfvec' to compute_similarity() "
+                    "to store half-precision vectors, which support up to "
+                    "4000 indexable dimensions (requires pgvector >= 0.7.0)"
+                )
+
+            raise ValueError(msg)
+
         if self.config.table_name not in self._get_table_names():
-            self._create_table(embeddings.shape[1])
+            self._create_table(dimension)
 
         if label_ids is not None:
             ids = label_ids
@@ -680,6 +768,7 @@ class PgVectorSimilarityIndex(SimilarityIndex):
 
         sort_order = "DESC" if reverse else "ASC"
         operator = _METRIC_OPERATORS[self.config.metric]
+        cast = self.config.vector_type
 
         sample_ids = []
         label_ids = [] if self.config.patches_field is not None else None
@@ -688,7 +777,7 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             if _filter:
                 self._cur.execute(
                     f"""
-                    SELECT id, sample_id, embedding_vector {operator} %s::vector AS distance
+                    SELECT id, sample_id, embedding_vector {operator} %s::{cast} AS distance
                     FROM "{self.config.table_name}"
                     WHERE id = ANY(%s)
                     ORDER BY distance {sort_order}
@@ -699,7 +788,7 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             else:
                 self._cur.execute(
                     f"""
-                    SELECT id, sample_id, embedding_vector {operator} %s::vector AS distance
+                    SELECT id, sample_id, embedding_vector {operator} %s::{cast} AS distance
                     FROM "{self.config.table_name}"
                     ORDER BY distance {sort_order}
                     LIMIT %s;

--- a/fiftyone/brain/internal/core/pgvector.py
+++ b/fiftyone/brain/internal/core/pgvector.py
@@ -21,17 +21,17 @@ import fiftyone.brain.internal.core.utils as fbu
 
 psycopg2 = fou.lazy_import("psycopg2")
 psy_extras = fou.lazy_import("psycopg2.extras")
+psy_sql = fou.lazy_import("psycopg2.sql")
 
 logger = logging.getLogger(__name__)
 
-# Supported metrics for pgvector
+# Supported metrics for pgvector; jaccard and hamming are not supported
+# because their operator classes only exist for bit columns
 _SUPPORTED_METRICS = {
     "cosine": "vector_cosine_ops",
     "dotproduct": "vector_ip_ops",
     "euclidean": "vector_l2_ops",
     "l1": "vector_l1_ops",
-    "jaccard": "vector_jaccard_ops",
-    "hamming": "vector_hamming_ops",
 }
 
 # Supported index types for pgvector
@@ -42,9 +42,6 @@ _IVFFLAT_SUPPORTED_METRICS = ("cosine", "dotproduct", "euclidean")
 
 # Supported vector column types for pgvector
 _SUPPORTED_VECTOR_TYPES = ("vector", "halfvec")
-
-# Metrics supported on halfvec columns (no jaccard/hamming opclasses)
-_HALFVEC_SUPPORTED_METRICS = ("cosine", "dotproduct", "euclidean", "l1")
 
 # Operator classes for halfvec columns (l1 is HNSW-only, enforced by the
 # ivfflat metric check)
@@ -59,15 +56,12 @@ _HALFVEC_OPCLASSES = {
 # ivfflat indexes)
 _MAX_INDEXABLE_DIMS = {"vector": 2000, "halfvec": 4000}
 
-# Query operators for each metric; "%" is doubled because these are
-# interpolated into parameterized psycopg2 queries
+# Query operators for each metric
 _METRIC_OPERATORS = {
     "cosine": "<=>",
     "dotproduct": "<#>",
     "euclidean": "<->",
     "l1": "<+>",
-    "jaccard": "<%%>",
-    "hamming": "<~>",
 }
 
 
@@ -80,7 +74,7 @@ class PgVectorSimilarityConfig(SimilarityConfig):
         table_name (None): the name of the table to use or create. If none is
             provided, a default table name will be used.
         metric ("cosine"): the similarity metric to use. Supported values are
-            ``("cosine", "dotproduct", "euclidean", "l1", "jaccard", "hamming")``
+            ``("cosine", "dotproduct", "euclidean", "l1")``
         connection_string (None): the connection string to the PostgreSQL database
         ssl_cert (None): the path to the SSL certificate file
         ssl_key (None): the path to the secret key used for the client certificate
@@ -96,9 +90,7 @@ class PgVectorSimilarityConfig(SimilarityConfig):
             embeddings. Supported values are ``("vector", "halfvec")``.
             ``"halfvec"`` stores half-precision (float16) vectors and
             supports indexes with up to 4000 dimensions, versus 2000 for
-            ``"vector"``, and requires pgvector >= 0.7.0. Note that halfvec
-            columns only support the
-            ``("cosine", "dotproduct", "euclidean", "l1")`` metrics
+            ``"vector"``, and requires pgvector >= 0.7.0
         index_type ("hnsw"): the type of index to use. Supported values are
             ``("hnsw", "ivfflat")``. Note that IVFFlat indexes only support
             the ``("cosine", "dotproduct", "euclidean")`` metrics
@@ -159,15 +151,6 @@ class PgVectorSimilarityConfig(SimilarityConfig):
             raise ValueError(
                 f"Unsupported vector_type '{vector_type}'. "
                 f"Supported values are {_SUPPORTED_VECTOR_TYPES}"
-            )
-
-        if (
-            vector_type == "halfvec"
-            and metric not in _HALFVEC_SUPPORTED_METRICS
-        ):
-            raise ValueError(
-                f"Metric '{metric}' is not supported by halfvec columns. "
-                f"Supported values are {_HALFVEC_SUPPORTED_METRICS}"
             )
 
         super().__init__(**kwargs)
@@ -262,7 +245,9 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             self._initialize()
         try:
             self._cur.execute(
-                f"""SELECT COUNT(*) FROM "{self.config.table_name}";"""
+                psy_sql.SQL("SELECT COUNT(*) FROM {};").format(
+                    psy_sql.Identifier(self.config.table_name)
+                )
             )
             return self._cur.fetchone()[0]
         except Exception as e:
@@ -338,20 +323,29 @@ class PgVectorSimilarityIndex(SimilarityIndex):
 
     def _get_index_names(self, table_name):
         self._cur.execute(
-            f"SELECT indexname FROM pg_indexes WHERE tablename = '{table_name}' AND schemaname = 'public';"
+            "SELECT indexname FROM pg_indexes WHERE tablename = %s AND schemaname = 'public';",
+            (table_name,),
         )
         return [row[0] for row in self._cur.fetchall()]
 
     def _create_table(self, dimension):
+        # `vector_type` is validated against `_SUPPORTED_VECTOR_TYPES` in the
+        # config constructor
+        column_type = f"{self.config.vector_type.upper()}({int(dimension)})"
         try:
             self._cur.execute(
-                f"""
-                    CREATE TABLE IF NOT EXISTS "{self.config.table_name}" (
+                psy_sql.SQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS {table} (
                     id TEXT PRIMARY KEY,
                     sample_id TEXT,
-                    embedding_vector {self.config.vector_type.upper()}({dimension})
+                    embedding_vector {column_type}
                 );
                 """
+                ).format(
+                    table=psy_sql.Identifier(self.config.table_name),
+                    column_type=psy_sql.SQL(column_type),
+                )
             )
             self._conn.commit()
         except Exception as e:
@@ -367,27 +361,33 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             operator_class = _SUPPORTED_METRICS[self.config.metric]
 
         index_type = self.config.index_type
+        index_id = psy_sql.Identifier(self.config.index_name)
+        table_id = psy_sql.Identifier(self.config.table_name)
         try:
             self._cur.execute(
-                f"""DROP INDEX IF EXISTS "{self.config.index_name}";"""
+                psy_sql.SQL("DROP INDEX IF EXISTS {};").format(index_id)
             )
             self._conn.commit()
             if index_type == "ivfflat":
                 self._cur.execute(
-                    f"""
-                    CREATE INDEX "{self.config.index_name}"
-                    ON "{self.config.table_name}" USING ivfflat (embedding_vector {operator_class})
-                    WITH (lists = %s);
-                    """,
+                    psy_sql.SQL(
+                        f"""
+                        CREATE INDEX {{index}}
+                        ON {{table}} USING ivfflat (embedding_vector {operator_class})
+                        WITH (lists = %s);
+                        """
+                    ).format(index=index_id, table=table_id),
                     (self.config.ivfflat_lists,),
                 )
             else:
                 self._cur.execute(
-                    f"""
-                    CREATE INDEX "{self.config.index_name}"
-                    ON "{self.config.table_name}" USING hnsw (embedding_vector {operator_class})
-                    WITH (m = %s, ef_construction = %s);
-                    """,
+                    psy_sql.SQL(
+                        f"""
+                        CREATE INDEX {{index}}
+                        ON {{table}} USING hnsw (embedding_vector {operator_class})
+                        WITH (m = %s, ef_construction = %s);
+                        """
+                    ).format(index=index_id, table=table_id),
                     (self.config.hnsw_m, self.config.hnsw_ef_construction),
                 )
             self._conn.commit()
@@ -405,7 +405,11 @@ class PgVectorSimilarityIndex(SimilarityIndex):
         named_cursor = self._conn.cursor(
             name="id_cursor"
         )  # Named cursor for server-side query
-        named_cursor.execute(f"""SELECT id FROM "{self.config.table_name}";""")
+        named_cursor.execute(
+            psy_sql.SQL("SELECT id FROM {};").format(
+                psy_sql.Identifier(self.config.table_name)
+            )
+        )
 
         existing_ids = []
         while True:
@@ -433,12 +437,17 @@ class PgVectorSimilarityIndex(SimilarityIndex):
     ):
         if self._conn.closed:
             self._initialize()
-        self._cur.execute(f"SET work_mem TO '{self.config.work_mem}'")
+        self._cur.execute(
+            psy_sql.SQL("SET work_mem TO {}").format(
+                psy_sql.Literal(self.config.work_mem)
+            )
+        )
 
         if self.config.maintenance_work_mem is not None:
             self._cur.execute(
-                f"SET maintenance_work_mem TO "
-                f"'{self.config.maintenance_work_mem}'"
+                psy_sql.SQL("SET maintenance_work_mem TO {}").format(
+                    psy_sql.Literal(self.config.maintenance_work_mem)
+                )
             )
 
         dimension = embeddings.shape[1]
@@ -495,19 +504,23 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             existing_ids = set()
 
         if existing_ids and not overwrite:
-            query = f"""
-                INSERT INTO "{self.config.table_name}" (id, sample_id, embedding_vector)
+            query = psy_sql.SQL(
+                """
+                INSERT INTO {} (id, sample_id, embedding_vector)
                 VALUES %s
                 ON CONFLICT (id) DO NOTHING;
                 """
+            ).format(psy_sql.Identifier(self.config.table_name))
         else:
-            query = f"""
-                INSERT INTO "{self.config.table_name}" (id, sample_id, embedding_vector)
+            query = psy_sql.SQL(
+                """
+                INSERT INTO {} (id, sample_id, embedding_vector)
                 VALUES %s
                 ON CONFLICT (id) DO UPDATE
                 SET sample_id = EXCLUDED.sample_id,
                     embedding_vector = EXCLUDED.embedding_vector;
                 """
+            ).format(psy_sql.Identifier(self.config.table_name))
 
         embeddings = [e.tolist() for e in embeddings]
         sample_ids = list(sample_ids)
@@ -569,7 +582,9 @@ class PgVectorSimilarityIndex(SimilarityIndex):
         try:
             # Use parameterized query to delete multiple IDs
             self._cur.execute(
-                f"""DELETE FROM "{self.config.table_name}" WHERE id IN %s;""",
+                psy_sql.SQL("DELETE FROM {} WHERE id IN %s;").format(
+                    psy_sql.Identifier(self.config.table_name)
+                ),
                 (tuple(ids),),
             )
         except Exception as e:
@@ -593,10 +608,14 @@ class PgVectorSimilarityIndex(SimilarityIndex):
     def get_embeddings_by_id(self, sample_ids=None, label_ids=None):
         if self._conn.closed:
             self._initialize()
+
+        table_id = psy_sql.Identifier(self.config.table_name)
         if label_ids is not None:
             try:
                 self._cur.execute(
-                    f"""SELECT id, sample_id, embedding_vector FROM "{self.config.table_name}" WHERE id = ANY(%s)""",
+                    psy_sql.SQL(
+                        "SELECT id, sample_id, embedding_vector FROM {} WHERE id = ANY(%s)"
+                    ).format(table_id),
                     (list(label_ids),),
                 )
             except Exception as e:
@@ -607,7 +626,9 @@ class PgVectorSimilarityIndex(SimilarityIndex):
         elif sample_ids is not None:
             try:
                 self._cur.execute(
-                    f"""SELECT id, sample_id, embedding_vector FROM "{self.config.table_name}" WHERE sample_id = ANY(%s)""",
+                    psy_sql.SQL(
+                        "SELECT id, sample_id, embedding_vector FROM {} WHERE sample_id = ANY(%s)"
+                    ).format(table_id),
                     (list(sample_ids),),
                 )
             except Exception as e:
@@ -618,7 +639,9 @@ class PgVectorSimilarityIndex(SimilarityIndex):
         else:
             try:
                 self._cur.execute(
-                    f"""SELECT id, sample_id, embedding_vector FROM "{self.config.table_name}";"""
+                    psy_sql.SQL(
+                        "SELECT id, sample_id, embedding_vector FROM {};"
+                    ).format(table_id)
                 )
             except Exception as e:
                 logger.error(
@@ -766,35 +789,40 @@ class PgVectorSimilarityIndex(SimilarityIndex):
         else:
             _filter = False
 
+        # `operator`, `cast`, and `sort_order` are all internal values
+        # validated by the config constructor or computed above
         sort_order = "DESC" if reverse else "ASC"
         operator = _METRIC_OPERATORS[self.config.metric]
         cast = self.config.vector_type
+
+        if _filter:
+            knn_query = psy_sql.SQL(
+                f"""
+                SELECT id, sample_id, embedding_vector {operator} %s::{cast} AS distance
+                FROM {{}}
+                WHERE id = ANY(%s)
+                ORDER BY distance {sort_order}
+                LIMIT %s;
+                """
+            ).format(psy_sql.Identifier(self.config.table_name))
+        else:
+            knn_query = psy_sql.SQL(
+                f"""
+                SELECT id, sample_id, embedding_vector {operator} %s::{cast} AS distance
+                FROM {{}}
+                ORDER BY distance {sort_order}
+                LIMIT %s;
+                """
+            ).format(psy_sql.Identifier(self.config.table_name))
 
         sample_ids = []
         label_ids = [] if self.config.patches_field is not None else None
         dists = []
         for q in query:
             if _filter:
-                self._cur.execute(
-                    f"""
-                    SELECT id, sample_id, embedding_vector {operator} %s::{cast} AS distance
-                    FROM "{self.config.table_name}"
-                    WHERE id = ANY(%s)
-                    ORDER BY distance {sort_order}
-                    LIMIT %s;
-                    """,
-                    (q.tolist(), index_ids, k),
-                )
+                self._cur.execute(knn_query, (q.tolist(), index_ids, k))
             else:
-                self._cur.execute(
-                    f"""
-                    SELECT id, sample_id, embedding_vector {operator} %s::{cast} AS distance
-                    FROM "{self.config.table_name}"
-                    ORDER BY distance {sort_order}
-                    LIMIT %s;
-                    """,
-                    (q.tolist(), k),
-                )
+                self._cur.execute(knn_query, (q.tolist(), k))
 
             results = self._cur.fetchall()
 
@@ -859,12 +887,16 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             f"Cleaning up: Deleting {self.config.index_type} index '{self.config.index_name}'"
         )
         self._cur.execute(
-            f"""DROP INDEX IF EXISTS "{self.config.index_name}";"""
+            psy_sql.SQL("DROP INDEX IF EXISTS {};").format(
+                psy_sql.Identifier(self.config.index_name)
+            )
         )
 
         if drop_table:
             self._cur.execute(
-                f"""DROP TABLE IF EXISTS "{self.config.table_name}";"""
+                psy_sql.SQL("DROP TABLE IF EXISTS {};").format(
+                    psy_sql.Identifier(self.config.table_name)
+                )
             )
             logger.info(
                 f"{self.config.table_name} table deleted successfully."

--- a/fiftyone/brain/internal/core/pgvector.py
+++ b/fiftyone/brain/internal/core/pgvector.py
@@ -34,6 +34,23 @@ _SUPPORTED_METRICS = {
     "hamming": "vector_hamming_ops",
 }
 
+# Supported index types for pgvector
+_SUPPORTED_INDEX_TYPES = ("hnsw", "ivfflat")
+
+# Metrics supported by pgvector's ivfflat access method
+_IVFFLAT_SUPPORTED_METRICS = ("cosine", "dotproduct", "euclidean")
+
+# Query operators for each metric; "%" is doubled because these are
+# interpolated into parameterized psycopg2 queries
+_METRIC_OPERATORS = {
+    "cosine": "<=>",
+    "dotproduct": "<#>",
+    "euclidean": "<->",
+    "l1": "<+>",
+    "jaccard": "<%%>",
+    "hamming": "<~>",
+}
+
 
 class PgVectorSimilarityConfig(SimilarityConfig):
     """Configuration for the PGVector similarity backend.
@@ -52,8 +69,17 @@ class PgVectorSimilarityConfig(SimilarityConfig):
             authority (CA) certificate(s).
         work_mem ("64MB"): the base maximum amount of memory to be used by a query operation
             (such as a sort or hash table) before writing to temporary disk files
+        index_type ("hnsw"): the type of index to use. Supported values are
+            ``("hnsw", "ivfflat")``. Note that IVFFlat indexes only support
+            the ``("cosine", "dotproduct", "euclidean")`` metrics
         hnsw_m (16): the max number of connections per layer in the HNSW index
         hnsw_ef_construction (64): the size of the dynamic candidate list for constructing the graph for the HNSW index
+        hnsw_ef_search (None): an optional size of the dynamic candidate list
+            for HNSW searches. If not provided, the server default (40) is
+            used
+        ivfflat_lists (100): the number of inverted lists in the IVFFlat index
+        ivfflat_probes (1): the number of lists to probe during IVFFlat
+            searches
         **kwargs: keyword arguments for
             :class:`fiftyone.brain.similarity.SimilarityConfig`
     """
@@ -68,14 +94,33 @@ class PgVectorSimilarityConfig(SimilarityConfig):
         ssl_key=None,
         ssl_root_cert=None,
         work_mem="64MB",
+        index_type="hnsw",
         hnsw_m=16,
         hnsw_ef_construction=64,
+        hnsw_ef_search=None,
+        ivfflat_lists=100,
+        ivfflat_probes=1,
         **kwargs,
     ):
         if metric not in _SUPPORTED_METRICS:
             raise ValueError(
                 f"Unsupported metric '{metric}'. "
                 f"Supported values are {_SUPPORTED_METRICS}"
+            )
+
+        if index_type not in _SUPPORTED_INDEX_TYPES:
+            raise ValueError(
+                f"Unsupported index_type '{index_type}'. "
+                f"Supported values are {_SUPPORTED_INDEX_TYPES}"
+            )
+
+        if (
+            index_type == "ivfflat"
+            and metric not in _IVFFLAT_SUPPORTED_METRICS
+        ):
+            raise ValueError(
+                f"Metric '{metric}' is not supported by IVFFlat indexes. "
+                f"Supported values are {_IVFFLAT_SUPPORTED_METRICS}"
             )
 
         super().__init__(**kwargs)
@@ -87,8 +132,12 @@ class PgVectorSimilarityConfig(SimilarityConfig):
         self.work_mem = work_mem
         self.index_name = index_name
         self.table_name = table_name
+        self.index_type = index_type
         self.hnsw_m = hnsw_m
         self.hnsw_ef_construction = hnsw_ef_construction
+        self.hnsw_ef_search = hnsw_ef_search
+        self.ivfflat_lists = ivfflat_lists
+        self.ivfflat_probes = ivfflat_probes
 
         self._connection_string = connection_string
 
@@ -185,12 +234,21 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             self.config.connection_string, **ssl_options
         )
         self._cur = self._conn.cursor()
-        try:
-            self._cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
-            self._conn.commit()
-        except Exception as e:
-            logger.error(f"Error creating vector extension: {str(e)}")
-            raise
+        self._cur.execute(
+            "SELECT 1 FROM pg_extension WHERE extname = 'vector'"
+        )
+        if self._cur.fetchone() is None:
+            try:
+                self._cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
+                self._conn.commit()
+            except Exception as e:
+                logger.error(
+                    "The 'vector' extension is not installed in the database "
+                    "and could not be created, which typically requires "
+                    "superuser privileges. Ask your database administrator "
+                    "to run 'CREATE EXTENSION vector'"
+                )
+                raise
 
         if self.config.table_name is None:
             table_names = self._get_table_names()
@@ -241,27 +299,42 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             )
             raise
 
-    def create_hnsw_index(self):
+    def create_index(self):
         operator_class = _SUPPORTED_METRICS[self.config.metric]
+        index_type = self.config.index_type
         try:
             self._cur.execute(
                 f"""DROP INDEX IF EXISTS "{self.config.index_name}";"""
             )
             self._conn.commit()
-            self._cur.execute(
-                f"""
-                CREATE INDEX "{self.config.index_name}"
-                ON "{self.config.table_name}" USING hnsw (embedding_vector {operator_class})
-                WITH (m = %s, ef_construction = %s);
-                """,
-                (self.config.hnsw_m, self.config.hnsw_ef_construction),
-            )
+            if index_type == "ivfflat":
+                self._cur.execute(
+                    f"""
+                    CREATE INDEX "{self.config.index_name}"
+                    ON "{self.config.table_name}" USING ivfflat (embedding_vector {operator_class})
+                    WITH (lists = %s);
+                    """,
+                    (self.config.ivfflat_lists,),
+                )
+            else:
+                self._cur.execute(
+                    f"""
+                    CREATE INDEX "{self.config.index_name}"
+                    ON "{self.config.table_name}" USING hnsw (embedding_vector {operator_class})
+                    WITH (m = %s, ef_construction = %s);
+                    """,
+                    (self.config.hnsw_m, self.config.hnsw_ef_construction),
+                )
             self._conn.commit()
         except Exception as e:
             logger.error(
-                f"Error creating HNSW index on table {self.config.table_name}:{str(e)}"
+                f"Error creating {index_type} index on table {self.config.table_name}:{str(e)}"
             )
             raise
+
+    def create_hnsw_index(self):
+        """Deprecated alias for :meth:`create_index`."""
+        self.create_index()
 
     def _get_index_ids(self, batch_size=1000):
         named_cursor = self._conn.cursor(
@@ -364,7 +437,7 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             psy_extras.execute_values(self._cur, query, data)
             self._conn.commit()
 
-        self.create_hnsw_index()
+        self.create_index()
 
         if close_conn:
             self.close_connections()
@@ -568,6 +641,15 @@ class PgVectorSimilarityIndex(SimilarityIndex):
         if self._conn.closed:
             self._initialize()
 
+        if self.config.index_type == "ivfflat":
+            self._cur.execute(
+                f"SET ivfflat.probes = {int(self.config.ivfflat_probes)};"
+            )
+        elif self.config.hnsw_ef_search is not None:
+            self._cur.execute(
+                f"SET hnsw.ef_search = {int(self.config.hnsw_ef_search)};"
+            )
+
         if query is None:
             raise ValueError("Postgres does not support full index neighbors")
 
@@ -597,6 +679,7 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             _filter = False
 
         sort_order = "DESC" if reverse else "ASC"
+        operator = _METRIC_OPERATORS[self.config.metric]
 
         sample_ids = []
         label_ids = [] if self.config.patches_field is not None else None
@@ -605,7 +688,7 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             if _filter:
                 self._cur.execute(
                     f"""
-                    SELECT id, sample_id, embedding_vector <-> %s::vector AS distance
+                    SELECT id, sample_id, embedding_vector {operator} %s::vector AS distance
                     FROM "{self.config.table_name}"
                     WHERE id = ANY(%s)
                     ORDER BY distance {sort_order}
@@ -616,7 +699,7 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             else:
                 self._cur.execute(
                     f"""
-                    SELECT id, sample_id, embedding_vector <-> %s::vector AS distance
+                    SELECT id, sample_id, embedding_vector {operator} %s::vector AS distance
                     FROM "{self.config.table_name}"
                     ORDER BY distance {sort_order}
                     LIMIT %s;
@@ -678,17 +761,17 @@ class PgVectorSimilarityIndex(SimilarityIndex):
 
     def cleanup(self, drop_table=False):
         """
-        Clean up the database by dropping the HNSW index and optionally the embeddings table.
+        Clean up the database by dropping the vector index and optionally the embeddings table.
         """
+        if self._conn.closed:
+            self._initialize()
+
         logger.info(
-            f"Cleaning up: Deleting HNSW index '{self.config.index_name}'"
+            f"Cleaning up: Deleting {self.config.index_type} index '{self.config.index_name}'"
         )
         self._cur.execute(
             f"""DROP INDEX IF EXISTS "{self.config.index_name}";"""
         )
-
-        if self._conn.closed:
-            self._initialize()
 
         if drop_table:
             self._cur.execute(

--- a/fiftyone/brain/internal/core/pgvector.py
+++ b/fiftyone/brain/internal/core/pgvector.py
@@ -538,8 +538,10 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             psy_extras.execute_values(self._cur, query, data)
             self._conn.commit()
 
-        if self.config.index_name not in self._get_index_names(self.config.table_name):
-                self.create_index()
+        if self.config.index_name not in self._get_index_names(
+            self.config.table_name
+        ):
+            self.create_index()
 
         if close_conn:
             self.close_connections()

--- a/fiftyone/brain/internal/core/pgvector.py
+++ b/fiftyone/brain/internal/core/pgvector.py
@@ -538,7 +538,8 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             psy_extras.execute_values(self._cur, query, data)
             self._conn.commit()
 
-        self.create_index()
+        if self.config.index_name not in self._get_index_names(self.config.table_name):
+                self.create_index()
 
         if close_conn:
             self.close_connections()

--- a/tests/intensive/test_similarity.py
+++ b/tests/intensive/test_similarity.py
@@ -495,6 +495,8 @@ def test_pgvector_config_validation():
     # defaults preserve backwards compatibility
     config = PgVectorSimilarityConfig()
     assert config.index_type == "hnsw"
+    assert config.vector_type == "vector"
+    assert config.maintenance_work_mem is None
 
     config = PgVectorSimilarityConfig(index_type="ivfflat", metric="euclidean")
     assert config.ivfflat_lists == 100
@@ -505,6 +507,27 @@ def test_pgvector_config_validation():
 
     with pytest.raises(ValueError):
         PgVectorSimilarityConfig(index_type="ivfflat", metric="l1")
+
+    # halfvec support
+    config = PgVectorSimilarityConfig(vector_type="halfvec")
+    assert config.vector_type == "halfvec"
+
+    # l1 is supported by halfvec with HNSW indexes
+    PgVectorSimilarityConfig(vector_type="halfvec", metric="l1")
+
+    with pytest.raises(ValueError):
+        PgVectorSimilarityConfig(vector_type="sparsevec")
+
+    with pytest.raises(ValueError):
+        PgVectorSimilarityConfig(vector_type="halfvec", metric="jaccard")
+
+    with pytest.raises(ValueError):
+        PgVectorSimilarityConfig(vector_type="halfvec", metric="hamming")
+
+    with pytest.raises(ValueError):
+        PgVectorSimilarityConfig(
+            vector_type="halfvec", metric="l1", index_type="ivfflat"
+        )
 
 
 def test_pgvector_ivfflat_backend():
@@ -549,6 +572,82 @@ def test_pgvector_ivfflat_backend():
 
     index.cleanup(drop_table=True)
     dataset.delete_brain_run(brain_key)
+    dataset.delete()
+
+
+def test_pgvector_halfvec_backend():
+    backend = "pgvector"
+    if backend not in get_custom_backends():
+        return
+
+    dataset = foz.load_zoo_dataset(
+        "quickstart",
+        max_samples=50,
+        dataset_name="quickstart-test-pgvector-halfvec",
+        drop_existing_dataset=True,
+    )
+
+    # embeddings that exceed the 2000-dim indexable limit for regular
+    # vector columns (eg Qwen embeddings are 2048-dim)
+    embeddings = np.random.randn(len(dataset), 2048)
+
+    # regular vector columns cannot index >2000 dims
+    with pytest.raises(ValueError, match="halfvec"):
+        fob.compute_similarity(
+            dataset,
+            embeddings=embeddings,
+            backend=backend,
+            brain_key="pgvector_highdim_error",
+        )
+
+    if "pgvector_highdim_error" in dataset.list_brain_runs():
+        dataset.delete_brain_run("pgvector_highdim_error")
+
+    for index_type, brain_key, kwargs in [
+        ("hnsw", "pgvector_halfvec_hnsw", {}),
+        (
+            "ivfflat",
+            "pgvector_halfvec_ivfflat",
+            {"ivfflat_lists": 10, "ivfflat_probes": 5},
+        ),
+    ]:
+        index = fob.compute_similarity(
+            dataset,
+            embeddings=embeddings,
+            backend=backend,
+            brain_key=brain_key,
+            vector_type="halfvec",
+            index_type=index_type,
+            maintenance_work_mem="256MB",
+            **kwargs,
+        )
+
+        assert index.config.vector_type == "halfvec"
+        assert index.total_index_size == len(dataset)
+
+        # verify the index was built on the halfvec column
+        if index._conn.closed:
+            index._initialize()
+
+        index._cur.execute(
+            "SELECT indexdef FROM pg_indexes WHERE indexname = %s",
+            (index.config.index_name,),
+        )
+        indexdef = index._cur.fetchone()[0]
+        assert f"USING {index_type}" in indexdef
+        assert "halfvec_cosine_ops" in indexdef
+
+        query_id = dataset.first().id
+        view = dataset.sort_by_similarity(query_id, k=10, brain_key=brain_key)
+        assert len(view) == 10
+
+        # embeddings round-trip with float16 precision
+        emb, _, _ = index.get_embeddings()
+        assert emb.shape == (len(dataset), 2048)
+
+        index.cleanup(drop_table=True)
+        dataset.delete_brain_run(brain_key)
+
     dataset.delete()
 
 

--- a/tests/intensive/test_similarity.py
+++ b/tests/intensive/test_similarity.py
@@ -508,6 +508,14 @@ def test_pgvector_config_validation():
     with pytest.raises(ValueError):
         PgVectorSimilarityConfig(index_type="ivfflat", metric="l1")
 
+    # jaccard/hamming operator classes only exist for bit columns, so these
+    # metrics are not supported
+    with pytest.raises(ValueError):
+        PgVectorSimilarityConfig(metric="jaccard")
+
+    with pytest.raises(ValueError):
+        PgVectorSimilarityConfig(metric="hamming")
+
     # halfvec support
     config = PgVectorSimilarityConfig(vector_type="halfvec")
     assert config.vector_type == "halfvec"
@@ -517,12 +525,6 @@ def test_pgvector_config_validation():
 
     with pytest.raises(ValueError):
         PgVectorSimilarityConfig(vector_type="sparsevec")
-
-    with pytest.raises(ValueError):
-        PgVectorSimilarityConfig(vector_type="halfvec", metric="jaccard")
-
-    with pytest.raises(ValueError):
-        PgVectorSimilarityConfig(vector_type="halfvec", metric="hamming")
 
     with pytest.raises(ValueError):
         PgVectorSimilarityConfig(
@@ -542,37 +544,41 @@ def test_pgvector_ivfflat_backend():
         drop_existing_dataset=True,
     )
     brain_key = "clip_pgvector_ivfflat"
-    index = fob.compute_similarity(
-        dataset,
-        model="clip-vit-base32-torch",
-        backend=backend,
-        brain_key=brain_key,
-        index_type="ivfflat",
-        ivfflat_lists=10,
-        ivfflat_probes=5,
-    )
+    index = None
+    try:
+        index = fob.compute_similarity(
+            dataset,
+            model="clip-vit-base32-torch",
+            backend=backend,
+            brain_key=brain_key,
+            index_type="ivfflat",
+            ivfflat_lists=10,
+            ivfflat_probes=5,
+        )
 
-    assert index.config.index_type == "ivfflat"
-    assert index.total_index_size == len(dataset)
+        assert index.config.index_type == "ivfflat"
+        assert index.total_index_size == len(dataset)
 
-    # verify that an IVFFlat index was actually created
-    if index._conn.closed:
-        index._initialize()
+        # verify that an IVFFlat index was actually created
+        if index._conn.closed:
+            index._initialize()
 
-    index._cur.execute(
-        "SELECT indexdef FROM pg_indexes WHERE indexname = %s",
-        (index.config.index_name,),
-    )
-    indexdef = index._cur.fetchone()[0]
-    assert "USING ivfflat" in indexdef
+        index._cur.execute(
+            "SELECT indexdef FROM pg_indexes WHERE indexname = %s",
+            (index.config.index_name,),
+        )
+        indexdef = index._cur.fetchone()[0]
+        assert "USING ivfflat" in indexdef
 
-    query_id = dataset.first().id
-    view = dataset.sort_by_similarity(query_id, k=10, brain_key=brain_key)
-    assert len(view) == 10
+        query_id = dataset.first().id
+        view = dataset.sort_by_similarity(query_id, k=10, brain_key=brain_key)
+        assert len(view) == 10
+    finally:
+        if index is not None:
+            index.cleanup(drop_table=True)
+            dataset.delete_brain_run(brain_key)
 
-    index.cleanup(drop_table=True)
-    dataset.delete_brain_run(brain_key)
-    dataset.delete()
+        dataset.delete()
 
 
 def test_pgvector_halfvec_backend():
@@ -591,64 +597,68 @@ def test_pgvector_halfvec_backend():
     # vector columns (eg Qwen embeddings are 2048-dim)
     embeddings = np.random.randn(len(dataset), 2048)
 
-    # regular vector columns cannot index >2000 dims
-    with pytest.raises(ValueError, match="halfvec"):
-        fob.compute_similarity(
-            dataset,
-            embeddings=embeddings,
-            backend=backend,
-            brain_key="pgvector_highdim_error",
-        )
+    try:
+        # regular vector columns cannot index >2000 dims
+        with pytest.raises(ValueError, match="halfvec"):
+            fob.compute_similarity(
+                dataset,
+                embeddings=embeddings,
+                backend=backend,
+                brain_key="pgvector_highdim_error",
+            )
 
-    if "pgvector_highdim_error" in dataset.list_brain_runs():
-        dataset.delete_brain_run("pgvector_highdim_error")
+        if "pgvector_highdim_error" in dataset.list_brain_runs():
+            dataset.delete_brain_run("pgvector_highdim_error")
 
-    for index_type, brain_key, kwargs in [
-        ("hnsw", "pgvector_halfvec_hnsw", {}),
-        (
-            "ivfflat",
-            "pgvector_halfvec_ivfflat",
-            {"ivfflat_lists": 10, "ivfflat_probes": 5},
-        ),
-    ]:
-        index = fob.compute_similarity(
-            dataset,
-            embeddings=embeddings,
-            backend=backend,
-            brain_key=brain_key,
-            vector_type="halfvec",
-            index_type=index_type,
-            maintenance_work_mem="256MB",
-            **kwargs,
-        )
+        for index_type, brain_key, kwargs in [
+            ("hnsw", "pgvector_halfvec_hnsw", {}),
+            (
+                "ivfflat",
+                "pgvector_halfvec_ivfflat",
+                {"ivfflat_lists": 10, "ivfflat_probes": 5},
+            ),
+        ]:
+            index = fob.compute_similarity(
+                dataset,
+                embeddings=embeddings,
+                backend=backend,
+                brain_key=brain_key,
+                vector_type="halfvec",
+                index_type=index_type,
+                maintenance_work_mem="256MB",
+                **kwargs,
+            )
 
-        assert index.config.vector_type == "halfvec"
-        assert index.total_index_size == len(dataset)
+            try:
+                assert index.config.vector_type == "halfvec"
+                assert index.total_index_size == len(dataset)
 
-        # verify the index was built on the halfvec column
-        if index._conn.closed:
-            index._initialize()
+                # verify the index was built on the halfvec column
+                if index._conn.closed:
+                    index._initialize()
 
-        index._cur.execute(
-            "SELECT indexdef FROM pg_indexes WHERE indexname = %s",
-            (index.config.index_name,),
-        )
-        indexdef = index._cur.fetchone()[0]
-        assert f"USING {index_type}" in indexdef
-        assert "halfvec_cosine_ops" in indexdef
+                index._cur.execute(
+                    "SELECT indexdef FROM pg_indexes WHERE indexname = %s",
+                    (index.config.index_name,),
+                )
+                indexdef = index._cur.fetchone()[0]
+                assert f"USING {index_type}" in indexdef
+                assert "halfvec_cosine_ops" in indexdef
 
-        query_id = dataset.first().id
-        view = dataset.sort_by_similarity(query_id, k=10, brain_key=brain_key)
-        assert len(view) == 10
+                query_id = dataset.first().id
+                view = dataset.sort_by_similarity(
+                    query_id, k=10, brain_key=brain_key
+                )
+                assert len(view) == 10
 
-        # embeddings round-trip with float16 precision
-        emb, _, _ = index.get_embeddings()
-        assert emb.shape == (len(dataset), 2048)
-
-        index.cleanup(drop_table=True)
-        dataset.delete_brain_run(brain_key)
-
-    dataset.delete()
+                # embeddings round-trip with float16 precision
+                emb, _, _ = index.get_embeddings()
+                assert emb.shape == (len(dataset), 2048)
+            finally:
+                index.cleanup(drop_table=True)
+                dataset.delete_brain_run(brain_key)
+    finally:
+        dataset.delete()
 
 
 def test_images():

--- a/tests/intensive/test_similarity.py
+++ b/tests/intensive/test_similarity.py
@@ -126,6 +126,7 @@ import time
 import unittest
 
 import numpy as np
+import pytest
 
 import fiftyone as fo
 import fiftyone.brain as fob  # pylint: disable=import-error,no-name-in-module
@@ -483,6 +484,71 @@ def test_qdrant_backend_config():
     else:
         print("Qdrant config grpc_port unset")
 
+    dataset.delete()
+
+
+def test_pgvector_config_validation():
+    from fiftyone.brain.internal.core.pgvector import (
+        PgVectorSimilarityConfig,
+    )
+
+    # defaults preserve backwards compatibility
+    config = PgVectorSimilarityConfig()
+    assert config.index_type == "hnsw"
+
+    config = PgVectorSimilarityConfig(index_type="ivfflat", metric="euclidean")
+    assert config.ivfflat_lists == 100
+    assert config.ivfflat_probes == 1
+
+    with pytest.raises(ValueError):
+        PgVectorSimilarityConfig(index_type="flat")
+
+    with pytest.raises(ValueError):
+        PgVectorSimilarityConfig(index_type="ivfflat", metric="l1")
+
+
+def test_pgvector_ivfflat_backend():
+    backend = "pgvector"
+    if backend not in get_custom_backends():
+        return
+
+    dataset = foz.load_zoo_dataset(
+        "quickstart",
+        max_samples=50,
+        dataset_name="quickstart-test-pgvector-ivfflat",
+        drop_existing_dataset=True,
+    )
+    brain_key = "clip_pgvector_ivfflat"
+    index = fob.compute_similarity(
+        dataset,
+        model="clip-vit-base32-torch",
+        backend=backend,
+        brain_key=brain_key,
+        index_type="ivfflat",
+        ivfflat_lists=10,
+        ivfflat_probes=5,
+    )
+
+    assert index.config.index_type == "ivfflat"
+    assert index.total_index_size == len(dataset)
+
+    # verify that an IVFFlat index was actually created
+    if index._conn.closed:
+        index._initialize()
+
+    index._cur.execute(
+        "SELECT indexdef FROM pg_indexes WHERE indexname = %s",
+        (index.config.index_name,),
+    )
+    indexdef = index._cur.fetchone()[0]
+    assert "USING ivfflat" in indexdef
+
+    query_id = dataset.first().id
+    view = dataset.sort_by_similarity(query_id, k=10, brain_key=brain_key)
+    assert len(view) == 10
+
+    index.cleanup(drop_table=True)
+    dataset.delete_brain_run(brain_key)
     dataset.delete()
 
 


### PR DESCRIPTION
# Rationale

This PR adds the IVFFlat index support where we previously only supported HNSW index. Also added halfvec vector type so we can support embeddings of dim > 2000.

## Changes

Added the IVFFlat index to pgvector backend + added halfvec vector type.

## Testing

Tested with pgvector locally and added tests. 

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->