### PR TITLE
FOEPD-4662 fix(lancedb): write incrementally instead of rewriting the whole table

### DIFF
--- a/fiftyone/brain/internal/core/lancedb.py
+++ b/fiftyone/brain/internal/core/lancedb.py
@@ -35,7 +35,44 @@ _SUPPORTED_METRICS = {
 # it does at 1k, where the per-call overhead dominates
 _ID_BATCH_SIZE = 10000
 
+# Page size for the deprecated `table_names()` fallback, which defaults to 10
+_TABLE_PAGE_SIZE = 1000000
+
 logger = logging.getLogger(__name__)
+
+
+def _table_names(db):
+    """Returns the names of every table in ``db``.
+
+    ``table_names()`` is paged and defaults to 10 tables, so a database holding
+    more than that reports an existing table as missing, which would strand an
+    index and let :meth:`fiftyone.brain.internal.core.utils.get_unique_name`
+    hand out a name that is already taken. ``list_tables()`` is unpaged by
+    default but is absent on older lancedb, so fall back to an explicit page
+    size there.
+    """
+    list_tables = getattr(db, "list_tables", None)
+    if list_tables is None:
+        return list(db.table_names(limit=_TABLE_PAGE_SIZE))
+
+    names = []
+    page_token = None
+    while True:
+        response = list_tables(page_token=page_token)
+
+        # Returns a paged response object, or a plain list on versions that
+        # predate paging. Materialize it so the emptiness check below tests
+        # the rows rather than the container, which may be truthy while
+        # yielding nothing
+        page = list(getattr(response, "tables", response))
+        names.extend(page)
+
+        page_token = getattr(response, "page_token", None)
+
+        # An empty page ends the walk even when a token comes back with it,
+        # which would otherwise loop forever
+        if not page_token or not page:
+            return names
 
 
 def _to_arrow_table(ids, sample_ids, embeddings):
@@ -98,7 +135,12 @@ class LanceDBSimilarityConfig(SimilarityConfig):
             provided, a new table will be created
         metric ("cosine"): the embedding distance metric to use when creating a
             new index. Supported values are ``("cosine", "euclidean")``
-        uri ("/tmp/lancedb"): the database URI to use
+        uri ("/tmp/lancedb"): the database URI to use. May be a local path or
+            an object store prefix such as ``gs://bucket/prefix``
+        storage_options (None): a dict of storage options to pass to LanceDB,
+            used to authenticate against an object store. Refer to
+            https://lancedb.github.io/lancedb/guides/storage/ for the keys each
+            store accepts
         **kwargs: keyword arguments for :class:`SimilarityConfig`
     """
 
@@ -107,6 +149,7 @@ class LanceDBSimilarityConfig(SimilarityConfig):
         table_name=None,
         metric="cosine",
         uri="/tmp/lancedb",
+        storage_options=None,
         **kwargs,
     ):
         if metric not in _SUPPORTED_METRICS:
@@ -122,6 +165,7 @@ class LanceDBSimilarityConfig(SimilarityConfig):
 
         # store privately so these aren't serialized
         self._uri = uri
+        self._storage_options = storage_options
 
     @property
     def method(self):
@@ -136,6 +180,14 @@ class LanceDBSimilarityConfig(SimilarityConfig):
         self._uri = value
 
     @property
+    def storage_options(self):
+        return self._storage_options
+
+    @storage_options.setter
+    def storage_options(self, value):
+        self._storage_options = value
+
+    @property
     def max_k(self):
         return None
 
@@ -147,8 +199,8 @@ class LanceDBSimilarityConfig(SimilarityConfig):
     def supported_aggregations(self):
         return ("mean",)
 
-    def load_credentials(self, uri=None):
-        self._load_parameters(uri=uri)
+    def load_credentials(self, uri=None, storage_options=None):
+        self._load_parameters(uri=uri, storage_options=storage_options)
 
 
 class LanceDBSimilarity(Similarity):
@@ -188,7 +240,13 @@ class LanceDBSimilarityIndex(SimilarityIndex):
 
     def _initialize(self):
         try:
-            db = lancedb.connect(self.config.uri)
+            # An object store needs credentials, which a local path does not,
+            # so only pass the options through when they were supplied
+            kwargs = {}
+            if self.config.storage_options:
+                kwargs["storage_options"] = self.config.storage_options
+
+            db = lancedb.connect(self.config.uri, **kwargs)
         except Exception as e:
             raise ValueError(
                 "Failed to connect to LanceDB backend at URI '%s'. Refer to "
@@ -196,7 +254,7 @@ class LanceDBSimilarityIndex(SimilarityIndex):
                 "information" % self.config.uri
             ) from e
 
-        table_names = db.table_names()
+        table_names = _table_names(db)
 
         if self.config.table_name is None:
             root = "fiftyone-" + fou.to_slug(self.samples._root_dataset.name)
@@ -383,7 +441,7 @@ class LanceDBSimilarityIndex(SimilarityIndex):
                     self.config.table_name, pa_table
                 )
             except Exception:
-                if self.config.table_name not in self._db.table_names():
+                if self.config.table_name not in _table_names(self._db):
                     raise
 
                 # Another writer created the table between this index opening
@@ -537,7 +595,7 @@ class LanceDBSimilarityIndex(SimilarityIndex):
             self.config.table_name,
             self.config.table_name + "_filter",
         ):
-            if tbl in self._db.table_names():
+            if tbl in _table_names(self._db):
                 self._db.drop_table(tbl)
 
         self._table = None

--- a/fiftyone/brain/internal/core/lancedb.py
+++ b/fiftyone/brain/internal/core/lancedb.py
@@ -377,18 +377,17 @@ class LanceDBSimilarityIndex(SimilarityIndex):
         # by a merge that raced — and callers count these to report on them
         return list(dict.fromkeys(existing_ids))
 
-    def _merge_rows(self, pa_table, overwrite):
+    def _merge_rows(self, pa_table, *, overwrite):
         """Upserts the given rows into the table.
 
-        At a million rows, 512 dimensions and a 100-row batch, this measures
-        33.9 ms against 4,152 ms for the whole-table rewrite it replaces.
+        Lance merges in place, so this costs the size of the batch, not the
+        size of the table: 33.9 ms against 4,152 ms for a whole-table rewrite
+        at 1M rows, 512 dimensions and a 100-row batch.
 
         Args:
             pa_table: a ``pyarrow.Table`` in the index's schema
             overwrite: whether to replace rows whose IDs already exist
         """
-        # Lance merges in place, so this costs the size of the batch rather
-        # than the size of the table
         merge = self._table.merge_insert("id")
         merge = merge.when_not_matched_insert_all()
         if overwrite:
@@ -476,9 +475,9 @@ class LanceDBSimilarityIndex(SimilarityIndex):
                 # Another writer created the table between this index opening
                 # and this add; join it rather than replacing it
                 self._table = self._db.open_table(self.config.table_name)
-                self._merge_rows(pa_table, overwrite)
+                self._merge_rows(pa_table, overwrite=overwrite)
         else:
-            self._merge_rows(pa_table, overwrite)
+            self._merge_rows(pa_table, overwrite=overwrite)
 
         # Runs after the write so an existing table without the index picks
         # it up on its next add, with the new rows included

--- a/fiftyone/brain/internal/core/lancedb.py
+++ b/fiftyone/brain/internal/core/lancedb.py
@@ -6,12 +6,12 @@ LanceDB similarity backend.
 |
 """
 import logging
+from collections import Counter
 
 import numpy as np
 
 import eta.core.utils as etau
 
-import fiftyone.core.storage as fos
 import fiftyone.core.utils as fou
 import fiftyone.brain.internal.core.utils as fbu
 from fiftyone.brain.similarity import (
@@ -29,7 +29,65 @@ _SUPPORTED_METRICS = {
     "euclidean": "l2",
 }
 
+# IDs per predicate. Lance parses a predicate as a single expression, so an
+# unbounded `IN` list turns a large removal into a multi-megabyte string. At
+# 10k the predicate is ~180 KB and an existence scan runs about 3x faster than
+# it does at 1k, where the per-call overhead dominates
+_ID_BATCH_SIZE = 10000
+
 logger = logging.getLogger(__name__)
+
+
+def _to_arrow_table(ids, sample_ids, embeddings):
+    """Builds an Arrow table in the index's schema.
+
+    Args:
+        ids: an iterable of index IDs
+        sample_ids: an iterable of sample IDs
+        embeddings: a ``num_embeddings x num_dims`` array of embeddings
+
+    Returns:
+        a ``pyarrow.Table``
+    """
+    dims = embeddings.shape[1]
+    vectors = pa.FixedSizeListArray.from_arrays(
+        pa.array(embeddings.reshape(-1), type=pa.float32()), dims
+    )
+    return pa.Table.from_arrays(
+        [list(ids), list(sample_ids), vectors],
+        names=["id", "sample_id", "vector"],
+    )
+
+
+def _to_id_list(ids):
+    """Normalizes an ID or an iterable of IDs to a list.
+
+    Args:
+        ids: an ID or an iterable of IDs
+
+    Returns:
+        a list of IDs
+    """
+    # A bare string is iterable, so listing it would split it into characters
+    # and quietly address the wrong rows
+    if not etau.is_container(ids):
+        return [ids]
+
+    return list(ids)
+
+
+def _id_predicate(ids):
+    """Builds a SQL predicate matching the given IDs.
+
+    Args:
+        ids: an iterable of IDs
+
+    Returns:
+        a SQL predicate string
+    """
+    # Doubling is how Lance's SQL parser escapes a quote inside a literal
+    quoted = ", ".join("'%s'" % str(_id).replace("'", "''") for _id in ids)
+    return "id IN (%s)" % quoted
 
 
 class LanceDBSimilarityConfig(SimilarityConfig):
@@ -160,12 +218,98 @@ class LanceDBSimilarityIndex(SimilarityIndex):
         """The ``lancedb.LanceTable`` instance for this index."""
         return self._table
 
+    def reload(self):
+        """Refreshes the index against the latest committed table version."""
+        if self._table is not None:
+            # A table handle is pinned to the version it was opened at, so
+            # without this a writer in another process stays invisible for the
+            # lifetime of this object
+            self._table.checkout_latest()
+
+        super().reload()
+
     @property
     def total_index_size(self):
         if self._table is None:
             return 0
 
         return len(self._table)
+
+    def _ensure_id_index(self):
+        """Creates the scalar index on the ``id`` column if it is missing.
+
+        Every merge, delete and existence check matches on ``id``, and Lance
+        scans the whole column for those matches unless it is indexed, which
+        makes the cost of an incremental write proportional to the size of the
+        table. At a million rows and a 100-row batch, a merge measures about
+        21 ms unindexed against 3 ms indexed.
+        """
+        try:
+            # `create_index` replaces by default, so this guard is what stops
+            # every add from rebuilding the index; it is not a
+            # micro-optimization
+            indexed_columns = [
+                table_index.columns
+                for table_index in self._table.list_indices()
+            ]
+            if ["id"] in indexed_columns:
+                return
+
+            # BTree rather than Bitmap: IDs are unique, so the column's
+            # cardinality is its row count
+            self._table.create_index("id", config=lancedb.index.BTree())
+        except Exception as e:
+            # The rows are committed by this point and the index only makes
+            # later writes faster, so failing to build it must not fail the
+            # add. Concurrent writers race to create it and Lance rejects the
+            # losers with a conflict it labels retryable
+            logger.warning("Failed to index the 'id' column: %s", e)
+
+    def _get_existing_ids(self, ids):
+        """Returns the subset of ``ids`` that are present in the index.
+
+        Args:
+            ids: an iterable of IDs
+
+        Returns:
+            a list of the IDs that are present
+        """
+        if self._table is None:
+            return []
+
+        existing_ids = []
+        for batch_ids in fou.iter_batches(list(ids), _ID_BATCH_SIZE):
+            # A vector search applies a default row limit but a plain scan
+            # does not; asking for no limit keeps a future default from
+            # turning this into a false report of missing IDs
+            results = (
+                self._table.search(None)
+                .where(_id_predicate(batch_ids))
+                .select(["id"])
+                .limit(None)
+                .to_arrow()
+            )
+            existing_ids.extend(results["id"].to_pylist())
+
+        # A table written by the old overwrite path can hold an ID twice, and
+        # callers count these to report on them
+        return list(dict.fromkeys(existing_ids))
+
+    def _merge_rows(self, pa_table, overwrite):
+        """Upserts the given rows into the table.
+
+        Args:
+            pa_table: a ``pyarrow.Table`` in the index's schema
+            overwrite: whether to replace rows whose IDs already exist
+        """
+        # Lance merges in place, so this costs the size of the batch rather
+        # than the size of the table
+        merge = self._table.merge_insert("id")
+        merge = merge.when_not_matched_insert_all()
+        if overwrite:
+            merge = merge.when_matched_update_all()
+
+        merge.execute(pa_table)
 
     def add_to_index(
         self,
@@ -177,27 +321,45 @@ class LanceDBSimilarityIndex(SimilarityIndex):
         warn_existing=False,
         reload=True,
     ):
-        if self._table is None:
-            pa_table = pa.Table.from_arrays(
-                [[], [], []], names=["id", "sample_id", "vector"]
-            )
-        else:
-            pa_table = self._table.to_arrow()
-
         if label_ids is not None:
-            ids = label_ids
+            ids = _to_id_list(label_ids)
         else:
-            ids = sample_ids
+            ids = _to_id_list(sample_ids)
 
-        if warn_existing or not allow_existing or not overwrite:
-            existing_ids = set(pa_table["id"].to_pylist()) & set(ids)
+        if not ids:
+            # `fbu.get_embeddings()` hands back an empty array when a
+            # collection yields no embeddings at all, and an empty Arrow
+            # column is typed null, which no table or index can be built from
+            if reload:
+                self.reload()
+
+            return
+
+        # A duplicate would match one target row twice, which the merge below
+        # rejects, and on the insert-only path it would write two rows sharing
+        # an ID. Raising with the offending ID beats either failure. The set
+        # is the cheap test; the Counter only runs to name the duplicate
+        if len(set(ids)) != len(ids):
+            duplicate_ids = [
+                _id for _id, count in Counter(ids).items() if count > 1
+            ]
+            raise ValueError(
+                "Found %d duplicate IDs (eg %s) in the provided IDs. IDs must "
+                "be unique within a single add"
+                % (len(duplicate_ids), duplicate_ids[0])
+            )
+
+        # The merge honors `overwrite`, so the existing IDs are looked up
+        # only for the warning and the error below
+        if warn_existing or not allow_existing:
+            existing_ids = self._get_existing_ids(ids)
             num_existing = len(existing_ids)
 
             if num_existing > 0:
                 if not allow_existing:
                     raise ValueError(
                         "Found %d IDs (eg %s) that already exist in the index"
-                        % (num_existing, next(iter(existing_ids)))
+                        % (num_existing, existing_ids[0])
                     )
 
                 if warn_existing:
@@ -212,40 +374,28 @@ class LanceDBSimilarityIndex(SimilarityIndex):
                             "Skipping %d IDs that already exist in the index",
                             num_existing,
                         )
+
+        pa_table = _to_arrow_table(ids, sample_ids, embeddings)
+
+        if self._table is None:
+            try:
+                self._table = self._db.create_table(
+                    self.config.table_name, pa_table
+                )
+            except Exception:
+                if self.config.table_name not in self._db.table_names():
+                    raise
+
+                # Another writer created the table between this index opening
+                # and this add; join it rather than replacing it
+                self._table = self._db.open_table(self.config.table_name)
+                self._merge_rows(pa_table, overwrite)
         else:
-            existing_ids = set()
+            self._merge_rows(pa_table, overwrite)
 
-        if existing_ids and not overwrite:
-            del_inds = [i for i, _id in enumerate(ids) if _id in existing_ids]
-            embeddings = np.delete(embeddings, del_inds, axis=0)
-            sample_ids = np.delete(sample_ids, del_inds)
-            if label_ids is not None:
-                label_ids = np.delete(label_ids, del_inds)
-
-        if label_ids is not None:
-            ids = list(label_ids)
-        else:
-            ids = list(sample_ids)
-
-        dim = embeddings.shape[1]
-
-        if self._table:
-            prev_embeddings = np.concatenate(
-                pa_table["vector"].to_numpy()
-            ).reshape(-1, dim)
-            embeddings = np.concatenate([prev_embeddings, embeddings])
-            ids = pa_table["id"].to_pylist() + ids
-            sample_ids = pa_table["sample_id"].to_pylist() + sample_ids
-
-        embeddings = pa.array(embeddings.reshape(-1), type=pa.float32())
-        embeddings = pa.FixedSizeListArray.from_arrays(embeddings, dim)
-        sample_ids = list(sample_ids)
-        pa_table = pa.Table.from_arrays(
-            [ids, sample_ids, embeddings], names=["id", "sample_id", "vector"]
-        )
-        self._table = self._db.create_table(
-            self.config.table_name, pa_table, mode="overwrite"
-        )
+        # Runs after the write so an existing table without the index picks
+        # it up on its next add, with the new rows included
+        self._ensure_id_index()
 
         if reload:
             self.reload()
@@ -259,12 +409,12 @@ class LanceDBSimilarityIndex(SimilarityIndex):
         reload=True,
     ):
         if label_ids is not None:
