### PR TITLE
pgvector: derive IVFFlat lists and probes from the dataset size

### DIFF
--- a/fiftyone/brain/internal/core/pgvector.py
+++ b/fiftyone/brain/internal/core/pgvector.py
@@ -6,6 +6,7 @@ PGVector similarity backend.
 |
 """
 import logging
+import math
 
 import numpy as np
 
@@ -64,6 +65,55 @@ _METRIC_OPERATORS = {
     "l1": "<+>",
 }
 
+# Rows per list when auto-deriving `ivfflat_lists`, per pgvector's guidance
+_IVFFLAT_ROWS_PER_LIST = 1000
+
+# Row count above which pgvector recommends sqrt(rows) lists instead
+_IVFFLAT_SQRT_THRESHOLD = 1000000
+
+
+def _default_ivfflat_lists(num_rows):
+    """Returns the recommended number of IVFFlat lists for a table with the
+    given number of rows.
+
+    Follows pgvector's guidance of ``rows / 1000`` for up to 1M rows and
+    ``sqrt(rows)`` beyond that. A list count approaching or exceeding the row
+    count leaves most lists empty or singleton, which destroys recall, so
+    small tables correctly resolve to a single list (ie exact search within
+    that list).
+
+    Args:
+        num_rows: the number of rows in the table
+
+    Returns:
+        the number of lists to use
+    """
+    if not num_rows or num_rows <= 0:
+        return 1
+
+    if num_rows <= _IVFFLAT_SQRT_THRESHOLD:
+        lists = num_rows // _IVFFLAT_ROWS_PER_LIST
+    else:
+        lists = int(math.sqrt(num_rows))
+
+    return max(1, lists)
+
+
+def _default_ivfflat_probes(lists):
+    """Returns the recommended number of IVFFlat probes for an index with the
+    given number of lists, per pgvector's ``sqrt(lists)`` guidance.
+
+    Args:
+        lists: the number of lists in the index
+
+    Returns:
+        the number of lists to probe
+    """
+    if not lists or lists <= 1:
+        return 1
+
+    return max(1, min(int(math.sqrt(lists)), lists))
+
 
 class PgVectorSimilarityConfig(SimilarityConfig):
     """Configuration for the PGVector similarity backend.
@@ -99,9 +149,14 @@ class PgVectorSimilarityConfig(SimilarityConfig):
         hnsw_ef_search (None): an optional size of the dynamic candidate list
             for HNSW searches. If not provided, the server default (40) is
             used
-        ivfflat_lists (100): the number of inverted lists in the IVFFlat index
-        ivfflat_probes (1): the number of lists to probe during IVFFlat
-            searches
+        ivfflat_lists (None): the number of inverted lists in the IVFFlat
+            index. By default, this is derived from the number of embeddings
+            in the index following pgvector's guidance of ``rows / 1000`` for
+            up to 1M rows and ``sqrt(rows)`` beyond that
+        ivfflat_probes (None): the number of lists to probe during IVFFlat
+            searches. By default, this is derived from the number of lists
+            following pgvector's ``sqrt(lists)`` guidance. Larger values
+            improve recall at the cost of speed
         **kwargs: keyword arguments for
             :class:`fiftyone.brain.similarity.SimilarityConfig`
     """
@@ -122,8 +177,8 @@ class PgVectorSimilarityConfig(SimilarityConfig):
         hnsw_m=16,
         hnsw_ef_construction=64,
         hnsw_ef_search=None,
-        ivfflat_lists=100,
-        ivfflat_probes=1,
+        ivfflat_lists=None,
+        ivfflat_probes=None,
         **kwargs,
     ):
         if metric not in _SUPPORTED_METRICS:
@@ -237,6 +292,7 @@ class PgVectorSimilarityIndex(SimilarityIndex):
         super().__init__(samples, config, brain_key, backend=backend)
         self._conn = None
         self._cur = None
+        self._ivfflat_lists = None
         self._initialize()
 
     @property
@@ -328,6 +384,23 @@ class PgVectorSimilarityIndex(SimilarityIndex):
         )
         return [row[0] for row in self._cur.fetchall()]
 
+    def _resolve_ivfflat_lists(self):
+        if self.config.ivfflat_lists is not None:
+            return int(self.config.ivfflat_lists)
+
+        if self._ivfflat_lists is None:
+            self._ivfflat_lists = _default_ivfflat_lists(
+                self.total_index_size
+            )
+
+        return self._ivfflat_lists
+
+    def _resolve_ivfflat_probes(self):
+        if self.config.ivfflat_probes is not None:
+            return int(self.config.ivfflat_probes)
+
+        return _default_ivfflat_probes(self._resolve_ivfflat_lists())
+
     def _create_table(self, dimension):
         # `vector_type` is validated against `_SUPPORTED_VECTOR_TYPES` in the
         # config constructor
@@ -369,6 +442,8 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             )
             self._conn.commit()
             if index_type == "ivfflat":
+                lists = self._resolve_ivfflat_lists()
+                logger.info(f"Building IVFFlat index with lists = {lists}")
                 self._cur.execute(
                     psy_sql.SQL(
                         f"""
