### PR TITLE
fix(representativeness): return centerness score, honor norm_method (fiftyone#8351)

### DIFF
--- a/fiftyone/brain/internal/core/representativeness.py
+++ b/fiftyone/brain/internal/core/representativeness.py
@@ -213,20 +213,31 @@ def _cluster_ranker(
         embeddings - cluster_centers[cluster_ids], axis=1
     )
 
+    # Centerness: samples close to their cluster center are more
+    # representative, so this decreases as the distance to the center grows.
     centerness_ranking = 1 / (1 + sample_dists)
 
-    # Normalize per cluster vs globally
-    norm_method = "local"
+    # Normalize per cluster vs globally. In both cases we normalize the
+    # centerness scores (not the raw distances) so that a higher value always
+    # means "more representative".
     if norm_method == "global":
         centerness_ranking = centerness_ranking / centerness_ranking.max()
     elif norm_method == "local":
         unique_ids = np.unique(cluster_ids)
         for unique_id in unique_ids:
             cluster_indices = np.where(cluster_ids == unique_id)[0]
-            cluster_dists = sample_dists[cluster_indices]
-            cluster_dists /= cluster_dists.max()
-            sample_dists[cluster_indices] = cluster_dists
-        centerness_ranking = sample_dists
+            cluster_scores = centerness_ranking[cluster_indices]
+            centerness_ranking[cluster_indices] = (
+                cluster_scores / cluster_scores.max()
+            )
+    else:
+        raise ValueError(
+            (
+                "Normalization method '%s' not supported. Please use one of "
+                "['global', 'local']"
+            )
+            % norm_method
+        )
 
     return centerness_ranking, clusterer
 

--- a/fiftyone/brain/internal/core/representativeness.py
+++ b/fiftyone/brain/internal/core/representativeness.py
@@ -186,6 +186,27 @@ def _compute_representativeness(embeddings, method="cluster-center"):
 def _cluster_ranker(
     embeddings, cluster_algorithm="kmeans", N=20, norm_method="local"
 ):
+    """Ranks samples by how representative (central) they are within their
+    cluster.
+
+    Samples close to their cluster center receive higher scores.
+
+    Args:
+        embeddings: a ``num_samples x num_dims`` array of embeddings
+        cluster_algorithm ("kmeans"): the clustering algorithm to use.
+            Supported values are ``("kmeans", "meanshift")``
+        N (20): the number of clusters to use when ``cluster_algorithm`` is
+            ``"kmeans"``
+        norm_method ("local"): how to normalize the centerness scores.
+            Supported values are ``("local", "global")``, which normalize
+            per-cluster or across all samples, respectively
+
+    Returns:
+        a tuple of
+
+        -   the ``num_samples`` array of representativeness scores
+        -   the fitted clusterer
+    """
     # Cluster
     if cluster_algorithm == "meanshift":
         bandwidth = skc.estimate_bandwidth(

--- a/tests/test_representativeness.py
+++ b/tests/test_representativeness.py
@@ -76,6 +76,7 @@ def test_cluster_ranker_local_is_normalized_per_cluster():
 
 
 def test_cluster_ranker_rejects_unknown_norm_method():
+    """An unknown ``norm_method`` should raise a ``ValueError``."""
     embeddings = _two_blob_embeddings(per_blob=50)
 
     with pytest.raises(ValueError):

--- a/tests/test_representativeness.py
+++ b/tests/test_representativeness.py
@@ -1,0 +1,82 @@
+"""
+Representativeness tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import numpy as np
+import pytest
+
+from fiftyone.brain.internal.core.representativeness import _cluster_ranker
+
+
+def _two_blob_embeddings(seed=0, per_blob=500):
+    """Two well-separated Gaussian blobs so that KMeans does not produce
+    degenerate near-empty clusters.
+    """
+    rng = np.random.RandomState(seed)
+    blob_a = rng.normal(loc=[0, 0], scale=1.0, size=(per_blob, 2))
+    blob_b = rng.normal(loc=[30, 30], scale=1.0, size=(per_blob, 2))
+    return np.vstack([blob_a, blob_b]).astype(np.float32)
+
+
+@pytest.mark.parametrize("norm_method", ["local", "global"])
+def test_cluster_ranker_is_centerness_not_distance(norm_method):
+    """Representativeness must be a *centerness* score: samples close to their
+    cluster center are more representative, so the ranking must be negatively
+    correlated with the distance to the assigned cluster center.
+
+    Regression test for the case where the ranking was overwritten with the
+    (normalized) raw distance, inverting the semantics, and where
+    ``norm_method`` was ignored (hardcoded to ``"local"``).
+    """
+    embeddings = _two_blob_embeddings()
+
+    ranking, clusterer = _cluster_ranker(embeddings, norm_method=norm_method)
+
+    dists = np.linalg.norm(
+        embeddings - clusterer.cluster_centers_[clusterer.labels_], axis=1
+    )
+    corr = np.corrcoef(ranking, dists)[0, 1]
+
+    # High representativeness <-> small distance to center.
+    assert corr < 0, (
+        "representativeness should decrease as distance to the cluster center "
+        "grows (got correlation %.4f)" % corr
+    )
+
+
+def test_cluster_ranker_global_ranks_most_central_first():
+    """With ``"global"`` normalization the single most central sample overall
+    should receive the highest representativeness score.
+    """
+    embeddings = _two_blob_embeddings()
+
+    ranking, clusterer = _cluster_ranker(embeddings, norm_method="global")
+
+    dists = np.linalg.norm(
+        embeddings - clusterer.cluster_centers_[clusterer.labels_], axis=1
+    )
+    assert np.argmax(ranking) == np.argmin(dists)
+
+
+def test_cluster_ranker_local_is_normalized_per_cluster():
+    """The ``"local"`` normalization should scale scores within each cluster
+    so that the most central sample of every cluster has a ranking of 1.
+    """
+    embeddings = _two_blob_embeddings()
+
+    ranking, clusterer = _cluster_ranker(embeddings, norm_method="local")
+
+    cluster_ids = clusterer.labels_
+    for unique_id in np.unique(cluster_ids):
+        cluster_scores = ranking[cluster_ids == unique_id]
+        assert np.isclose(cluster_scores.max(), 1.0)
+
+
+def test_cluster_ranker_rejects_unknown_norm_method():
+    embeddings = _two_blob_embeddings(per_blob=50)
+
+    with pytest.raises(ValueError):
+        _cluster_ranker(embeddings, norm_method="unknown")


### PR DESCRIPTION
## Summary

`_cluster_ranker` (used by `compute_representativeness`, method `"cluster-center"`) returned values with **inverted semantics**: samples far from their cluster center received the *highest* representativeness, when representativeness is documented/named as "close to a cluster center = typical/representative".

Reported in voxel51/fiftyone#8351.

## Root cause

In `fiftyone/brain/internal/core/representativeness.py::_cluster_ranker`:

```python
centerness_ranking = 1 / (1 + sample_dists)   # correct: high = central

norm_method = "local"          # hardcoded, ignores the argument
if norm_method == "global":
    centerness_ranking = centerness_ranking / centerness_ranking.max()
elif norm_method == "local":
    ...
        cluster_dists /= cluster_dists.max()
        sample_dists[cluster_indices] = cluster_dists
    centerness_ranking = sample_dists   # overwrites centerness with distance
```

Two defects:
1. `norm_method` was hardcoded to `"local"`, so the `"global"` branch was unreachable regardless of the argument.
2. The `"local"` branch discarded the correctly computed `centerness_ranking` and replaced it with the per-cluster-normalized **raw distance** — the inverse of centerness.

## Fix

Normalize the **centerness scores** (not the raw distances) in both branches, honor the `norm_method` argument, and raise `ValueError` on unknown values. A higher value now always means "more representative".

## Verification

Reproduced with the reporters synthetic two-blob embeddings by calling `_cluster_ranker` directly:

- Before: `corr(representativeness, distance_to_center) = +0.74` (an outlier score).
- After: `-0.92` (local) and `-0.96` (global) — representativeness decreases with distance, as intended.

Added `tests/test_representativeness.py` covering both `norm_method`s (negative correlation), per-cluster normalization to 1.0 for `"local"`, most-central-first for `"global"`, and the invalid-method `ValueError`. The tests fail on the previous code and pass with this change; diff is scoped to the function and kept within the repos 79-char limit.