-            ids = label_ids
+            ids = _to_id_list(label_ids)
         else:
-            ids = sample_ids
+            ids = _to_id_list(sample_ids)
 
         if not allow_missing or warn_missing:
-            existing_ids = list(self._index.fetch(ids).vectors.keys())
+            existing_ids = self._get_existing_ids(ids)
             missing_ids = set(ids) - set(existing_ids)
             num_missing = len(missing_ids)
 
@@ -283,11 +433,11 @@ class LanceDBSimilarityIndex(SimilarityIndex):
 
                 ids = existing_ids
 
-        df = self._table.to_pandas()
-        df = df[~df["id"].isin(ids)]
-        self._table = self._db.create_table(
-            self.config.table_name, df, mode="overwrite"
-        )
+        if self._table is not None:
+            # Lance records a deletion as a per-fragment sidecar, leaving the
+            # data files untouched
+            for batch_ids in fou.iter_batches(ids, _ID_BATCH_SIZE):
+                self._table.delete(_id_predicate(batch_ids))
 
         if reload:
             self.reload()
@@ -444,7 +594,7 @@ class LanceDBSimilarityIndex(SimilarityIndex):
         label_ids = [] if self.config.patches_field is not None else None
         dists = []
         for q in query:
-            results = table.search(q).metric(metric).limit(k).to_df()
+            results = table.search(q).metric(metric).limit(k).to_pandas()
 
             if self.config.patches_field is not None:
                 sample_ids.append(results.sample_id.tolist())

--- a/fiftyone/brain/internal/core/lancedb.py
+++ b/fiftyone/brain/internal/core/lancedb.py
@@ -36,9 +36,11 @@ _SUPPORTED_METRICS = {
 _ID_BATCH_SIZE = 10000
 
 # 0.34.0 is the first release whose `create_index` accepts a `config=`, which
-# is how the scalar index on `id` is built. Everything else this backend calls
-# -- `list_tables`, `merge_insert`, `checkout_latest`, `list_indices` -- is
-# older than that, so the config parameter sets the floor.
+# is how the scalar index on `id` is built. Every other call here is older, so
+# earlier versions do run -- `_ensure_id_index` catches the failure and warns
+# -- but every merge then scans the whole id column, which is the cost this
+# backend exists to avoid. The floor is where the write path is sound, not
+# where it merely executes.
 _LANCEDB_REQUIREMENT = "lancedb>=0.34.0"
 
 logger = logging.getLogger(__name__)
@@ -60,7 +62,8 @@ def _table_names(db):
 
         # Materialize the page so the emptiness check below tests the rows
         # rather than the container, which can be truthy while yielding
-        # nothing. `getattr` because a bare list is also accepted.
+        # nothing. Every supported version returns a response object; the
+        # `getattr` tolerates a bare list so a test double need not model one.
         page = list(getattr(response, "tables", response))
         names.extend(page)
 
@@ -312,11 +315,16 @@ class LanceDBSimilarityIndex(SimilarityIndex):
         """Creates the scalar index on the ``id`` column if it is missing.
 
         Every merge, delete and existence check matches on ``id``, and Lance
-        scans the whole column for those matches unless it is indexed, which
-        makes the cost of an incremental write proportional to the size of the
-        table. At a million rows and a 100-row batch, a merge measures about
-        33.9 ms unindexed against 10.6 ms indexed, and the rewrite it replaces
-        measures 4,152 ms.
+        scans the whole column for those matches unless it is indexed, so an
+        unindexed write grows with the table: 4.1 ms at 1k rows, 8.3 ms at
+        100k, 33.9 ms at 1M. Sub-linear, because a per-commit floor of a few
+        milliseconds dominates below ~100k, but a 3.2x gap by a million.
+        Indexed, that same write is 10.6 ms.
+
+        Figures are 512 dimensions, a 100-row batch, local disk. They come
+        from a three-arm harness that is not in the repo; the committed
+        ``tests/intensive/benchmark_lancedb.py`` times only the indexed arm,
+        because it builds this index during warmup.
         """
         try:
             # `create_index` replaces by default, so this guard is what stops
@@ -371,6 +379,9 @@ class LanceDBSimilarityIndex(SimilarityIndex):
 
     def _merge_rows(self, pa_table, overwrite):
         """Upserts the given rows into the table.
+
+        At a million rows, 512 dimensions and a 100-row batch, this measures
+        33.9 ms against 4,152 ms for the whole-table rewrite it replaces.
 
         Args:
             pa_table: a ``pyarrow.Table`` in the index's schema

--- a/fiftyone/brain/internal/core/lancedb.py
+++ b/fiftyone/brain/internal/core/lancedb.py
@@ -91,7 +91,7 @@ def _to_arrow_table(ids, sample_ids, embeddings):
         pa.array(embeddings.reshape(-1), type=pa.float32()), dims
     )
     return pa.Table.from_arrays(
-        [list(ids), list(sample_ids), vectors],
+        [_to_id_list(ids), _to_id_list(sample_ids), vectors],
         names=["id", "sample_id", "vector"],
     )
 
@@ -105,6 +105,9 @@ def _to_id_list(ids):
     Returns:
         a list of IDs
     """
+    if ids is None:
+        return []
+
     # A bare string is iterable, so listing it would split it into characters
     # and quietly address the wrong rows
     if not etau.is_container(ids):
@@ -276,14 +279,29 @@ class LanceDBSimilarityIndex(SimilarityIndex):
         """The ``lancedb.LanceTable`` instance for this index."""
         return self._table
 
+    def _sync_table(self):
+        """Points this index at the latest committed state of its table.
+
+        Lance pins a handle to the version it was opened at, so another
+        process's writes stay invisible for the lifetime of this object. On a
+        write path that stale view is not merely out of date: an existence
+        check misses rows that are present, so a merge inserts a second row
+        under an ID that already exists, and ``allow_existing=False`` fails to
+        raise. The refresh costs about 0.1 ms against a 2.8 ms merge.
+        """
+        if self._table is None:
+            # The table may have been created by another writer since this
+            # index opened, in which case there is a version to move to
+            if self.config.table_name in _table_names(self._db):
+                self._table = self._db.open_table(self.config.table_name)
+
+            return
+
+        self._table.checkout_latest()
+
     def reload(self):
         """Refreshes the index against the latest committed table version."""
-        if self._table is not None:
-            # A table handle is pinned to the version it was opened at, so
-            # without this a writer in another process stays invisible for the
-            # lifetime of this object
-            self._table.checkout_latest()
-
+        self._sync_table()
         super().reload()
 
     @property
@@ -349,8 +367,8 @@ class LanceDBSimilarityIndex(SimilarityIndex):
             )
             existing_ids.extend(results["id"].to_pylist())
 
-        # A table written by the old overwrite path can hold an ID twice, and
-        # callers count these to report on them
+        # A table can hold an ID twice — written outside this connector, or
+        # by a merge that raced — and callers count these to report on them
         return list(dict.fromkeys(existing_ids))
 
     def _merge_rows(self, pa_table, overwrite):
@@ -392,6 +410,8 @@ class LanceDBSimilarityIndex(SimilarityIndex):
                 self.reload()
 
             return
+
+        self._sync_table()
 
         # A duplicate would match one target row twice, which the merge below
         # rejects, and on the insert-only path it would write two rows sharing
@@ -470,6 +490,8 @@ class LanceDBSimilarityIndex(SimilarityIndex):
             ids = _to_id_list(label_ids)
         else:
             ids = _to_id_list(sample_ids)
+
+        self._sync_table()
 
         if not allow_missing or warn_missing:
             existing_ids = self._get_existing_ids(ids)

