### PR TITLE
docs: fix links (replacing develop with main).

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to FiftyOne Brain
 
 All Brain contributions should follow the practices established in
-[FiftyOne](https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md).
+[FiftyOne](https://github.com/voxel51/fiftyone/blob/main/CONTRIBUTING.md).
 
 ## Adding new public methods to the Brain package
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,4 +1,4 @@
 # FiftyOne Brain Style Guide
 
 The Brain follows the same style guidelines as
-[FiftyOne](https://github.com/voxel51/fiftyone/blob/develop/STYLE_GUIDE.md).
+[FiftyOne](https://github.com/voxel51/fiftyone/blob/main/STYLE_GUIDE.md).


### PR DESCRIPTION
# Rationale

This repo recently went from trunk based from git flow. When we removed the develop branch, we missed a few references.

Thanks to @prernadh in #311 who updated a `develop` with `main` that brought this to my attention.

## Changes

* links

## Testing

New links take the reader to the intended pages.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->