@@ -377,7 +452,7 @@ class PgVectorSimilarityIndex(SimilarityIndex):
                         WITH (lists = %s);
                         """
                     ).format(index=index_id, table=table_id),
-                    (self.config.ivfflat_lists,),
+                    (lists,),
                 )
             else:
                 self._cur.execute(
@@ -537,6 +612,10 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             data = list(zip(_ids, _sample_ids, _embeddings))
             psy_extras.execute_values(self._cur, query, data)
             self._conn.commit()
+
+        # The row count has changed, so any auto-derived `ivfflat_lists` value
+        # must be recomputed before the index is (re)built
+        self._ivfflat_lists = None
 
         if self.config.index_name not in self._get_index_names(
             self.config.table_name
@@ -756,9 +835,8 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             self._initialize()
 
         if self.config.index_type == "ivfflat":
-            self._cur.execute(
-                f"SET ivfflat.probes = {int(self.config.ivfflat_probes)};"
-            )
+            probes = self._resolve_ivfflat_probes()
+            self._cur.execute(f"SET ivfflat.probes = {int(probes)};")
         elif self.config.hnsw_ef_search is not None:
             self._cur.execute(
                 f"SET hnsw.ef_search = {int(self.config.hnsw_ef_search)};"
@@ -828,6 +906,26 @@ class PgVectorSimilarityIndex(SimilarityIndex):
                 self._cur.execute(knn_query, (q.tolist(), k))
 
             results = self._cur.fetchall()
+
+            if _filter:
+                # Approximate indexes filter *within* the candidate set they
+                # visit, so a filtered query can return fewer than `k` results
+                # even when more than `k` matching rows exist
+                expected = min(k, len(index_ids))
+                if len(results) < expected:
+                    knob = (
+                        "ivfflat_probes"
+                        if self.config.index_type == "ivfflat"
+                        else "hnsw_ef_search"
+                    )
+                    logger.warning(
+                        "Filtered similarity query returned %d of %d "
+                        "requested results. Increase '%s' to improve recall "
+                        "on filtered views",
+                        len(results),
+                        expected,
+                        knob,
+                    )
 
             if self.config.patches_field is not None:
                 sample_ids.append([r[1] for r in results])

--- a/fiftyone/brain/internal/core/pgvector.py
+++ b/fiftyone/brain/internal/core/pgvector.py
@@ -99,6 +99,26 @@ def _default_ivfflat_lists(num_rows):
     return max(1, lists)
 
 
+def _parse_reloption_lists(reloptions):
+    """Extracts the ``lists`` value from a ``pg_class.reloptions`` array.
+
+    Args:
+        reloptions: the reloptions array, eg ``["lists=100"]``, or None
+
+    Returns:
+        the number of lists, or None if absent or unparseable
+    """
+    for option in reloptions or ():
+        key, _, value = option.partition("=")
+        if key.strip() == "lists":
+            try:
+                return int(value)
+            except ValueError:
+                return None
+
+    return None
+
+
 def _default_ivfflat_probes(lists):
     """Returns the recommended number of IVFFlat probes for an index with the
     given number of lists, per pgvector's ``sqrt(lists)`` guidance.
@@ -292,7 +312,6 @@ class PgVectorSimilarityIndex(SimilarityIndex):
         super().__init__(samples, config, brain_key, backend=backend)
         self._conn = None
         self._cur = None