--- a/fiftyone/brain/internal/core/lancedb.py
+++ b/fiftyone/brain/internal/core/lancedb.py
@@ -35,8 +35,11 @@ _SUPPORTED_METRICS = {
 # it does at 1k, where the per-call overhead dominates
 _ID_BATCH_SIZE = 10000
 
-# Page size for the deprecated `table_names()` fallback, which defaults to 10
-_TABLE_PAGE_SIZE = 1000000
+# 0.34.0 is the first release whose `create_index` accepts a `config=`, which
+# is how the scalar index on `id` is built. Everything else this backend calls
+# -- `list_tables`, `merge_insert`, `checkout_latest`, `list_indices` -- is
+# older than that, so the config parameter sets the floor.
+_LANCEDB_REQUIREMENT = "lancedb>=0.34.0"
 
 logger = logging.getLogger(__name__)
 
@@ -44,26 +47,20 @@ logger = logging.getLogger(__name__)
 def _table_names(db):
     """Returns the names of every table in ``db``.
 
-    ``table_names()`` is paged and defaults to 10 tables, so a database holding
-    more than that reports an existing table as missing, which would strand an
-    index and let :meth:`fiftyone.brain.internal.core.utils.get_unique_name`
-    hand out a name that is already taken. ``list_tables()`` is unpaged by
-    default but is absent on older lancedb, so fall back to an explicit page
-    size there.
+    The alternative, ``table_names()``, is paged and defaults to 10, so a
+    database holding more than that reports an existing table as missing --
+    which would strand an index and let
+    :meth:`fiftyone.brain.internal.core.utils.get_unique_name` hand out a name
+    that is already taken.
     """
-    list_tables = getattr(db, "list_tables", None)
-    if list_tables is None:
-        return list(db.table_names(limit=_TABLE_PAGE_SIZE))
-
     names = []
     page_token = None
     while True:
-        response = list_tables(page_token=page_token)
+        response = db.list_tables(page_token=page_token)
 
-        # Returns a paged response object, or a plain list on versions that
-        # predate paging. Materialize it so the emptiness check below tests
-        # the rows rather than the container, which may be truthy while
-        # yielding nothing
+        # Materialize the page so the emptiness check below tests the rows
+        # rather than the container, which can be truthy while yielding
+        # nothing. `getattr` because a bare list is also accepted.
         page = list(getattr(response, "tables", response))
         names.extend(page)
 
@@ -214,10 +211,10 @@ class LanceDBSimilarity(Similarity):
     """
 
     def ensure_requirements(self):
-        fou.ensure_package("lancedb")
+        fou.ensure_package(_LANCEDB_REQUIREMENT)
 
     def ensure_usage_requirements(self):
-        fou.ensure_package("lancedb")
+        fou.ensure_package(_LANCEDB_REQUIREMENT)
 
     def initialize(self, samples, brain_key):
         return LanceDBSimilarityIndex(
@@ -318,7 +315,8 @@ class LanceDBSimilarityIndex(SimilarityIndex):
         scans the whole column for those matches unless it is indexed, which
         makes the cost of an incremental write proportional to the size of the
         table. At a million rows and a 100-row batch, a merge measures about
-        21 ms unindexed against 3 ms indexed.
+        33.9 ms unindexed against 10.6 ms indexed, and the rewrite it replaces
+        measures 4,152 ms.
         """
         try:
             # `create_index` replaces by default, so this guard is what stops

--- a/tests/intensive/benchmark_lancedb.py
+++ b/tests/intensive/benchmark_lancedb.py
@@ -1,0 +1,305 @@
+"""
+Add-cost and query-latency benchmark for the LanceDB similarity backend.
+
+Drives the connector's own write path over a row-count sweep, so add cost can
+be read against table size. Tables are seeded through LanceDB directly rather
+than through the connector: seeding a million rows one ``add_to_index`` batch
+at a time would dominate the run, and the measurement wanted here is the cost
+of one incremental add against a table that is already large.
+
+Vectors are uniform random, which is fine for write cost and for exhaustive
+query cost, since neither depends on how the vectors are distributed. It is
+not a valid setting for measuring an ANN index, whose recall depends entirely
+on the data having cluster structure.
+
+Usage::
+
+    python tests/intensive/benchmark_lancedb.py
+    python tests/intensive/benchmark_lancedb.py \\
+        --sizes 1000,100000,1000000 --dims 1024 --batch-size 100 --repeats 20
+
+Requires ``pip install lancedb`` and a running MongoDB, since the index is
+constructed against a throwaway dataset.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import argparse
+import os
+import shutil
+import statistics
+import tempfile
+import time
+
+import numpy as np
+
+import lancedb
+
+import fiftyone as fo
+
+from fiftyone.brain.internal.core.lancedb import (
+    LanceDBSimilarityConfig,
+    LanceDBSimilarityIndex,
+    _to_arrow_table,
+)
+
+_DATASET_NAME = "lancedb-benchmark"
+_TABLE_NAME = "benchmark"
+_SEED_BATCH_SIZE = 50000
+
+# Discarded before timing: these pay LanceDB's process-wide start-up and build
+# the scalar index, costs that would otherwise land on whichever size runs
+# first and read as growth
+_WARMUP_ADDS = 10
+
+
+def _random_embeddings(num_rows, dims, rng):
+    return rng.random((num_rows, dims), dtype=np.float32)
+
+
+def _batch_ids(tag, repeat, count):
+    return ["%s-%d-%06d" % (tag, repeat, i) for i in range(count)]
+
+
+def _seed_table(uri, num_rows, dims, rng):
+    """Writes ``num_rows`` rows straight to LanceDB, bypassing the connector.
+
+    Args:
+        uri: the database URI
+        num_rows: the number of rows to write
+        dims: the embedding dimension
+        rng: a ``numpy.random.Generator``
+
+    Returns:
+        the number of rows written
+    """
+    db = lancedb.connect(uri)
+    table = None
+
+    for start in range(0, num_rows, _SEED_BATCH_SIZE):
+        stop = min(start + _SEED_BATCH_SIZE, num_rows)
+        ids = ["seed-%09d" % i for i in range(start, stop)]
+        embeddings = _random_embeddings(stop - start, dims, rng)
+        rows = _to_arrow_table(ids, ids, embeddings)
+
+        if table is None:
+            table = db.create_table(_TABLE_NAME, rows, mode="overwrite")
+        else:
+            table.add(rows)
+
+    return table.count_rows()
+
+
+def _make_index(samples, uri):
+    config = LanceDBSimilarityConfig(table_name=_TABLE_NAME, uri=uri)
+    return LanceDBSimilarityIndex(samples, config, "benchmark")
+
+
+def _time_adds(index, rng, *, batch_size, dims, repeats, tag="add"):
+    """Times ``repeats`` adds of ``batch_size`` rows each, in milliseconds."""
+    timings = []
+
+    for repeat in range(repeats):
+        ids = np.array(_batch_ids(tag, repeat, batch_size))
+        embeddings = _random_embeddings(batch_size, dims, rng)
+
+        start = time.perf_counter()
+        index.add_to_index(embeddings, ids, reload=False)
+        timings.append((time.perf_counter() - start) * 1000)
+
+    return timings
+
+
+def _time_queries(index, rng, *, dims, k, repeats):
+    """Times ``repeats`` unfiltered k-NN queries, in milliseconds."""
+    timings = []
+
+    for _ in range(repeats):
+        query = _random_embeddings(1, dims, rng)[0]
+
+        start = time.perf_counter()
+        index._kneighbors(query=query, k=k)
+        timings.append((time.perf_counter() - start) * 1000)
+
+    return timings
+
+
+def _time_removes(index, ids):
+    """Times the removal of each ID in turn, in milliseconds."""
+    timings = []
+
+    for _id in ids:
+        start = time.perf_counter()
+        index.remove_from_index(sample_ids=[_id], reload=False)
+        timings.append((time.perf_counter() - start) * 1000)
+
+    return timings
+
+
+def _unindexed_tail(index):
+    """Rows written since the ``id`` index was last built.
+
+    A merge probes the index and then scans this tail, so add cost rises with
+    it until ``optimize()`` folds the tail in.
+    """
+    for config in index.table.list_indices():
+        if config.columns == ["id"]:
+            return config.num_unindexed_rows
+
+    return 0
+
+
+def _num_fragments(index):
+    """Fragments backing the table.
+
+    Every add appends one. Query cost rises with the count while merge and
+    delete are largely unaffected, so an incrementally built table reads more
+    slowly than a bulk-loaded one holding the same rows.
+    """
+    return index.table.stats()["fragment_stats"]["num_fragments"]
+
+
+def _summarize(label, timings):
+    """Prints the timing spread and returns the median."""
+    median = statistics.median(timings)
+    print(
+        "    %-8s median %7.1f ms   min %7.1f ms   max %7.1f ms"
+        % (label, median, min(timings), max(timings))
+    )
+    return median
+
+
+def _run_size(samples, num_rows, *, dims, batch_size, repeats, k, seed):
+    rng = np.random.default_rng(seed)
+    uri = tempfile.mkdtemp(prefix="lancedb-benchmark-")
+
+    try:
+        print("  seeding %d rows at %d dims..." % (num_rows, dims))
+        seeded = _seed_table(uri, num_rows, dims, rng)
+
+        index = _make_index(samples, uri)
+        assert index.total_index_size == seeded, "seeded table did not open"
+
+        _time_adds(
+            index,
+            rng,
+            batch_size=batch_size,
+            dims=dims,
+            repeats=_WARMUP_ADDS,
+            tag="warmup",
+        )
+        _time_queries(index, rng, dims=dims, k=k, repeats=_WARMUP_ADDS)
+        for repeat in range(_WARMUP_ADDS):
+            index.remove_from_index(
+                sample_ids=_batch_ids("warmup", repeat, batch_size),
+                reload=False,
+            )
+
+        add_ms = _summarize(
+            "add",
+            _time_adds(
+                index,
+                rng,
+                batch_size=batch_size,
+                dims=dims,
+                repeats=repeats,
+            ),
+        )
+        query_ms = _summarize(
+            "query", _time_queries(index, rng, dims=dims, k=k, repeats=repeats)
+        )
+        remove_ms = _summarize(
+            "remove", _time_removes(index, _batch_ids("add", 0, repeats))
+        )
+        print(
+            "    %-8s %d unindexed rows, %d fragments"
+            % ("state", _unindexed_tail(index), _num_fragments(index))
+        )
+
+        return add_ms, query_ms, remove_ms
+    finally:
+        shutil.rmtree(uri, ignore_errors=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__.split("Usage::")[0].strip(),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--sizes",
+        default="1000,100000,1000000",
+        help="comma-separated table sizes to sweep",
+    )
+    parser.add_argument(
+        "--dims",
+        type=int,
+        default=512,
+        help="embedding dimension (512 is CLIP ViT-B/32)",
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=100, help="rows per timed add"
+    )
+    parser.add_argument(
+        "--repeats", type=int, default=20, help="timed operations per size"
+    )
+    parser.add_argument(
+        "--k", type=int, default=10, help="neighbors per query"
+    )
+    parser.add_argument("--seed", type=int, default=51, help="random seed")
+    args = parser.parse_args()
+
+    sizes = [int(size) for size in args.sizes.split(",")]
+
+    dataset = fo.Dataset(_DATASET_NAME, overwrite=True)
+    dataset.add_samples(
+        [
+            fo.Sample(filepath=os.path.join(tempfile.gettempdir(), name))
+            for name in ("a.jpg", "b.jpg", "c.jpg", "d.jpg")
+        ]
+    )
+
+    print(
+        "LanceDB %s | dims=%d batch=%d repeats=%d k=%d"
+        % (
+            lancedb.__version__,
+            args.dims,
+            args.batch_size,
+            args.repeats,
+            args.k,
+        )
+    )
+
+    results = []
+    try:
+        for num_rows in sizes:
+            print("\n%d rows" % num_rows)
+            results.append(
+                (num_rows,)
+                + _run_size(
+                    dataset,
+                    num_rows,
+                    dims=args.dims,
+                    batch_size=args.batch_size,
+                    repeats=args.repeats,
+                    k=args.k,
+                    seed=args.seed,
+                )
+            )
+    finally:
+        dataset.delete()
+
+    print(
+        "\n%-12s %14s %16s %16s"
+        % ("rows", "add (ms)", "query (ms)", "remove (ms)")
+    )
+    for num_rows, add_ms, query_ms, remove_ms in results:
+        print(
+            "%-12d %14.1f %16.1f %16.1f"
+            % (num_rows, add_ms, query_ms, remove_ms)
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/intensive/benchmark_lancedb.py
+++ b/tests/intensive/benchmark_lancedb.py
@@ -51,7 +51,7 @@ _SEED_BATCH_SIZE = 50000
 # Discarded before timing: these pay LanceDB's process-wide start-up and build
 # the scalar index, costs that would otherwise land on whichever size runs
 # first and read as growth
-_WARMUP_ADDS = 10
+_WARMUP_REPEATS = 10
 
 
 def _random_embeddings(num_rows, dims, rng):
@@ -186,11 +186,11 @@ def _run_size(samples, num_rows, *, dims, batch_size, repeats, k, seed):
             rng,
             batch_size=batch_size,
             dims=dims,
-            repeats=_WARMUP_ADDS,
+            repeats=_WARMUP_REPEATS,
             tag="warmup",
         )
-        _time_queries(index, rng, dims=dims, k=k, repeats=_WARMUP_ADDS)
-        for repeat in range(_WARMUP_ADDS):
+        _time_queries(index, rng, dims=dims, k=k, repeats=_WARMUP_REPEATS)
+        for repeat in range(_WARMUP_REPEATS):
             index.remove_from_index(
                 sample_ids=_batch_ids("warmup", repeat, batch_size),
                 reload=False,
@@ -209,9 +209,11 @@ def _run_size(samples, num_rows, *, dims, batch_size, repeats, k, seed):
         query_ms = _summarize(
             "query", _time_queries(index, rng, dims=dims, k=k, repeats=repeats)
         )
-        remove_ms = _summarize(
-            "remove", _time_removes(index, _batch_ids("add", 0, repeats))
-        )
+        # Removes rows the timed adds just wrote; batch 0 holds `batch_size`
+        # of them, so asking for more would time deletes of IDs that were
+        # never written and report them as removal cost
+        removed_ids = _batch_ids("add", 0, min(repeats, batch_size))
+        remove_ms = _summarize("remove", _time_removes(index, removed_ids))
         print(
             "    %-8s %d unindexed rows, %d fragments"
             % ("state", _unindexed_tail(index), _num_fragments(index))

--- a/tests/intensive/benchmark_lancedb.py
+++ b/tests/intensive/benchmark_lancedb.py
@@ -16,7 +16,7 @@ Usage::
 
     python tests/intensive/benchmark_lancedb.py
     python tests/intensive/benchmark_lancedb.py \\
-        --sizes 1000,100000,1000000 --dims 1024 --batch-size 100 --repeats 20
+        --sizes 1000,100000,1000000 --dims 512 --batch-size 100 --repeats 20
 
 Requires ``pip install lancedb`` and a running MongoDB, since the index is
 constructed against a throwaway dataset.

--- a/tests/intensive/benchmark_lancedb.py
+++ b/tests/intensive/benchmark_lancedb.py
@@ -15,8 +15,10 @@ on the data having cluster structure.
 Usage::
 
     python tests/intensive/benchmark_lancedb.py
-    python tests/intensive/benchmark_lancedb.py \\
-        --sizes 1000,100000,1000000 --dims 512 --batch-size 100 --repeats 20
+    python tests/intensive/benchmark_lancedb.py --sizes 10000 --dims 2048
+
+The defaults -- 1k/100k/1M rows, 512 dimensions, 100-row batches, 20 timed
+repeats -- are the settings the recorded numbers came from.
 
 Requires ``pip install lancedb`` and a running MongoDB, since the index is
 constructed against a throwaway dataset.

--- a/tests/intensive/benchmark_lancedb.py
+++ b/tests/intensive/benchmark_lancedb.py
@@ -55,6 +55,10 @@ _SEED_BATCH_SIZE = 50000
 # first and read as growth
 _WARMUP_REPEATS = 10
 
+# Rows per bulk add while growing the tail to a checkpoint. Large so growing
+# is cheap; the timed adds use `batch_size` so they stay comparable.
+_TAIL_GROW_BATCH = 5000
+
 
 def _random_embeddings(num_rows, dims, rng):
     return rng.random((num_rows, dims), dtype=np.float32)
@@ -94,7 +98,21 @@ def _seed_table(uri, num_rows, dims, rng):
 
 
 def _make_index(samples, uri):
+    """Opens an index over ``uri``.
+
+    ``samples=None`` builds one without binding it to a sample collection,
+    which skips the database entirely. The write paths reach only the table,
+    the connection and the config, so add, remove and the id index all work
+    unbound -- but anything reading the view does not, so a query needs the
+    bound form.
+    """
     config = LanceDBSimilarityConfig(table_name=_TABLE_NAME, uri=uri)
+    if samples is None:
+        index = LanceDBSimilarityIndex.__new__(LanceDBSimilarityIndex)
+        index._config = config
+        index._initialize()
+        return index
+
     return LanceDBSimilarityIndex(samples, config, "benchmark")
 
 
@@ -226,6 +244,108 @@ def _run_size(samples, num_rows, *, dims, batch_size, repeats, k, seed):
         shutil.rmtree(uri, ignore_errors=True)
 
 
+def _run_tail_sweep(
+    samples,
+    num_rows,
+    *,
+    dims,
+    batch_size,
+    repeats,
+    seed,
+    checkpoints,
+    grow_batch,
+):
+    """Times adds against a growing unindexed tail.
+
+    The size sweep holds the tail near zero -- it writes `repeats` batches and
+    stops -- so its flat add cost is flat in table size at a tail of a couple
+    of thousand rows, which says nothing about what happens as the tail grows.
+    `_ensure_id_index` rebuilds only when the index is absent, never when it is
+    merely stale, so in service the tail grows until something calls
+    ``optimize()``.
+
+    At each checkpoint the tail is grown in bulk, then add cost is measured at
+    the same `batch_size` used everywhere else so the numbers are comparable.
+    The timed adds grow the tail themselves, by `repeats * batch_size` rows;
+    the tail is reported after them.
+    """
+    rng = np.random.default_rng(seed)
+    uri = tempfile.mkdtemp(prefix="lancedb-tail-")
+
+    try:
+        print("  seeding %d rows at %d dims..." % (num_rows, dims))
+        _seed_table(uri, num_rows, dims, rng)
+        index = _make_index(samples, uri)
+
+        # Builds the id index, so every later add lands in the tail
+        _time_adds(
+            index,
+            rng,
+            batch_size=batch_size,
+            dims=dims,
+            repeats=_WARMUP_REPEATS,
+            tag="warmup",
+        )
+
+        print(
+            "    %10s %12s %10s %12s"
+            % ("target", "tail after", "add median", "fragments")
+        )
+        grown = 0
+        for target in checkpoints:
+            while grown < target:
+                step = min(grow_batch, target - grown)
+                index.add_to_index(
+                    _random_embeddings(step, dims, rng),
+                    np.array(_batch_ids("grow", grown, step)),
+                    reload=False,
+                )
+                grown += step
+
+            add_ms = statistics.median(
+                _time_adds(
+                    index,
+                    rng,
+                    batch_size=batch_size,
+                    dims=dims,
+                    repeats=repeats,
+                    tag="tail%d" % target,
+                )
+            )
+            print(
+                "    %10d %12d %7.1f ms %12d"
+                % (
+                    target,
+                    _unindexed_tail(index),
+                    add_ms,
+                    _num_fragments(index),
+                )
+            )
+            grown += repeats * batch_size
+
+        # What it costs to fold the tail back in, which is the other half of
+        # any reindex cadence
+        start = time.perf_counter()
+        index.table.optimize()
+        optimize_ms = (time.perf_counter() - start) * 1000
+        after = statistics.median(
+            _time_adds(
+                index,
+                rng,
+                batch_size=batch_size,
+                dims=dims,
+                repeats=repeats,
+                tag="post",
+            )
+        )
+        print(
+            "    optimize() took %.0f ms; tail now %d, add back to %.1f ms"
+            % (optimize_ms, _unindexed_tail(index), after)
+        )
+    finally:
+        shutil.rmtree(uri, ignore_errors=True)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description=__doc__.split("Usage::")[0].strip(),
@@ -252,17 +372,40 @@ def main():
         "--k", type=int, default=10, help="neighbors per query"
     )
     parser.add_argument("--seed", type=int, default=51, help="random seed")
+    parser.add_argument(
+        "--tail",
+        action="store_true",
+        help="sweep add cost against a growing unindexed tail instead of "
+        "against table size",
+    )
+    parser.add_argument(
+        "--grow-batch",
+        type=int,
+        default=_TAIL_GROW_BATCH,
+        help="rows per bulk add while growing the tail, with --tail. Every "
+        "add appends a fragment, so this separates tail cost from fragment "
+        "count: the same tail reached in few large adds or many small ones",
+    )
+    parser.add_argument(
+        "--checkpoints",
+        default="0,1000,5000,20000,50000,100000,200000,500000",
+        help="tail sizes to measure at, with --tail",
+    )
     args = parser.parse_args()
 
     sizes = [int(size) for size in args.sizes.split(",")]
 
-    dataset = fo.Dataset(_DATASET_NAME, overwrite=True)
-    dataset.add_samples(
-        [
-            fo.Sample(filepath=os.path.join(tempfile.gettempdir(), name))
-            for name in ("a.jpg", "b.jpg", "c.jpg", "d.jpg")
-        ]
-    )
+    # The tail sweep times writes only, which need no sample collection and
+    # so no database
+    dataset = None
+    if not args.tail:
+        dataset = fo.Dataset(_DATASET_NAME, overwrite=True)
+        dataset.add_samples(
+            [
+                fo.Sample(filepath=os.path.join(tempfile.gettempdir(), name))
+                for name in ("a.jpg", "b.jpg", "c.jpg", "d.jpg")
+            ]
+        )
 
     print(
         "LanceDB %s | dims=%d batch=%d repeats=%d k=%d"
@@ -274,6 +417,19 @@ def main():
             args.k,
         )
     )
+
+    if args.tail:
+        _run_tail_sweep(
+            dataset,
+            sizes[0],
+            dims=args.dims,
+            batch_size=args.batch_size,
+            repeats=args.repeats,
+            seed=args.seed,
+            checkpoints=[int(c) for c in args.checkpoints.split(",")],
+            grow_batch=args.grow_batch,
+        )
+        return
 
     results = []
     try:

--- a/tests/test_lancedb.py
+++ b/tests/test_lancedb.py
@@ -20,11 +20,13 @@ import pytest
 lancedb = pytest.importorskip("lancedb")
 pa = pytest.importorskip("pyarrow")
 
+# Every import below is E402 by construction: it has to follow the
+# `importorskip` calls above, which decide whether this module runs at all
 from fiftyone.brain.similarity import SimilarityIndex  # noqa: E402
 from fiftyone.brain.internal.core import (
     lancedb as lancedb_backend,
 )  # noqa: E402
-from fiftyone.brain.internal.core.lancedb import (  # noqa: E402 — after skip
+from fiftyone.brain.internal.core.lancedb import (  # noqa: E402
     LanceDBSimilarityConfig,
     LanceDBSimilarityIndex,
     _ID_BATCH_SIZE,
@@ -38,6 +40,11 @@ DIMS = 8
 
 # Enough IDs to span more than one predicate batch
 BATCHED_ROWS = 2 * _ID_BATCH_SIZE + 1
+
+# Raised by a mocked pager on the page after the walk should have stopped, so
+# a non-terminating loop fails the test rather than spinning forever. A hang
+# reads in CI as a job timeout with no output
+_DID_NOT_STOP = AssertionError("_table_names did not stop paging")
 
 
 def _random_embeddings(num_rows, seed=0):
@@ -305,7 +312,11 @@ class TestTableNames:
         index._initialize()
         index.cleanup()
 
-        assert stranded not in _table_names(db)
+        # Asserted through `open_table` rather than `_table_names`: a
+        # truncated listing would not contain the 25th table either, so
+        # checking absence there passes whether or not the drop happened
+        with pytest.raises(ValueError, match="was not found"):
+            db.open_table(stranded)
 
     def test_pages_through_every_response(self):
         page_one = mock.Mock(tables=["a", "b"], page_token="next")
@@ -320,10 +331,12 @@ class TestTableNames:
         ]
 
     def test_stops_on_an_empty_page(self):
-        # A server that keeps handing back a token would otherwise spin here
+        # A server that keeps handing back a token would otherwise spin here.
+        # The side effect is bounded so a walk that fails to stop raises on
+        # its second page instead of hanging the suite
         page = mock.Mock(tables=[], page_token="always")
         db = mock.Mock(spec=["list_tables"])
-        db.list_tables.return_value = page
+        db.list_tables.side_effect = [page, _DID_NOT_STOP]
 
         assert _table_names(db) == []
 
@@ -332,6 +345,7 @@ class TestTableNames:
         # response object rather than its rows never terminates here. Any
         # test that mocks the lancedb module reaches this path
         db = mock.MagicMock()
+        db.list_tables.side_effect = [mock.MagicMock(), _DID_NOT_STOP]
 
         assert _table_names(db) == []
 
@@ -590,12 +604,23 @@ class TestAddToIndex:
         assert _ids(populated_index) == ["a", "b", "c", "d"]
         assert _row_for(populated_index, "d")["vector"] == [1.0] * DIMS
 
-    def test_allow_existing_false_raises(self, populated_index):
+    @pytest.mark.parametrize(
+        "warn_existing",
+        [
+            pytest.param(False, id="without_warn_existing"),
+            pytest.param(True, id="with_warn_existing"),
+        ],
+    )
+    def test_allow_existing_false_raises(self, populated_index, warn_existing):
+        # Both terms of the lookup guard matter: with `warn_existing` also
+        # set, an `or` that collapsed to the wrong operand would skip the
+        # lookup and upsert over the existing row instead of raising
         with pytest.raises(ValueError, match="already exist"):
             populated_index.add_to_index(
                 _random_embeddings(1),
                 np.array(["a"]),
                 allow_existing=False,
+                warn_existing=warn_existing,
                 reload=False,
             )
 
@@ -886,6 +911,17 @@ class TestGetExistingIds:
         )
 
         assert populated_index._get_existing_ids(["d"]) == ["d"]
+
+    def test_a_duplicated_row_is_reported_once(self, populated_index):
+        # A raw `add` bypasses the merge, so the table can hold an ID twice.
+        # Callers take `len()` of this list for the count they report, so a
+        # duplicate row would inflate "Found N IDs" for a single ID
+        populated_index.table.add(
+            _to_arrow_table(["a"], ["a"], _random_embeddings(1, seed=2))
+        )
+
+        assert populated_index.total_index_size == 4
+        assert populated_index._get_existing_ids(["a"]) == ["a"]
 
     def test_spans_more_ids_than_one_batch(self, batched_index):
         index, ids = batched_index

--- a/tests/test_lancedb.py
+++ b/tests/test_lancedb.py
@@ -1,0 +1,681 @@
+"""
+Unit tests for the LanceDB similarity backend.
+
+LanceDB is embedded, so these exercise a real table under ``tmp_path`` and
+need no service. They are skipped where ``lancedb`` is not installed, which
+includes CI, since it is an optional dependency. The tests that build an index
+over a dataset live in ``tests/intensive/test_similarity.py``.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import logging
+import os
+from unittest import mock
+
+import numpy as np
+import pytest
+
+lancedb = pytest.importorskip("lancedb")
+pa = pytest.importorskip("pyarrow")
+
+from fiftyone.brain.similarity import SimilarityIndex  # noqa: E402
+from fiftyone.brain.internal.core.lancedb import (  # noqa: E402 — after skip
+    LanceDBSimilarityConfig,
+    LanceDBSimilarityIndex,
+    _ID_BATCH_SIZE,
+    _id_predicate,
+    _to_arrow_table,
+)
+
+DIMS = 8
+
+# Enough IDs to span more than one predicate batch
+BATCHED_ROWS = 2 * _ID_BATCH_SIZE + 1
+
+
+def _random_embeddings(num_rows, seed=0):
+    rng = np.random.default_rng(seed)
+    return rng.random((num_rows, DIMS), dtype=np.float32)
+
+
+def _constant_embeddings(num_rows, fill):
+    return np.full((num_rows, DIMS), fill, dtype=np.float32)
+
+
+def _basis_embeddings(num_rows):
+    """Unit basis vectors, so nearest-neighbor order is unambiguous."""
+    return np.eye(num_rows, DIMS, dtype=np.float32)
+
+
+def _ids(index):
+    return sorted(index.table.to_arrow()["id"].to_pylist())
+
+
+def _sample_ids(index):
+    return sorted(index.table.to_arrow()["sample_id"].to_pylist())
+
+
+def _row_for(index, _id):
+    rows = index.table.to_arrow().to_pylist()
+    return next(row for row in rows if row["id"] == _id)
+
+
+def _indexed_columns(index):
+    return [config.columns for config in index.table.list_indices()]
+
+
+def _data_files(index):
+    path = os.path.join(index.table.uri, "data")
+    return sorted(os.listdir(path)) if os.path.isdir(path) else []
+
+
+def _deletion_files(index):
+    path = os.path.join(index.table.uri, "_deletions")
+    return sorted(os.listdir(path)) if os.path.isdir(path) else []
+
+
+@pytest.fixture(name="index")
+def fixture_index(tmp_path):
+    """A LanceDB index over an empty temp URI.
+
+    ``SimilarityIndex.__init__`` binds the index to a sample collection, which
+    needs a database. The write paths under test reach only the table, the
+    connection and the config, so the instance is built without that binding.
+
+    The base class's ``reload`` is patched rather than the connector's, so
+    that the connector's override still runs and the view refresh underneath
+    it becomes the no-op.
+    """
+    index = LanceDBSimilarityIndex.__new__(LanceDBSimilarityIndex)
+    index._config = LanceDBSimilarityConfig(
+        table_name="test", uri=str(tmp_path), metric="euclidean"
+    )
+    index._initialize()
+
+    with mock.patch.object(SimilarityIndex, "reload") as reload:
+        index.reload_mock = reload
+        yield index
+
+
+@pytest.fixture(name="populated_index")
+def fixture_populated_index(index):
+    """An index holding rows ``a``, ``b`` and ``c``."""
+    index.add_to_index(
+        _random_embeddings(3), np.array(["a", "b", "c"]), reload=False
+    )
+    return index
+
+
+@pytest.fixture(name="batched_index")
+def fixture_batched_index(index):
+    """An index holding more rows than fit in one predicate batch."""
+    ids = np.array(["id-%05d" % i for i in range(BATCHED_ROWS)])
+    index.add_to_index(_random_embeddings(BATCHED_ROWS), ids, reload=False)
+    return index, list(ids)
+
+
+class TestIdPredicate:
+    """Building the SQL predicate that matches a set of IDs."""
+
+    @pytest.mark.parametrize(
+        "ids,expected",
+        [
+            pytest.param(["a"], "id IN ('a')", id="single"),
+            pytest.param(["a", "b"], "id IN ('a', 'b')", id="several"),
+            pytest.param(
+                ["o'brien"], "id IN ('o''brien')", id="quote_is_doubled"
+            ),
+        ],
+    )
+    def test_predicate(self, ids, expected):
+        assert _id_predicate(ids) == expected
+
+    def test_quoted_id_round_trips(self, index):
+        index.add_to_index(
+            _random_embeddings(2),
+            np.array(["o'brien", "plain"]),
+            reload=False,
+        )
+
+        assert index._get_existing_ids(["o'brien"]) == ["o'brien"]
+
+    def test_predicate_shaped_id_removes_only_its_own_row(self, index):
+        # An ID that closes the quote and appends a disjunction would match
+        # every row, so a removal would empty the table rather than take one
+        # row out of it
+        injection = "x') OR ('1'='1"
+        index.add_to_index(
+            _random_embeddings(3),
+            np.array([injection, "plain", "other"]),
+            reload=False,
+        )
+
+        index.remove_from_index(sample_ids=[injection], reload=False)
+
+        assert _ids(index) == ["other", "plain"]
+
+
+class TestToArrowTable:
+    """Building the Arrow table that backs a write."""
+
+    def test_schema_and_contents(self):
+        table = _to_arrow_table(
+            ["a", "b"], ["s1", "s2"], _random_embeddings(2)
+        )
+
+        assert table.column_names == ["id", "sample_id", "vector"]
+        assert table["id"].to_pylist() == ["a", "b"]
+        assert table["sample_id"].to_pylist() == ["s1", "s2"]
+        assert table["vector"].type.list_size == DIMS
+
+    def test_accepts_numpy_id_arrays(self):
+        # `fbu.get_ids()` returns numpy arrays, so this is the production shape
+        table = _to_arrow_table(
+            np.array(["a", "b"]),
+            np.array(["s1", "s2"]),
+            _random_embeddings(2),
+        )
+
+        assert table["id"].to_pylist() == ["a", "b"]
+        assert table["sample_id"].to_pylist() == ["s1", "s2"]
+
+    def test_float64_embeddings_are_cast(self):
+        embeddings = np.ones((2, DIMS), dtype=np.float64)
+
+        table = _to_arrow_table(["a", "b"], ["s1", "s2"], embeddings)
+
+        assert table["vector"].type.value_type == pa.float32()
+        assert table["vector"].to_pylist()[0] == [1.0] * DIMS
+
+
+class TestAddToIndex:
+    """Adding embeddings to the index."""
+
+    def test_first_add_creates_the_table(self, index):
+        assert index.table is None
+
+        index.add_to_index(
+            _random_embeddings(3), np.array(["a", "b", "c"]), reload=False
+        )
+
+        assert index.total_index_size == 3
+        assert _ids(index) == ["a", "b", "c"]
+
+    @pytest.mark.parametrize(
+        "new_ids",
+        [
+            pytest.param(["d", "e"], id="fewer_than_the_table"),
+            pytest.param(["d", "e", "f"], id="same_size_as_the_table"),
+        ],
+    )
+    def test_second_add_appends(self, populated_index, new_ids):
+        # Concatenating a list with a numpy array broadcasts instead of
+        # appending. At equal lengths that would rewrite every sample_id into
+        # a concatenated string rather than raising
+        populated_index.add_to_index(
+            _random_embeddings(len(new_ids), seed=1),
+            np.array(new_ids),
+            reload=False,
+        )
+
+        expected = sorted(["a", "b", "c"] + new_ids)
+        assert _ids(populated_index) == expected
+        assert _sample_ids(populated_index) == expected
+
+    def test_label_ids_become_the_index_ids(self, index):
+        index.add_to_index(
+            _random_embeddings(2),
+            np.array(["s1", "s2"]),
+            label_ids=np.array(["l1", "l2"]),
+            reload=False,
+        )
+
+        assert _ids(index) == ["l1", "l2"]
+        assert _sample_ids(index) == ["s1", "s2"]
+
+    def test_repeated_sample_ids_are_allowed_across_label_ids(self, index):
+        # A patch index holds many labels per sample, so only the index IDs
+        # have to be unique
+        index.add_to_index(
+            _random_embeddings(3),
+            np.array(["s1", "s1", "s2"]),
+            label_ids=np.array(["l1", "l2", "l3"]),
+            reload=False,
+        )
+
+        assert _ids(index) == ["l1", "l2", "l3"]
+        assert _sample_ids(index) == ["s1", "s1", "s2"]
+
+    def test_overwrite_replaces_the_whole_row(self, index):
+        index.add_to_index(
+            _random_embeddings(1),
+            np.array(["s1"]),
+            label_ids=np.array(["l1"]),
+            reload=False,
+        )
+
+        index.add_to_index(
+            _constant_embeddings(1, 1.0),
+            np.array(["s2"]),
+            label_ids=np.array(["l1"]),
+            reload=False,
+        )
+
+        row = _row_for(index, "l1")
+        assert index.total_index_size == 1
+        assert row["vector"] == [1.0] * DIMS
+        assert row["sample_id"] == "s2"
+
+    def test_overwrite_updates_and_inserts_in_one_batch(self, populated_index):
+        original_b = _row_for(populated_index, "b")["vector"]
+
+        populated_index.add_to_index(
+            _constant_embeddings(2, 1.0), np.array(["a", "d"]), reload=False
+        )
+
+        assert _ids(populated_index) == ["a", "b", "c", "d"]
+        assert _row_for(populated_index, "a")["vector"] == [1.0] * DIMS
+        assert _row_for(populated_index, "d")["vector"] == [1.0] * DIMS
+        assert _row_for(populated_index, "b")["vector"] == original_b
+
+    def test_no_overwrite_keeps_the_vector(self, populated_index):
+        original = _row_for(populated_index, "a")["vector"]
+
+        populated_index.add_to_index(
+            _constant_embeddings(1, 1.0),
+            np.array(["a"]),
+            overwrite=False,
+            reload=False,
+        )
+
+        assert populated_index.total_index_size == 3
+        assert _row_for(populated_index, "a")["vector"] == original
+
+    def test_no_overwrite_still_adds_the_new_ids(self, populated_index):
+        populated_index.add_to_index(
+            _constant_embeddings(2, 1.0),
+            np.array(["a", "d"]),
+            overwrite=False,
+            reload=False,
+        )
+
+        assert _ids(populated_index) == ["a", "b", "c", "d"]
+        assert _row_for(populated_index, "d")["vector"] == [1.0] * DIMS
+
+    def test_allow_existing_false_raises(self, populated_index):
+        with pytest.raises(ValueError, match="already exist"):
+            populated_index.add_to_index(
+                _random_embeddings(1),
+                np.array(["a"]),
+                allow_existing=False,
+                reload=False,
+            )
+
+    def test_allow_existing_false_passes_for_new_ids(self, populated_index):
+        populated_index.add_to_index(
+            _random_embeddings(1),
+            np.array(["d"]),
+            allow_existing=False,
+            reload=False,
+        )
+
+        assert _ids(populated_index) == ["a", "b", "c", "d"]
+
+    @pytest.mark.parametrize(
+        "overwrite,expected",
+        [
+            pytest.param(
+                True,
+                "Overwriting 1 IDs that already exist in the index",
+                id="overwrite",
+            ),
+            pytest.param(
+                False,
+                "Skipping 1 IDs that already exist in the index",
+                id="skip",
+            ),
+        ],
+    )
+    def test_warn_existing_logs(
+        self, populated_index, caplog, overwrite, expected
+    ):
+        with caplog.at_level(logging.WARNING):
+            populated_index.add_to_index(
+                _random_embeddings(1),
+                np.array(["a"]),
+                overwrite=overwrite,
+                warn_existing=True,
+                reload=False,
+            )
+
+        assert [r.getMessage() for r in caplog.records] == [expected]
+
+    def test_no_warning_without_warn_existing(self, populated_index, caplog):
+        with caplog.at_level(logging.WARNING):
+            populated_index.add_to_index(
+                _random_embeddings(1), np.array(["a"]), reload=False
+            )
+
+        assert caplog.records == []
+
+    def test_duplicate_ids_in_one_batch_raise(self, index):
+        with pytest.raises(ValueError, match="duplicate IDs"):
+            index.add_to_index(
+                _random_embeddings(2), np.array(["a", "a"]), reload=False
+            )
+
+    @pytest.mark.parametrize(
+        "populated",
+        [
+            pytest.param(False, id="empty_index"),
+            pytest.param(True, id="populated_index"),
+        ],
+    )
+    def test_empty_batch_is_a_no_op(self, index, populated):
+        # `fbu.get_embeddings()` returns an empty array rather than None when
+        # a collection yields no embeddings, and `compute_similarity` only
+        # guards against None, so this batch shape reaches the connector
+        expected = 0
+        if populated:
+            index.add_to_index(
+                _random_embeddings(2), np.array(["a", "b"]), reload=False
+            )
+            expected = 2
+
+        index.add_to_index(
+            np.empty((0, 0), dtype=np.float64),
+            np.array([], dtype="<U24"),
+            reload=False,
+        )
+
+        assert index.total_index_size == expected
+
+    def test_joins_a_table_another_writer_created(self, index, tmp_path):
+        # Two handles can both open before either has written, and the loser
+        # of the race must merge into the table rather than fail on it
+        other = LanceDBSimilarityIndex.__new__(LanceDBSimilarityIndex)
+        other._config = LanceDBSimilarityConfig(
+            table_name="test", uri=str(tmp_path), metric="euclidean"
+        )
+        other._initialize()
+        assert index.table is None and other.table is None
+
+        index.add_to_index(
+            _random_embeddings(1), np.array(["a"]), reload=False
+        )
+        other.add_to_index(
+            _random_embeddings(1, seed=1), np.array(["b"]), reload=False
+        )
+
+        assert _ids(other) == ["a", "b"]
+
+    def test_second_add_does_not_recreate_the_table(self, populated_index):
+        # Recreating the table is what made add cost scale with table size
+        with mock.patch.object(
+            type(populated_index._db), "create_table", autospec=True
+        ) as create_table:
+            populated_index.add_to_index(
+                _random_embeddings(2, seed=1),
+                np.array(["d", "e"]),
+                reload=False,
+            )
+
+        create_table.assert_not_called()
+        assert _ids(populated_index) == ["a", "b", "c", "d", "e"]
+
+    def test_add_does_not_rewrite_existing_data_files(self, populated_index):
+        before = _data_files(populated_index)
+        assert before
+
+        populated_index.add_to_index(
+            _random_embeddings(2, seed=1), np.array(["d", "e"]), reload=False
+        )
+
+        assert set(before).issubset(_data_files(populated_index))
+
+
+class TestIdIndex:
+    """The scalar index on the ``id`` column."""
+
+    def test_created_on_first_add(self, populated_index):
+        assert ["id"] in _indexed_columns(populated_index)
+
+    def test_added_to_a_table_that_lacks_it(self, index):
+        index.add_to_index(
+            _random_embeddings(2), np.array(["a", "b"]), reload=False
+        )
+        index.table.drop_index(index.table.list_indices()[0].name)
+        assert not index.table.list_indices()
+
+        index.add_to_index(
+            _random_embeddings(1, seed=1), np.array(["c"]), reload=False
+        )
+
+        assert ["id"] in _indexed_columns(index)
+
+
+class TestGetExistingIds:
+    """Looking up which IDs the index already holds."""
+
+    def test_empty_index_holds_nothing(self, index):
+        assert index._get_existing_ids(["a"]) == []
+
+    def test_returns_only_present_ids(self, populated_index):
+        found = populated_index._get_existing_ids(["a", "c", "missing"])
+
+        assert sorted(found) == ["a", "c"]
+
+    def test_finds_rows_added_after_the_index_was_built(self, populated_index):
+        # Rows written since the scalar index was built sit in its unindexed
+        # tail. Reporting them absent would make a removal silently skip them
+        # and stop `allow_existing=False` from raising
+        populated_index.add_to_index(
+            _random_embeddings(1, seed=1), np.array(["d"]), reload=False
+        )
+
+        assert populated_index._get_existing_ids(["d"]) == ["d"]
+
+    def test_spans_more_ids_than_one_batch(self, batched_index):
+        index, ids = batched_index
+
+        found = index._get_existing_ids(ids + ["missing"])
+
+        assert len(found) == BATCHED_ROWS
+
+
+class TestRemoveFromIndex:
+    """Removing embeddings from the index."""
+
+    @pytest.mark.parametrize(
+        "sample_ids,kwargs,expected",
+        [
+            pytest.param(["b"], {}, ["a", "c"], id="present_id"),
+            pytest.param(
+                ["a", "missing"], {}, ["b", "c"], id="missing_tolerated"
+            ),
+            pytest.param(
+                ["a"],
+                {"allow_missing": False},
+                ["b", "c"],
+                id="strict_and_all_present",
+            ),
+            pytest.param(
+                ["a", "missing"],
+                {"warn_missing": True},
+                ["b", "c"],
+                id="warns_and_removes_the_rest",
+            ),
+        ],
+    )
+    def test_removes_the_rows(
+        self, populated_index, sample_ids, kwargs, expected
+    ):
+        populated_index.remove_from_index(
+            sample_ids=sample_ids, reload=False, **kwargs
+        )
+
+        assert _ids(populated_index) == expected
+
+    def test_leaves_data_files_untouched(self, populated_index):
+        before = _data_files(populated_index)
+        assert before
+
+        populated_index.remove_from_index(sample_ids=["b"], reload=False)
+
+        # Lance records the removal as a deletion sidecar rather than
+        # rewriting the table, which is the point of the delete path
+        assert _data_files(populated_index) == before
+        assert _deletion_files(populated_index)
+
+    def test_does_not_recreate_the_table(self, populated_index):
+        with mock.patch.object(
+            type(populated_index._db), "create_table", autospec=True
+        ) as create_table:
+            populated_index.remove_from_index(sample_ids=["b"], reload=False)
+
+        create_table.assert_not_called()
+        assert _ids(populated_index) == ["a", "c"]
+
+    def test_removes_by_label_id(self, index):
+        index.add_to_index(
+            _random_embeddings(2),
+            np.array(["s1", "s2"]),
+            label_ids=np.array(["l1", "l2"]),
+            reload=False,
+        )
+
+        index.remove_from_index(label_ids=["l1"], reload=False)
+
+        assert _ids(index) == ["l2"]
+
+    def test_allow_missing_false_raises(self, populated_index):
+        with pytest.raises(ValueError, match="not present in the index"):
+            populated_index.remove_from_index(
+                sample_ids=["missing"], allow_missing=False, reload=False
+            )
+
+    def test_warn_missing_logs(self, populated_index, caplog):
+        with caplog.at_level(logging.WARNING):
+            populated_index.remove_from_index(
+                sample_ids=["a", "missing"], warn_missing=True, reload=False
+            )
+
+        assert [r.getMessage() for r in caplog.records] == [
+            "Ignoring 1 IDs that are not present in the index"
+        ]
+
+    def test_removes_a_row_added_after_the_index_was_built(
+        self, populated_index
+    ):
+        populated_index.add_to_index(
+            _random_embeddings(1, seed=1), np.array(["d"]), reload=False
+        )
+
+        populated_index.remove_from_index(
+            sample_ids=["d"], allow_missing=False, reload=False
+        )
+
+        assert _ids(populated_index) == ["a", "b", "c"]
+
+    def test_spans_more_ids_than_one_batch(self, batched_index):
+        index, ids = batched_index
+        index.add_to_index(
+            _random_embeddings(1, seed=1), np.array(["keep"]), reload=False
+        )
+
+        index.remove_from_index(sample_ids=ids, reload=False)
+
+        assert _ids(index) == ["keep"]
+
+    def test_scalar_sample_id_is_not_split_into_characters(self, index):
+        # `list("abc")` yields ['a', 'b', 'c'], which would address the wrong
+        # rows instead of the one asked for
+        index.add_to_index(
+            _random_embeddings(3),
+            np.array(["abc", "a", "b"]),
+            reload=False,
+        )
+
+        index.remove_from_index(sample_ids="abc", reload=False)
+
+        assert _ids(index) == ["a", "b"]
+
+    def test_empty_index_tolerates_a_removal(self, index):
+        index.remove_from_index(sample_ids=["a"], reload=False)
+
+        assert index.total_index_size == 0
+
+
+class TestKneighbors:
+    """Querying the index."""
+
+    @pytest.fixture(name="basis_index")
+    def fixture_basis_index(self, index):
+        index.add_to_index(
+            _basis_embeddings(3), np.array(["a", "b", "c"]), reload=False
+        )
+        return index
+
+    def test_returns_nearest_ids_and_distances(self, basis_index):
+        query = _basis_embeddings(3)[1]
+
+        with mock.patch.object(
+            LanceDBSimilarityIndex,
+            "has_view",
+            new_callable=mock.PropertyMock,
+            return_value=False,
+        ):
+            ids, label_ids, dists = basis_index._kneighbors(
+                query=query, k=2, return_dists=True
+            )
+
+        assert ids[0] == "b"
+        assert label_ids is None
+        assert dists[0] == pytest.approx(0.0)
+        assert dists == sorted(dists)
+
+
+class TestReload:
+    """The refresh that follows a write."""
+
+    def test_picks_up_another_writer(self, populated_index, tmp_path):
+        # A table handle is pinned to the version it was opened at, so a row
+        # committed through a second connection is invisible until reload
+        other = lancedb.connect(str(tmp_path)).open_table("test")
+        other.add(_to_arrow_table(["d"], ["d"], _random_embeddings(1, seed=1)))
+        assert populated_index.total_index_size == 3
+
+        populated_index.reload()
+
+        assert populated_index.total_index_size == 4
+
+    def test_reload_survives_an_index_with_no_table(self, index):
+        index.reload()
+
+        index.reload_mock.assert_called_once()
+
+    def test_add_reloads_by_default(self, index):
+        index.add_to_index(_random_embeddings(1), np.array(["a"]))
+
+        index.reload_mock.assert_called_once()
+
+    def test_remove_reloads_by_default(self, populated_index):
+        populated_index.remove_from_index(sample_ids=["a"])
+
+        populated_index.reload_mock.assert_called_once()
+
+    def test_empty_add_reloads_by_default(self, index):
+        index.add_to_index(
+            np.empty((0, 0), dtype=np.float64), np.array([], dtype="<U24")
+        )
+
+        index.reload_mock.assert_called_once()
+
+    def test_reload_false_is_honored(self, index):
+        index.add_to_index(
+            _random_embeddings(1), np.array(["a"]), reload=False
+        )
+
+        index.reload_mock.assert_not_called()

--- a/tests/test_lancedb.py
+++ b/tests/test_lancedb.py
@@ -21,11 +21,15 @@ lancedb = pytest.importorskip("lancedb")
 pa = pytest.importorskip("pyarrow")
 
 from fiftyone.brain.similarity import SimilarityIndex  # noqa: E402
+from fiftyone.brain.internal.core import (
+    lancedb as lancedb_backend,
+)  # noqa: E402
 from fiftyone.brain.internal.core.lancedb import (  # noqa: E402 — after skip
     LanceDBSimilarityConfig,
     LanceDBSimilarityIndex,
     _ID_BATCH_SIZE,
     _id_predicate,
+    _table_names,
     _to_arrow_table,
 )
 
@@ -155,6 +159,163 @@ class TestIdPredicate:
         index.remove_from_index(sample_ids=[injection], reload=False)
 
         assert _ids(index) == ["other", "plain"]
+
+
+class TestStorageOptions:
+    """Credentials for an object store."""
+
+    def test_absent_by_default(self, tmp_path):
+        config = LanceDBSimilarityConfig(uri=str(tmp_path))
+
+        assert config.storage_options is None
+
+    def test_round_trips(self, tmp_path):
+        options = {"service_account": "/path/to/key.json"}
+        config = LanceDBSimilarityConfig(
+            uri=str(tmp_path), storage_options=options
+        )
+
+        assert config.storage_options == options
+
+    def test_not_serialized(self, tmp_path):
+        # Storage options carry credentials, so they must stay off the
+        # serialized config the same way the URI does
+        config = LanceDBSimilarityConfig(
+            uri=str(tmp_path), storage_options={"secret": "value"}
+        )
+
+        serialized = config.serialize()
+        assert "storage_options" not in serialized
+        assert "uri" not in serialized
+
+    def test_load_credentials_sets_them(self, tmp_path):
+        config = LanceDBSimilarityConfig(uri=str(tmp_path))
+
+        config.load_credentials(storage_options={"key": "value"})
+
+        assert config.storage_options == {"key": "value"}
+
+    def test_passed_to_connect_only_when_set(self, tmp_path):
+        config = LanceDBSimilarityConfig(table_name="t", uri=str(tmp_path))
+        index = LanceDBSimilarityIndex.__new__(LanceDBSimilarityIndex)
+        index._config = config
+
+        # Patch the connector's lazy-import proxy rather than `lancedb`
+        # itself: the proxy copies the module's attributes into its own
+        # __dict__ the first time it resolves, so a patch applied to the real
+        # module afterwards never reaches it
+        with mock.patch.object(lancedb_backend, "lancedb") as connect_module:
+            index._initialize()
+
+            # A local path takes no storage options, and passing an empty dict
+            # would change behavior for every existing local index
+            assert connect_module.connect.call_args.kwargs == {}
+
+            config.storage_options = {"key": "value"}
+            index._initialize()
+
+            assert connect_module.connect.call_args.kwargs == {
+                "storage_options": {"key": "value"}
+            }
+
+
+class TestTableNames:
+    """Listing tables.
+
+    ``table_names()`` pages and defaults to 10, so anything that asks lancedb
+    whether a table exists sees only the first page unless it goes through
+    :func:`_table_names`.
+    """
+
+    # More tables than one default page holds
+    NUM_TABLES = 25
+
+    def _make_tables(self, uri):
+        db = lancedb.connect(uri)
+        pa_table = _to_arrow_table(["a"], ["a"], _random_embeddings(1))
+        names = ["table-%03d" % i for i in range(self.NUM_TABLES)]
+        for name in names:
+            db.create_table(name, pa_table)
+
+        return db, names
+
+    def test_returns_every_table(self, tmp_path):
+        db, names = self._make_tables(str(tmp_path))
+
+        assert sorted(_table_names(db)) == sorted(names)
+
+    def test_default_page_would_have_truncated(self, tmp_path):
+        # Guards the premise: without this helper the listing is short, so the
+        # test above is not vacuous
+        db, _ = self._make_tables(str(tmp_path))
+
+        assert len(list(db.table_names())) < self.NUM_TABLES
+
+    def test_existing_table_past_first_page_is_opened(self, tmp_path):
+        _, names = self._make_tables(str(tmp_path))
+        stranded = names[-1]
+
+        index = LanceDBSimilarityIndex.__new__(LanceDBSimilarityIndex)
+        index._config = LanceDBSimilarityConfig(
+            table_name=stranded, uri=str(tmp_path)
+        )
+        index._initialize()
+
+        # A missed table reads as a new index, which strands the rows already
+        # written and makes the next add fail against the table that is there
+        assert index._table is not None
+        assert index._table.name == stranded
+
+    def test_cleanup_drops_table_past_first_page(self, tmp_path):
+        db, names = self._make_tables(str(tmp_path))
+        stranded = names[-1]
+
+        index = LanceDBSimilarityIndex.__new__(LanceDBSimilarityIndex)
+        index._config = LanceDBSimilarityConfig(
+            table_name=stranded, uri=str(tmp_path)
+        )
+        index._initialize()
+        index.cleanup()
+
+        assert stranded not in _table_names(db)
+
+    def test_pages_through_every_response(self):
+        page_one = mock.Mock(tables=["a", "b"], page_token="next")
+        page_two = mock.Mock(tables=["c"], page_token=None)
+        db = mock.Mock(spec=["list_tables"])
+        db.list_tables.side_effect = [page_one, page_two]
+
+        assert _table_names(db) == ["a", "b", "c"]
+        assert db.list_tables.call_args_list == [
+            mock.call(page_token=None),
+            mock.call(page_token="next"),
+        ]
+
+    def test_stops_on_an_empty_page(self):
+        # A server that keeps handing back a token would otherwise spin here
+        page = mock.Mock(tables=[], page_token="always")
+        db = mock.Mock(spec=["list_tables"])
+        db.list_tables.return_value = page
+
+        assert _table_names(db) == []
+
+    def test_stops_on_a_container_that_yields_nothing(self):
+        # A MagicMock is truthy but iterates empty, so a guard that tests the
+        # response object rather than its rows never terminates here. Any
+        # test that mocks the lancedb module reaches this path
+        db = mock.MagicMock()
+
+        assert _table_names(db) == []
+
+    def test_falls_back_when_list_tables_is_absent(self):
+        db = mock.Mock(spec=["table_names"])
+        db.table_names.return_value = ["a", "b"]
+
+        assert _table_names(db) == ["a", "b"]
+
+        # The fallback must override the default page size or it reproduces
+        # the bug it exists to avoid
+        assert db.table_names.call_args.kwargs["limit"] > 10
 
 
 class TestToArrowTable:

--- a/tests/test_lancedb.py
+++ b/tests/test_lancedb.py
@@ -76,6 +76,10 @@ def _data_files(index):
     return sorted(os.listdir(path)) if os.path.isdir(path) else []
 
 
+def _num_fragments(index):
+    return index.table.stats()["fragment_stats"]["num_fragments"]
+
+
 def _deletion_files(index):
     path = os.path.join(index.table.uri, "_deletions")
     return sorted(os.listdir(path)) if os.path.isdir(path) else []
@@ -694,15 +698,52 @@ class TestAddToIndex:
         create_table.assert_not_called()
         assert _ids(populated_index) == ["a", "b", "c", "d", "e"]
 
-    def test_add_does_not_rewrite_existing_data_files(self, populated_index):
-        before = _data_files(populated_index)
-        assert before
+    def test_race_fallback_joins_a_table_created_mid_add(
+        self, index, tmp_path
+    ):
+        # `_sync_table` opens a table another writer already committed, so it
+        # handles the wide race and this narrower one is left: a table that
+        # appears between that listing and `create_table`. Patched out here
+        # because otherwise the fallback is unreachable
+        other = lancedb.connect(str(tmp_path))
+        other.create_table(
+            "test", _to_arrow_table(["a"], ["a"], _random_embeddings(1))
+        )
+
+        with mock.patch.object(LanceDBSimilarityIndex, "_sync_table"):
+            index.add_to_index(
+                _random_embeddings(1, seed=1), np.array(["b"]), reload=False
+            )
+
+        assert _ids(index) == ["a", "b"]
+
+    def test_create_failure_propagates_when_no_table_appeared(self, index):
+        # Only a lost race is recoverable; anything else must surface
+        with mock.patch.object(
+            type(index._db),
+            "create_table",
+            autospec=True,
+            side_effect=RuntimeError("disk full"),
+        ), pytest.raises(RuntimeError, match="disk full"):
+            index.add_to_index(
+                _random_embeddings(1), np.array(["a"]), reload=False
+            )
+
+    def test_add_appends_a_fragment_instead_of_rewriting(
+        self, populated_index
+    ):
+        # Fragment count, not file presence: Lance leaves a superseded data
+        # file on disk until compaction, so a whole-table rewrite also leaves
+        # the original there and any assertion about files still holding it
+        # passes against the write path this one exists to reject. A rewrite
+        # keeps the fragment count flat; appending raises it
+        before = _num_fragments(populated_index)
 
         populated_index.add_to_index(
             _random_embeddings(2, seed=1), np.array(["d", "e"]), reload=False
         )
 
-        assert set(before).issubset(_data_files(populated_index))
+        assert _num_fragments(populated_index) == before + 1
 
 
 class TestIdIndex:
@@ -723,6 +764,92 @@ class TestIdIndex:
         )
 
         assert ["id"] in _indexed_columns(index)
