### PR TITLE
Fix inverted representativeness ranking in _cluster_ranker

### DIFF
--- a/fiftyone/brain/internal/core/representativeness.py
+++ b/fiftyone/brain/internal/core/representativeness.py
@@ -216,17 +216,24 @@ def _cluster_ranker(
     centerness_ranking = 1 / (1 + sample_dists)
 
     # Normalize per cluster vs globally
-    norm_method = "local"
     if norm_method == "global":
         centerness_ranking = centerness_ranking / centerness_ranking.max()
     elif norm_method == "local":
         unique_ids = np.unique(cluster_ids)
         for unique_id in unique_ids:
             cluster_indices = np.where(cluster_ids == unique_id)[0]
-            cluster_dists = sample_dists[cluster_indices]
-            cluster_dists /= cluster_dists.max()
-            sample_dists[cluster_indices] = cluster_dists
-        centerness_ranking = sample_dists
+            cluster_centerness = centerness_ranking[cluster_indices]
+            centerness_ranking[cluster_indices] = (
+                cluster_centerness / cluster_centerness.max()
+            )
+    else:
+        raise ValueError(
+            (
+                "Normalization method '%s' not supported. Please use one of "
+                "['global', 'local']"
+            )
+            % norm_method
+        )
 
     return centerness_ranking, clusterer
 

--- a/tests/test_representativeness.py
+++ b/tests/test_representativeness.py
@@ -1,0 +1,101 @@
+"""
+Representativeness tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import unittest
+
+import numpy as np
+import pytest
+import sklearn.cluster as skc
+
+import fiftyone as fo
+
+from fiftyone.brain.internal.core.representativeness import (
+    _cluster_ranker,
+    _compute_representativeness,
+)
+
+
+def _make_embeddings():
+    """Two well-separated Gaussian blobs, 500 points each.
+
+    Large enough that the hardcoded ``KMeans(n_clusters=20)`` used by
+    ``_cluster_ranker()`` does not produce degenerate near-empty clusters.
+    """
+    np.random.seed(0)
+    a = np.random.normal(loc=[0, 0], scale=1.0, size=(500, 2))
+    b = np.random.normal(loc=[30, 30], scale=1.0, size=(500, 2))
+    return np.vstack([a, b]).astype(np.float32)
+
+
+def _distances_to_assigned_center(embeddings):
+    """Each point's distance to its own cluster center, recomputed with the
+    same clustering parameters ``_cluster_ranker()`` uses internally.
+    """
+    clusterer = skc.KMeans(n_clusters=20, random_state=1234).fit(embeddings)
+    return np.linalg.norm(
+        embeddings - clusterer.cluster_centers_[clusterer.labels_], axis=1
+    )
+
+
+@pytest.mark.parametrize("norm_method", ["local", "global"])
+def test_cluster_ranker_is_centerness_not_distance(norm_method):
+    """Representativeness must decrease as distance to the cluster center
+    increases, for both normalization methods.
+    """
+    embeddings = _make_embeddings()
+    dists = _distances_to_assigned_center(embeddings)
+
+    ranking, _ = _cluster_ranker(embeddings, norm_method=norm_method)
+
+    corr = np.corrcoef(ranking, dists)[0, 1]
+    assert corr < -0.5, (
+        "representativeness should anti-correlate with distance to cluster "
+        "center, got corr=%.4f" % corr
+    )
+
+    closest = int(np.argmin(dists))
+    farthest = int(np.argmax(dists))
+    assert ranking[closest] > ranking[farthest]
+
+    assert ranking.min() >= 0.0
+    assert ranking.max() <= 1.0 + 1e-6
+
+
+def test_cluster_ranker_honors_norm_method():
+    """The ``norm_method`` argument must actually be used."""
+    embeddings = _make_embeddings()
+
+    local, _ = _cluster_ranker(embeddings, norm_method="local")
+    glob, _ = _cluster_ranker(embeddings, norm_method="global")
+
+    assert not np.allclose(local, glob)
+
+
+def test_cluster_ranker_rejects_bad_norm_method():
+    embeddings = _make_embeddings()
+
+    with pytest.raises(ValueError):
+        _cluster_ranker(embeddings, norm_method="not-a-method")
+
+
+@pytest.mark.parametrize(
+    "method", ["cluster-center", "cluster-center-downweight"]
+)
+def test_compute_representativeness_orientation(method):
+    """End-to-end: both public methods produce centerness, not distance."""
+    embeddings = _make_embeddings()
+    dists = _distances_to_assigned_center(embeddings)
+
+    ranking = _compute_representativeness(embeddings, method=method)
+
+    corr = np.corrcoef(ranking, dists)[0, 1]
+    assert corr < -0.3, "got corr=%.4f for method=%s" % (corr, method)
+
+
+if __name__ == "__main__":
+    fo.config.show_progress_bars = True
+    unittest.main(verbosity=2)


### PR DESCRIPTION
`compute_representativeness()` currently returns something close to the opposite of what its name and docs promise: samples sitting right on top of their cluster center come back near 0, and the outliers at the edge of a cluster come back near 1.

The cause is in `_cluster_ranker()` in `fiftyone/brain/internal/core/representativeness.py`. The function starts out correctly — `centerness_ranking = 1 / (1 + sample_dists)` is a proper centerness score, high for central points. But two things then go wrong:

```python
norm_method = "local"          # hardcoded, shadows the argument
if norm_method == "global":
    ...
elif norm_method == "local":
    for unique_id in unique_ids:
        cluster_dists = sample_dists[cluster_indices]
        cluster_dists /= cluster_dists.max()
        sample_dists[cluster_indices] = cluster_dists
    centerness_ranking = sample_dists   # discards the centerness score
```

The hardcoded assignment on the first line makes the `norm_method` parameter dead — the `"global"` branch can never run no matter what a caller passes. And the local branch normalizes `sample_dists` (raw distance) rather than `centerness_ranking`, then assigns it over the top, throwing away the centerness computed two lines earlier. What comes out is a per-cluster-normalized distance, i.e. an outlier score.

The fix normalizes `centerness_ranking` itself inside the local branch and drops the hardcoded assignment, so both normalization methods are reachable and both return centerness. I also added an `else: raise ValueError(...)` for unrecognized values, which matches how the `cluster_algorithm` and `method` arguments are already validated in this same module — previously an unknown `norm_method` would silently fall through and return unnormalized values.

## Verifying

I checked the orientation by generating 1000 points in two well-separated Gaussian blobs, running the ranker, and correlating the result against each point's true distance to its assigned KMeans center (recomputed independently with the same `n_clusters=20, random_state=1234` the function uses internally). If the output is centerness, that correlation should be strongly negative.

Before:

```
corr(ranking, distance_to_center) = +0.7448
closest point  -> 0.0022     (expected: near 1)
farthest point -> 1.0000     (expected: near 0)
norm_method="global" vs "local": max|difference| = 0.000000
```

After:

```
corr(ranking, distance_to_center) = -0.9169   (local)
corr(ranking, distance_to_center) = -0.9644   (global)
closest point  -> 1.0000
farthest point -> 0.4229
norm_method="global" vs "local": max|difference| = 0.158392
```

`tests/test_representativeness.py` is new and covers both normalization methods, both public `method` values (`cluster-center` and `cluster-center-downweight`), the argument-is-honored case, and the new `ValueError`. To confirm the tests actually pin the bug rather than passing incidentally, I stashed only the source file and re-ran them against the original code — 5 of 6 fail there on the real assertions (`assert corr < -0.5` with corr `+0.7448`), and all 6 pass with the fix.

Test run, using the same invocation as `.github/workflows/build.yml`:

```
tests/test_filter_ids.py .............. 9 passed
tests/test_refresh_errors.py .......... 4 passed
tests/test_results_serialization.py ... 4 passed
tests/test_use_view.py ................ 6 passed
tests/test_representativeness.py ...... 6 passed
```

Two notes on the environment, both pre-existing and unrelated to this change: `tests/test_uniqueness.py` fails to import here because it needs `voxel51-eta[storage]` (`ModuleNotFoundError: No module named 'azure'`), and it fails identically on a pristine checkout of `main`. `black --check` also flags both files, but only for a missing blank line after the module docstring — pristine `main` is flagged the same way, and `black --diff` touches nothing inside the changed function, so I left the formatting alone rather than adding unrelated churn. `pylint --rcfile=pylintrc` goes from 16 to 17 messages; the one addition is a `consider-using-f-string` on the new `ValueError`, which uses `%s` formatting to match the two sibling error messages in the same function verbatim.

Refs voxel51/fiftyone#8351