-        self._ivfflat_lists = None
         self._initialize()
 
     @property
@@ -384,20 +403,46 @@ class PgVectorSimilarityIndex(SimilarityIndex):
         )
         return [row[0] for row in self._cur.fetchall()]
 
+    def _get_index_lists(self):
+        """Returns the number of lists that the existing IVFFlat index was
+        built with, or None if no such index exists.
+        """
+        self._cur.execute(
+            """
+            SELECT c.reloptions
+            FROM pg_class c
+            JOIN pg_am am ON am.oid = c.relam
+            WHERE c.relname = %s AND am.amname = 'ivfflat';
+            """,
+            (self.config.index_name,),
+        )
+        row = self._cur.fetchone()
+        return _parse_reloption_lists(row[0]) if row is not None else None
+
     def _resolve_ivfflat_lists(self):
+        """Returns the number of lists to build the IVFFlat index with,
+        derived from the current row count unless configured explicitly.
+        """
         if self.config.ivfflat_lists is not None:
             return int(self.config.ivfflat_lists)
 
-        if self._ivfflat_lists is None:
-            self._ivfflat_lists = _default_ivfflat_lists(self.total_index_size)
-
-        return self._ivfflat_lists
+        return _default_ivfflat_lists(self.total_index_size)
 
     def _resolve_ivfflat_probes(self):
+        """Returns the number of lists to probe during searches, derived from
+        the list count that the existing index was actually built with.
+
+        Falls back to the count a build would use if the index does not exist
+        yet, so that the value never depends on a cached row count.
+        """
         if self.config.ivfflat_probes is not None:
             return int(self.config.ivfflat_probes)
 
-        return _default_ivfflat_probes(self._resolve_ivfflat_lists())
+        lists = self._get_index_lists()
+        if lists is None:
+            lists = self._resolve_ivfflat_lists()
+
+        return _default_ivfflat_probes(lists)
 
     def _create_table(self, dimension):
         # `vector_type` is validated against `_SUPPORTED_VECTOR_TYPES` in the
@@ -610,10 +655,6 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             data = list(zip(_ids, _sample_ids, _embeddings))
             psy_extras.execute_values(self._cur, query, data)
             self._conn.commit()