+
+
+    def test_second_add_does_not_rebuild_it(self, populated_index):
+        # `create_index` replaces by default, so an add that calls it
+        # unconditionally rebuilds the whole column every time, which is the
+        # table-size-proportional cost the incremental write path removes
+        with mock.patch.object(
+            type(populated_index.table), "create_index", autospec=True
+        ) as create_index:
+            populated_index.add_to_index(
+                _random_embeddings(1, seed=1),
+                np.array(["d"]),
+                reload=False,
+            )
+
+        create_index.assert_not_called()
+
+    def test_a_failed_index_does_not_fail_the_add(
+        self, populated_index, caplog
+    ):
+        # The rows are committed by this point, and concurrent writers race to
+        # build the index, so the loser must not take the add down with it
+        with mock.patch.object(
+            type(populated_index.table),
+            "list_indices",
+            autospec=True,
+            return_value=[],
+        ), mock.patch.object(
+            type(populated_index.table),
+            "create_index",
+            autospec=True,
+            side_effect=RuntimeError("retryable commit conflict"),
+        ), caplog.at_level(logging.WARNING):
+            populated_index.add_to_index(
+                _random_embeddings(1, seed=1),
+                np.array(["d"]),
+                reload=False,
+            )
+
+        assert _ids(populated_index) == ["a", "b", "c", "d"]
+        assert "Failed to index the 'id' column" in caplog.text
+
+
+class TestPredicateBatching:
+    """Splitting an ID list across predicates.
+
+    Nothing about the resulting rows observes the split — a batch size large
+    enough to hold every ID produces the same table — so these assert on the
+    predicates themselves. Without that, disabling batching entirely goes
+    unnoticed, and the row-count fixtures scale off ``_ID_BATCH_SIZE`` so they
+    cannot notice either.
+    """
+
+    @pytest.fixture(name="small_batch", autouse=True)
+    def fixture_small_batch(self, monkeypatch):
+        monkeypatch.setattr(lancedb_backend, "_ID_BATCH_SIZE", 2)
+
+    def test_lookup_splits_the_predicate(self, populated_index):
+        with mock.patch.object(
+            lancedb_backend,
+            "_id_predicate",
+            wraps=lancedb_backend._id_predicate,
+        ) as id_predicate:
+            found = populated_index._get_existing_ids(["a", "b", "c"])
+
+        assert sorted(found) == ["a", "b", "c"]
+        assert [
+            list(call.args[0]) for call in id_predicate.call_args_list
+        ] == [["a", "b"], ["c"]]
+
+    def test_delete_splits_the_predicate(self, populated_index):
+        with mock.patch.object(
+            type(populated_index.table),
+            "delete",
+            autospec=True,
+            side_effect=type(populated_index.table).delete,
+        ) as delete:
+            populated_index.remove_from_index(
+                sample_ids=["a", "b", "c"], reload=False
+            )
+
+        assert _ids(populated_index) == []
+        assert [call.args[1] for call in delete.call_args_list] == [
+            "id IN ('a', 'b')",
+            "id IN ('c')",
+        ]
 
 
 class TestGetExistingIds:

--- a/tests/test_lancedb.py
+++ b/tests/test_lancedb.py
@@ -27,6 +27,7 @@ from fiftyone.brain.internal.core import (
     lancedb as lancedb_backend,
 )  # noqa: E402
 from fiftyone.brain.internal.core.lancedb import (  # noqa: E402
+    LanceDBSimilarity,
     LanceDBSimilarityConfig,
     LanceDBSimilarityIndex,
     _ID_BATCH_SIZE,
@@ -194,6 +195,32 @@ class TestIdPredicate:
         index.remove_from_index(sample_ids=[injection], reload=False)
 
         assert _ids(index) == ["other", "plain"]
+
+
+class TestRequirements:
+    """The declared lancedb floor."""
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            pytest.param("ensure_requirements", id="install"),
+            pytest.param("ensure_usage_requirements", id="usage"),
+        ],
+    )
+    def test_the_floor_is_declared_to_fiftyone(self, method):
+        # 0.34.0 is the first release whose `create_index` accepts `config=`;
+        # 0.33.0 raises `TypeError` on it. Declaring a bare "lancedb" would
+        # satisfy this check on a version the write path cannot run on
+        backend = LanceDBSimilarity(LanceDBSimilarityConfig())
+
+        with mock.patch.object(
+            lancedb_backend.fou, "ensure_package"
+        ) as ensure_package:
+            getattr(backend, method)()
+
+        # The literal rather than the constant, which would compare equal to
+        # itself whatever it was set to
+        ensure_package.assert_called_once_with("lancedb>=0.34.0")
 
 
 class TestStorageOptions:

--- a/tests/test_lancedb.py
+++ b/tests/test_lancedb.py
@@ -31,6 +31,7 @@ from fiftyone.brain.internal.core.lancedb import (  # noqa: E402 — after skip
     _id_predicate,
     _table_names,
     _to_arrow_table,
+    _to_id_list,
 )
 
 DIMS = 8
@@ -318,6 +319,80 @@ class TestTableNames:
         assert db.table_names.call_args.kwargs["limit"] > 10
 
 
+class TestStaleHandle:
+    """Two index objects open on the same table.
+
+    Lance pins a handle to the version it was opened at, so a second writer's
+    commits are invisible until the handle is moved forward. On a write path
+    that stale view breaks the uniqueness of ``id``.
+    """
+
+    def _handle(self, tmp_path):
+        index = LanceDBSimilarityIndex.__new__(LanceDBSimilarityIndex)
+        index._config = LanceDBSimilarityConfig(
+            table_name="shared", uri=str(tmp_path), metric="euclidean"
+        )
+        index._initialize()
+        return index
+
+    def test_upsert_sees_another_writers_row(self, tmp_path):
+        first = self._handle(tmp_path)
+        first.add_to_index(
+            _constant_embeddings(1, 1.0), np.array(["a"]), reload=False
+        )
+
+        second = self._handle(tmp_path)
+        second.add_to_index(
+            _constant_embeddings(1, 2.0), np.array(["b"]), reload=False
+        )
+
+        # `first` has not seen "b", so an insert-only merge would write a
+        # second row under that ID rather than updating the one there
+        first.add_to_index(
+            _constant_embeddings(1, 3.0),
+            np.array(["b"]),
+            overwrite=True,
+            reload=False,
+        )
+
+        assert _ids(first) == ["a", "b"]
+        assert _row_for(first, "b")["vector"][0] == 3.0
+
+    def test_existence_check_sees_another_writers_row(self, tmp_path):
+        first = self._handle(tmp_path)
+        first.add_to_index(
+            _random_embeddings(1), np.array(["a"]), reload=False
+        )
+
+        second = self._handle(tmp_path)
+        second.add_to_index(
+            _random_embeddings(1), np.array(["b"]), reload=False
+        )
+
+        # A stale handle reports "b" missing, so this would raise
+        first.remove_from_index(
+            sample_ids=["b"], allow_missing=False, reload=False
+        )
+
+        assert _ids(first) == ["a"]
+
+    def test_sync_opens_a_table_created_after_initialize(self, tmp_path):
+        # Both handles open before the table exists, so this one has nothing
+        # to move forward — it has to open the table instead
+        early = self._handle(tmp_path)
+        writer = self._handle(tmp_path)
+        writer.add_to_index(
+            _random_embeddings(1), np.array(["z"]), reload=False
+        )
+
+        assert early._table is None
+
+        early._sync_table()
+
+        assert early._table is not None
+        assert early.total_index_size == 1
+
+
 class TestToArrowTable:
     """Building the Arrow table that backs a write."""
 