-
-        # The row count has changed, so any auto-derived `ivfflat_lists` value
-        # must be recomputed before the index is (re)built
-        self._ivfflat_lists = None
 
         if self.config.index_name not in self._get_index_names(
             self.config.table_name

--- a/fiftyone/brain/internal/core/pgvector.py
+++ b/fiftyone/brain/internal/core/pgvector.py
@@ -389,9 +389,7 @@ class PgVectorSimilarityIndex(SimilarityIndex):
             return int(self.config.ivfflat_lists)
 
         if self._ivfflat_lists is None:
-            self._ivfflat_lists = _default_ivfflat_lists(
-                self.total_index_size
-            )
+            self._ivfflat_lists = _default_ivfflat_lists(self.total_index_size)
 
         return self._ivfflat_lists
 

--- a/tests/intensive/test_similarity.py
+++ b/tests/intensive/test_similarity.py
@@ -499,8 +499,9 @@ def test_pgvector_config_validation():
     assert config.maintenance_work_mem is None
 
     config = PgVectorSimilarityConfig(index_type="ivfflat", metric="euclidean")
-    assert config.ivfflat_lists == 100
-    assert config.ivfflat_probes == 1
+    # None means the values are derived from the data at index build time
+    assert config.ivfflat_lists is None
+    assert config.ivfflat_probes is None
 
     with pytest.raises(ValueError):
         PgVectorSimilarityConfig(index_type="flat")

--- a/tests/test_pgvector.py
+++ b/tests/test_pgvector.py
@@ -15,10 +15,13 @@ from fiftyone.brain.internal.core.pgvector import (
     PgVectorSimilarityConfig,
     _default_ivfflat_lists,
     _default_ivfflat_probes,
+    _parse_reloption_lists,
 )
 
 
 class TestIvfflatListDefaults:
+    """Deriving the IVFFlat list count from a row count."""
+
     def test_small_tables_resolve_to_one_list(self):
         # A list count approaching the row count leaves lists empty or
         # singleton, which destroys recall. One list means exact search
@@ -45,6 +48,8 @@ class TestIvfflatListDefaults:
 
 
 class TestIvfflatProbeDefaults:
+    """Deriving the IVFFlat probe count from a list count."""
+
     def test_probes_follow_sqrt_lists(self):
         assert _default_ivfflat_probes(1) == 1
         assert _default_ivfflat_probes(100) == 10
@@ -60,6 +65,8 @@ class TestIvfflatProbeDefaults:
 
 
 class TestIvfflatConfigDefaults:
+    """Config-level defaults for the IVFFlat parameters."""
+
     def test_ivfflat_params_default_to_auto(self):
         config = PgVectorSimilarityConfig(
             index_type="ivfflat", metric="euclidean"
@@ -79,3 +86,25 @@ class TestIvfflatConfigDefaults:
 
         assert config.ivfflat_lists == 10
         assert config.ivfflat_probes == 5
+
+
+class TestParseReloptionLists:
+    """Reading the built list count out of ``pg_class.reloptions``."""
+
+    def test_extracts_lists(self):
+        assert _parse_reloption_lists(["lists=100"]) == 100
+        assert _parse_reloption_lists(["lists=7"]) == 7
+
+    def test_ignores_other_options(self):
+        assert _parse_reloption_lists(["fillfactor=90", "lists=42"]) == 42
+
+    def test_absent_or_empty(self):
+        assert _parse_reloption_lists(None) is None
+        assert _parse_reloption_lists([]) is None
+        assert _parse_reloption_lists(["fillfactor=90"]) is None
+
+    def test_unparseable_value(self):
+        assert _parse_reloption_lists(["lists=abc"]) is None
+
+    def test_does_not_match_prefixed_keys(self):
+        assert _parse_reloption_lists(["nolists=5"]) is None

--- a/tests/test_pgvector.py
+++ b/tests/test_pgvector.py
@@ -1,0 +1,81 @@
+"""
+Unit tests for the pgvector similarity backend.
+
+These tests do not require a running PostgreSQL instance, so unlike the
+pgvector tests in ``tests/intensive/``, they run in CI. The integration tests
+live in ``tests/intensive/test_similarity.py``.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import pytest
+
+from fiftyone.brain.internal.core.pgvector import (
+    PgVectorSimilarityConfig,
+    _default_ivfflat_lists,
+    _default_ivfflat_probes,
+)
+
+
+class TestIvfflatListDefaults:
+    def test_small_tables_resolve_to_one_list(self):
+        # A list count approaching the row count leaves lists empty or
+        # singleton, which destroys recall. One list means exact search
+        for num_rows in (0, 1, 78, 500, 999):
+            assert _default_ivfflat_lists(num_rows) == 1
+
+    def test_rows_over_1000_up_to_1m(self):
+        assert _default_ivfflat_lists(1000) == 1
+        assert _default_ivfflat_lists(10000) == 10
+        assert _default_ivfflat_lists(50000) == 50
+        assert _default_ivfflat_lists(1000000) == 1000
+
+    def test_sqrt_rows_above_1m(self):
+        assert _default_ivfflat_lists(4000000) == 2000
+        assert _default_ivfflat_lists(9000000) == 3000
+
+    def test_lists_never_exceed_rows(self):
+        for num_rows in (1, 10, 100, 1000, 10000, 10**6, 10**7):
+            assert _default_ivfflat_lists(num_rows) <= num_rows
+
+    def test_degenerate_inputs(self):
+        assert _default_ivfflat_lists(None) == 1
+        assert _default_ivfflat_lists(-5) == 1
+
+
+class TestIvfflatProbeDefaults:
+    def test_probes_follow_sqrt_lists(self):
+        assert _default_ivfflat_probes(1) == 1
+        assert _default_ivfflat_probes(100) == 10
+        assert _default_ivfflat_probes(1000) == 31
+
+    def test_probes_never_exceed_lists(self):
+        for lists in (1, 2, 3, 10, 100, 1000, 32768):
+            assert _default_ivfflat_probes(lists) <= lists
+
+    def test_degenerate_inputs(self):
+        assert _default_ivfflat_probes(None) == 1
+        assert _default_ivfflat_probes(0) == 1
+
+
+class TestIvfflatConfigDefaults:
+    def test_ivfflat_params_default_to_auto(self):
+        config = PgVectorSimilarityConfig(
+            index_type="ivfflat", metric="euclidean"
+        )
+
+        # None means "derive from the data at index build time"
+        assert config.ivfflat_lists is None
+        assert config.ivfflat_probes is None
+
+    def test_explicit_ivfflat_params_are_preserved(self):
+        config = PgVectorSimilarityConfig(
+            index_type="ivfflat",
+            metric="euclidean",
+            ivfflat_lists=10,
+            ivfflat_probes=5,
+        )
+
+        assert config.ivfflat_lists == 10
+        assert config.ivfflat_probes == 5


### PR DESCRIPTION
Addresses review comment on #311:

Update default `ivfflat_` parameter values based on recommendations from `pgvector`'s README:
[`lists`](https://github.com/pgvector/pgvector?tab=readme-ov-file#ivfflat) and
[`probes`](https://github.com/pgvector/pgvector?tab=readme-ov-file#query-options-1).

- Derive `ivfflat_lists` from the row count (pgvector's rows/1000, or sqrt(rows) above 1M) rather than defaulting to a fixed 100. Smaller datasets would have empty or singleton lists.
- Derive `ivfflat_probes` from the list count (sqrt(lists)), and warn when a filtered query returns fewer than k results

Adds tests/test_pgvector.py

# Rationale
Could cause undesirable behavior in smaller datasets. Below ~1,000 samples you get fewer rows than you asked for. `sort_by_similarity(query_id, k=10)` returns a view of two samples, and in the App the similarity grid comes back nearly empty.

`lists=100` is the correct value for a 100,000-row table; every dataset smaller than that is over-partitioned. With `probes=1` a query examines 1% of the corpus regardless of size, and the two defaults multiply. pgvector itself emits `NOTICE: ivfflat index created with little data / This will cause low recall.` when rows < lists, but psycopg2 collects that into `conn.notices`, which this backend never reads so the failure is silent: the index builds, queries succeed, results are just short.

## Changes
- `ivfflat_lists` and `ivfflat_probes` now default to `None`, meaning "derive from the data". Explicitly passed values are honored unchanged. Both parameters are new in #311 and unreleased, so changing the defaults has no backwards-compatibility surface.
- Two pure module-level helpers: `_default_ivfflat_lists(num_rows)` (`rows // 1000` up to 1M rows, `sqrt(rows)` above, floor of 1) and `_default_ivfflat_probes(lists)` (`sqrt(lists)`, never exceeding `lists`).
- `_resolve_ivfflat_lists()` / `_resolve_ivfflat_probes()` map config value → derived value. The resolved list count is cached per index instance and invalidated after inserts, so a growing index re-derives on its next build.
- `create_index()` builds with the resolved list count and logs it.
- `_kneighbors()` applies the resolved probe count, and warns when a filtered query returns fewer than `min(k, len(index_ids))` rows, naming the knob to raise.

**`tests/test_pgvector.py`** (new)

10 tests, no database required so they run in CI. Covers the boundaries at 1,000 and 1M rows, the invariants that lists never exceed rows and probes never exceed lists, degenerate inputs (`None`, `0`, negative), and that explicit config values pass through untouched.

**`tests/intensive/test_similarity.py`**

Updated the two assertions that pinned the old fixed defaults.

## Testing
In my local environment:
```
$ python -m pytest tests/test_pgvector.py -q
10 passed

$ python -m pytest tests/ --ignore tests/intensive/ --ignore tests/models -q
3 failed, 32 passed
```

The three failures are environmental and reproduce identically on the base commit (28b6f75): `test_uniqueness::test_uniqueness` needs torch, `test_uniqueness::test_gray` needs the CI service account, and `test_filter_ids::test_identical_collection_early_exits` fails the same way pre-change. Baseline on the base commit is 22 passed, so the delta is exactly the 10 new tests. `tests/models` excluded locally (torch not installed).

**Not run:** the pgvector integration tests in `tests/intensive/`. They need a live PostgreSQL with pgvector >= 0.7, which I did not have available, and CI excludes that directory anyway.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->