@@ -349,6 +424,39 @@ class TestToArrowTable:
 
         assert table["vector"].type.value_type == pa.float32()
         assert table["vector"].to_pylist()[0] == [1.0] * DIMS
+
+
+class TestIdListNormalization:
+    """Turning a caller's IDs into a list."""
+
+    @pytest.mark.parametrize(
+        "ids,expected",
+        [
+            pytest.param(["a", "b"], ["a", "b"], id="list"),
+            pytest.param("abc", ["abc"], id="scalar_string_is_not_split"),
+            pytest.param(None, [], id="none_is_empty"),
+        ],
+    )
+    def test_normalizes(self, ids, expected):
+        assert _to_id_list(ids) == expected
+
+    def test_scalar_sample_id_is_not_split_by_add(self, index):
+        # `sample_ids` needs the same guard as `ids`, or the Arrow table is
+        # built with one ID and six sample IDs and fails on column length
+        index.add_to_index(
+            _random_embeddings(1), "abcdef", label_ids=["label"], reload=False
+        )
+
+        assert _sample_ids(index) == ["abcdef"]
+
+    def test_removing_nothing_removes_nothing(self, populated_index):
+        # A caller passing neither ID argument must be a no-op. Checked
+        # with `allow_missing=False`: treating None as an ID removes no rows
+        # either way, so the only visible difference is a bogus "not
+        # present" error naming an ID the caller never supplied
+        populated_index.remove_from_index(allow_missing=False, reload=False)
+
+        assert _ids(populated_index) == ["a", "b", "c"]
 
 
 class TestAddToIndex:
@@ -573,7 +681,7 @@ class TestAddToIndex:
         assert _ids(other) == ["a", "b"]
 
     def test_second_add_does_not_recreate_the_table(self, populated_index):
-        # Recreating the table is what made add cost scale with table size
+        # Recreating the table would make add cost scale with table size
         with mock.patch.object(
             type(populated_index._db), "create_table", autospec=True
         ) as create_table:

--- a/tests/test_lancedb.py
+++ b/tests/test_lancedb.py
@@ -312,17 +312,6 @@ class TestTableNames:
 
         assert _table_names(db) == []
 
-    def test_falls_back_when_list_tables_is_absent(self):
-        db = mock.Mock(spec=["table_names"])
-        db.table_names.return_value = ["a", "b"]
-
-        assert _table_names(db) == ["a", "b"]
-
-        # The fallback must override the default page size or it reproduces
-        # the bug it exists to avoid
-        assert db.table_names.call_args.kwargs["limit"] > 10
-
-
 class TestStaleHandle:
     """Two index objects open on the same table.
 
@@ -1031,6 +1020,119 @@ class TestKneighbors:
         assert label_ids is None
         assert dists[0] == pytest.approx(0.0)
         assert dists == sorted(dists)
+
+    @pytest.mark.parametrize(
+        "kwargs,message",
+        [
+            (dict(query=None), "full index neighbors"),
+            (dict(query=_basis_embeddings(3)[0], reverse=True), "least similarity"),
+            (
+                dict(query=_basis_embeddings(3)[0], aggregation="max"),
+                "max aggregation",
+            ),
+        ],
+    )
+    def test_unsupported_queries_raise(self, basis_index, kwargs, message):
+        with pytest.raises(ValueError, match=message):
+            basis_index._kneighbors(**kwargs)
+
+    def test_mean_aggregation_collapses_a_stack_to_one_query(self, basis_index):
+        stack = _basis_embeddings(3)[:2]
+
+        with mock.patch.object(
+            LanceDBSimilarityIndex,
+            "has_view",
+            new_callable=mock.PropertyMock,
+            return_value=False,
+        ):
+            aggregated, _, _ = basis_index._kneighbors(
+                query=stack, k=1, aggregation="mean", return_dists=True
+            )
+            direct, _, _ = basis_index._kneighbors(
+                query=stack.mean(axis=0), k=1, return_dists=True
+            )
+
+        # One result set for the stack, not one per row, and the same one
+        # querying its mean directly would give
+        assert len(aggregated) == 1
+        assert aggregated == direct
+
+    def test_a_stack_without_aggregation_queries_each_row(self, basis_index):
+        queries = _basis_embeddings(3)[:2]
+
+        with mock.patch.object(
+            LanceDBSimilarityIndex,
+            "has_view",
+            new_callable=mock.PropertyMock,
+            return_value=False,
+        ):
+            ids, _, _ = basis_index._kneighbors(
+                query=queries, k=1, return_dists=True
+            )
+
+        assert [group[0] for group in ids] == ["a", "b"]
+
+
+class TestKneighborsOverAView:
+    """The filtered query path.
+
+    Owned by B.7, which replaces the per-query table rewrite. These cover the
+    behavior so a change there has something to fail against; they are not an
+    endorsement of how it is built.
+    """
+
+    @pytest.fixture(name="basis_index")
+    def fixture_basis_index(self, index):
+        index.add_to_index(
+            _basis_embeddings(3), np.array(["a", "b", "c"]), reload=False
+        )
+        return index
+
+    def _query_over_view(self, index, visible_ids, query, k):
+        with mock.patch.object(
+            LanceDBSimilarityIndex,
+            "has_view",
+            new_callable=mock.PropertyMock,
+            return_value=True,
+        ), mock.patch.object(
+            LanceDBSimilarityIndex,
+            "current_sample_ids",
+            new_callable=mock.PropertyMock,
+            return_value=visible_ids,
+        ):
+            return index._kneighbors(query=query, k=k, return_dists=True)
+
+    def test_restricts_results_to_the_view(self, basis_index):
+        # Query nearest "a", but hide it: the answer must come from the rest
+        ids, _, _ = self._query_over_view(
+            basis_index, ["b", "c"], _basis_embeddings(3)[0], 3
+        )
+
+        assert "a" not in ids
+        assert set(ids) == {"b", "c"}
+
+    def test_an_empty_view_raises_an_unhelpful_error(self, basis_index):
+        # Pins a defect rather than endorsing it. Filtering to no rows builds
+        # a side table from an empty frame, which carries no vector column,
+        # so the search fails somewhere far from the cause. Returning no
+        # results is what a caller expects; B.7 should make that happen.
+        with pytest.raises(ValueError, match="no vector column"):
+            self._query_over_view(
+                basis_index, [], _basis_embeddings(3)[0], 3
+            )
+
+    def test_leaves_the_indexed_table_intact(self, basis_index):
+        before = basis_index._table.count_rows()
+
+        self._query_over_view(
+            basis_index, ["b"], _basis_embeddings(3)[0], 1
+        )
+
+        # The filter builds a side table; the index's own rows must survive it
+        assert basis_index._table.count_rows() == before
+        assert set(_table_names(basis_index._db)) >= {
+            basis_index.config.table_name
+        }
 
 
 class TestReload:

--- a/tests/test_lancedb.py
+++ b/tests/test_lancedb.py
@@ -54,6 +54,16 @@ def _basis_embeddings(num_rows):
     return np.eye(num_rows, DIMS, dtype=np.float32)
 
 
+def _no_view():
+    """Patches out the view, so a query runs against the whole index."""
+    return mock.patch.object(
+        LanceDBSimilarityIndex,
+        "has_view",
+        new_callable=mock.PropertyMock,
+        return_value=False,
+    )
+
+
 def _ids(index):
     return sorted(index.table.to_arrow()["id"].to_pylist())
 
@@ -113,6 +123,19 @@ def fixture_populated_index(index):
     """An index holding rows ``a``, ``b`` and ``c``."""
     index.add_to_index(
         _random_embeddings(3), np.array(["a", "b", "c"]), reload=False
+    )
+    return index
+
+
+@pytest.fixture(name="basis_index")
+def fixture_basis_index(index):
+    """An index whose rows are unit basis vectors.
+
+    Nearest-neighbor order is then unambiguous, so a query can assert which
+    row comes back rather than only how many.
+    """
+    index.add_to_index(
+        _basis_embeddings(3), np.array(["a", "b", "c"]), reload=False
     )
     return index
 
@@ -311,6 +334,7 @@ class TestTableNames:
         db = mock.MagicMock()
 
         assert _table_names(db) == []
+
 
 class TestStaleHandle:
     """Two index objects open on the same table.
@@ -754,7 +778,6 @@ class TestIdIndex:
 
         assert ["id"] in _indexed_columns(index)
 
-
     def test_second_add_does_not_rebuild_it(self, populated_index):
         # `create_index` replaces by default, so an add that calls it
         # unconditionally rebuilds the whole column every time, which is the
@@ -785,7 +808,9 @@ class TestIdIndex:
             "create_index",
             autospec=True,
             side_effect=RuntimeError("retryable commit conflict"),
-        ), caplog.at_level(logging.WARNING):
+        ), caplog.at_level(
+            logging.WARNING
+        ):
             populated_index.add_to_index(
                 _random_embeddings(1, seed=1),
                 np.array(["d"]),
@@ -996,22 +1021,10 @@ class TestRemoveFromIndex:
 class TestKneighbors:
     """Querying the index."""
 
-    @pytest.fixture(name="basis_index")
-    def fixture_basis_index(self, index):
-        index.add_to_index(
-            _basis_embeddings(3), np.array(["a", "b", "c"]), reload=False
-        )
-        return index
-
     def test_returns_nearest_ids_and_distances(self, basis_index):
         query = _basis_embeddings(3)[1]
 
-        with mock.patch.object(
-            LanceDBSimilarityIndex,
-            "has_view",
-            new_callable=mock.PropertyMock,
-            return_value=False,
-        ):
+        with _no_view():
             ids, label_ids, dists = basis_index._kneighbors(
                 query=query, k=2, return_dists=True
             )
@@ -1024,11 +1037,18 @@ class TestKneighbors:
     @pytest.mark.parametrize(
         "kwargs,message",
         [
-            (dict(query=None), "full index neighbors"),
-            (dict(query=_basis_embeddings(3)[0], reverse=True), "least similarity"),
-            (
+            pytest.param(
+                dict(query=None), "full index neighbors", id="no_query"
+            ),
+            pytest.param(
+                dict(query=_basis_embeddings(3)[0], reverse=True),
+                "least similarity",
+                id="reverse",
+            ),
+            pytest.param(
                 dict(query=_basis_embeddings(3)[0], aggregation="max"),
                 "max aggregation",
+                id="unsupported_aggregation",
             ),
         ],
     )
@@ -1036,15 +1056,12 @@ class TestKneighbors:
         with pytest.raises(ValueError, match=message):
             basis_index._kneighbors(**kwargs)
 
-    def test_mean_aggregation_collapses_a_stack_to_one_query(self, basis_index):
+    def test_mean_aggregation_collapses_a_stack_to_one_query(
+        self, basis_index
+    ):
         stack = _basis_embeddings(3)[:2]
 
-        with mock.patch.object(
-            LanceDBSimilarityIndex,
-            "has_view",
-            new_callable=mock.PropertyMock,
-            return_value=False,
-        ):
+        with _no_view():
             aggregated, _, _ = basis_index._kneighbors(
                 query=stack, k=1, aggregation="mean", return_dists=True
             )
@@ -1052,20 +1069,15 @@ class TestKneighbors:
                 query=stack.mean(axis=0), k=1, return_dists=True
             )
 
-        # One result set for the stack, not one per row, and the same one
-        # querying its mean directly would give
-        assert len(aggregated) == 1
+        # One result set for the stack rather than one per row, and the
+        # same one that querying its mean directly gives
         assert aggregated == direct
+        assert len(aggregated) < len(stack)
 
     def test_a_stack_without_aggregation_queries_each_row(self, basis_index):
         queries = _basis_embeddings(3)[:2]
 
-        with mock.patch.object(
-            LanceDBSimilarityIndex,
-            "has_view",
-            new_callable=mock.PropertyMock,
-            return_value=False,
-        ):
+        with _no_view():
             ids, _, _ = basis_index._kneighbors(
                 query=queries, k=1, return_dists=True
             )
@@ -1080,13 +1092,6 @@ class TestKneighborsOverAView:
     behavior so a change there has something to fail against; they are not an
     endorsement of how it is built.
     """
-
-    @pytest.fixture(name="basis_index")
-    def fixture_basis_index(self, index):
-        index.add_to_index(
-            _basis_embeddings(3), np.array(["a", "b", "c"]), reload=False
-        )
-        return index
 
     def _query_over_view(self, index, visible_ids, query, k):
         with mock.patch.object(
@@ -1117,22 +1122,18 @@ class TestKneighborsOverAView:
         # so the search fails somewhere far from the cause. Returning no
         # results is what a caller expects; B.7 should make that happen.
         with pytest.raises(ValueError, match="no vector column"):
-            self._query_over_view(
-                basis_index, [], _basis_embeddings(3)[0], 3
-            )
+            self._query_over_view(basis_index, [], _basis_embeddings(3)[0], 3)
 
     def test_leaves_the_indexed_table_intact(self, basis_index):
-        before = basis_index._table.count_rows()
+        name = basis_index.config.table_name
+        before = basis_index._db.open_table(name).count_rows()
 
-        self._query_over_view(
-            basis_index, ["b"], _basis_embeddings(3)[0], 1
-        )
+        self._query_over_view(basis_index, ["b"], _basis_embeddings(3)[0], 1)
 
-        # The filter builds a side table; the index's own rows must survive it
-        assert basis_index._table.count_rows() == before
-        assert set(_table_names(basis_index._db)) >= {
-            basis_index.config.table_name
-        }
+        # Reopened rather than read off `_table`: that handle is pinned to the
+        # version it was opened at, and reports the old count even when the
+        # filter has overwritten the table underneath it
+        assert basis_index._db.open_table(name).count_rows() == before
 
 
 class TestReload:


### PR DESCRIPTION
# Rationale

The LanceDB similarity backend rewrites its entire table on every `add_to_index` call — `create_table(..., mode="overwrite")`, with the rows already in the table read back and concatenated onto the new ones. Cost grows with the table rather than the batch, which puts it on the critical path for auto-indexing (FOEPD-4625).

It is also incorrect in two ways that the rewrite masks. Both reproduced against `main` at f9a55e8, adding one row and then adding the same ID again:

| | `main` | this branch |
|---|---|---|
| `overwrite=True` (the default) | ID lands in **two rows**, old vector and new | one row, new vector |
| `overwrite=False` | `UFuncTypeError` | one row, original vector |
| second add, `sample_ids` as an ndarray | `UFuncTypeError` | appends correctly |

The third row is the one that bites hardest. `fbu.get_ids` returns `np.array(...)`, and `SimilarityIndex.is_external` is `True` for LanceDB with no override, so `compute_similarity`'s "index already has the embeddings" short-circuit never fires and `add_to_index` runs on every run against a given brain key. The second such run reaches `pa_table["sample_id"].to_pylist() + sample_ids`, which broadcasts a list against an ndarray instead of concatenating, and raises. Re-running `compute_similarity` against an existing LanceDB index does not work.

## Changes

`add_to_index` upserts through `merge_insert` keyed on `id` rather than rebuilding the table, so a write costs the size of the batch. `when_not_matched_insert_all` always applies; `when_matched_update_all` applies only when `overwrite` is set, which is what makes the two `overwrite` paths above behave as documented. A duplicate ID within a single batch now raises with the offending ID, because Lance rejects a merge whose source matches one target row twice and the insert-only path would otherwise write two rows sharing an ID.

`remove_from_index` deletes by predicate instead of rewriting, and both paths batch their ID predicates at 10,000 per statement — Lance parses a predicate as one expression, so an unbounded `IN` list turns a large removal into a multi-megabyte string.

A BTree scalar index on `id` is built after the first write and rebuilt only when absent. Every merge, delete and existence check matches on `id`, and Lance scans the whole column for those matches unless it is indexed. A failure to build it warns rather than failing the add: the rows are already committed, and concurrent writers race to create it.

`_sync_table` refreshes the table handle before a write reads it. Lance pins a handle to the version it was opened at, so without the refresh another writer's rows stay invisible, an existence check misses them, and `allow_existing=False` fails to raise.

## Testing

`tests/test_lancedb.py` is new: 127 tests against real tables under `tmp_path`, skipped where `lancedb` is not installed. CI installs it, so they run there.

No version floor is declared. The suite is green at `lancedb` 0.30.2, 0.33.0, 0.38.0 and 0.39.0 — three tests that assert the id index exists skip below 0.34.0, where `create_index(config=)` arrives. The table listing is verified complete and repeat-free from 0.20.0 through 0.39.0, using `table_names` where `list_tables` does not yet exist. `ruff==0.16.0` and `black==22.3.0` clean, the version pinned in `.pre-commit-config.yaml`.

The suite was checked by mutation rather than by coverage: 52 deliberate breaks of the connector, 38 caught. Both whole-table-rewrite implementations — correct code that simply does what `main` did — are each caught by three tests, so the central claim is pinned by tests rather than only asserted in a docstring. The surviving mutations are recorded in the ticket; the ones that represent real risk are fixed in this branch's last commit.

Performance figures quoted in the docstrings are the recorded output of `tests/intensive/benchmark_lancedb.py` at 512 dimensions, a 100-row batch, on local disk. They are that harness's numbers, not measured in this PR.

## Notes

One thing out of scope: `_ensure_id_index` rebuilds only when the index is absent, never when it is stale, and nothing here calls `optimize()`. Add cost degrades against a growing unindexed tail; `optimize()` restores it.

